### PR TITLE
Make ci-speedup discoverable: topics, description, and landing-page links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Public agent skills from StarSling. Each skill lives in its own self-contained
 directory under `skills/<name>/` and installs individually.
 
-Today this repo ships one skill: **`ci-speedup`**.
+Today this repo ships one skill: **`ci-speedup`**
+([overview](https://starsling.dev/ci-speedup)).
 
 ## ci-speedup: measured CI audits for GitHub Actions
 
@@ -100,6 +101,9 @@ third party. See [SECURITY.md](SECURITY.md) for the data-handling model.
 - [`PROVENANCE.md`](PROVENANCE.md): how the detection catalog was developed and
   validated.
 - [`examples/`](examples/): a sanitized sample report showing the output shape.
+- [starsling.dev/ci-speedup](https://starsling.dev/ci-speedup): the skill's
+  landing page — what a run does, walked through end to end, without cloning
+  anything.
 
 ## For maintainers
 

--- a/skills/ci-speedup/SKILL.md
+++ b/skills/ci-speedup/SKILL.md
@@ -428,7 +428,7 @@ only) § Adding a pattern to the catalog.
 
 ## Methodology
 
-Reference docs (read on demand — each links one level deep from here):
+Reference docs (read on demand — each links one level deep from here; outside the repo, [starsling.dev/ci-speedup](https://starsling.dev/ci-speedup) walks through the same model):
 
 - [references/wall-clock-methodology.md](references/wall-clock-methodology.md) —
   critical-path / long-pole / cluster-floor model: wall-clock is `max(parallel


### PR DESCRIPTION
Metadata and documentation only. No skill logic, catalog, evals, scripts, or tests touched, so no CHANGELOG entry.

## Why

Search Console shows **zero impressions over 90 days for any query containing "speedup"** — the term is a product name, not a keyword, and has no organic demand. So none of this optimizes copy for that phrase. Internal linking from starsling.dev is already saturated (37 pages link to `/ci-speedup`); the missing inputs are **external** links and **GitHub-native** discovery surfaces, which is what this changes.

## What changed

**Repo metadata** (applied directly, not part of the diff):

- **Topics** set from empty to: `github-actions`, `ci-cd`, `continuous-integration`, `claude-code`, `agent-skills`, `ai-agents`, `devops`, `developer-tools`. Topics are a first-class filter in GitHub search and are indexed off-site.
- **Description** sharpened from "Agent skills from StarSling", which says nothing about what the skill does, to: "Free, MIT-licensed agent skills from StarSling. ci-speedup audits your GitHub Actions workflows and reports, from real run history, why CI is slow." This string is what GitHub search results and link previews show.
- `homepage` was already `https://starsling.dev/ci-speedup` and is unchanged.

**In the diff:**

- `README.md`: two links to the landing page — one under the intro line naming the skill, one as a `## Learn more` bullet. The existing StarSling Runners link under `## For maintainers` is untouched.
- `skills/ci-speedup/SKILL.md`: one link, folded into the existing `## Methodology` lead-in so anyone reading the skill directly has a path to the landing page. Frontmatter `description` is untouched — it controls triggering.

## Verification

- `gh api repos/starslingdev/skills --jq '{topics,description,homepage}'` reflects the new topics and description.
- Every added link returns HTTP 200.
- `python3 -m pytest -q`: **2559 passed, 15 skipped**. The SKILL.md addition is folded into an existing line on purpose — the body was at 499 of its 500-line progressive-disclosure budget, and a new paragraph tripped `test_skill_body_stays_under_the_progressive_disclosure_budget`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)