### PR TITLE
README: add skills.sh install-count badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # StarSling Skills
 
+[![skills.sh](https://skills.sh/b/starslingdev/skills)](https://skills.sh/starslingdev/skills)
+
 Public agent skills from StarSling. Each skill lives in its own self-contained
 directory under `skills/<name>/` and installs individually.
 


### PR DESCRIPTION
Adds the skills.sh install-count badge under the README title, pointed at `starslingdev/skills`.

```markdown
[![skills.sh](https://skills.sh/b/starslingdev/skills)](https://skills.sh/starslingdev/skills)
```

Docs-only; no skill behavior change (no CHANGELOG entry needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)