### PR TITLE
ci-speedup: verify sizing guard joins jobs via the scanned job graph, never a cross-workflow name match (#2)

### DIFF
--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -50,7 +50,10 @@ unversioned and updates by reinstall from `main`.
   553.0 min/mo `lint`, and a correctly-sized 3,187.9 min/mo credit false-FAILed
   the gate. The join now resolves key ↔ `name:` in BOTH directions through the
   artifact's own `workflow_job_graph`, tries every same-workflow identity before
-  the cross-workflow fallback, and sums all matrix legs of the resolved job. An
+  the cross-workflow fallback, and sums all matrix legs of the resolved job.
+  Graph-resolved aliases are SAME-WORKFLOW ONLY — the cross-workflow fallback
+  still matches the literal base, so a job with no spine row in its own workflow
+  can never bind an unrelated namesake's compute and inflate the upper bound. An
   affected job genuinely absent from the spine still surfaces as a coverage gap,
   and an artifact with no job graph keeps the previous bare-name behavior.
 

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -55,7 +55,10 @@ unversioned and updates by reinstall from `main`.
   still matches the literal base, so a job with no spine row in its own workflow
   can never bind an unrelated namesake's compute and inflate the upper bound. An
   affected job genuinely absent from the spine still surfaces as a coverage gap,
-  and an artifact with no job graph keeps the previous bare-name behavior.
+  and an artifact with no job graph keeps the previous bare-name behavior. An
+  AMBIGUOUS display name — two job keys in one workflow rendering to the same
+  `name:`, hence one shared spine row — yields no alias, so a finding is never
+  bounded by its twin's compute.
 
 ### Fixed (pre-flip audit wave 2)
 

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -36,6 +36,24 @@ unversioned and updates by reinstall from `main`.
   quote a credential; mask it and note the mask), and the repo's `SECURITY.md`
   documents the three-layer log-data model (W011).
 
+### Fixed
+
+- **2026-07-28** — **The physical-bound sizing guard now joins a finding's jobs
+  through the scanned job graph, never a cross-workflow name match** (issue #2).
+  `verify_report.check_saving_within_measured_compute` matched a finding's
+  `affected_jobs` (YAML keys) against the cost spine's job names (rendered
+  `name:` display names, one row per matrix leg). A `name:`-overridden job missed
+  that join entirely and fell through to the cross-workflow same-name fallback,
+  which bound an UNRELATED job in another workflow that happened to share the bare
+  name — on biomejs/biome, OPT33's `lint` in `pull_request.yml` (real compute
+  13,381.6 min/mo across two matrix legs) bound `pull_request_markdown.yml`'s
+  553.0 min/mo `lint`, and a correctly-sized 3,187.9 min/mo credit false-FAILed
+  the gate. The join now resolves key ↔ `name:` in BOTH directions through the
+  artifact's own `workflow_job_graph`, tries every same-workflow identity before
+  the cross-workflow fallback, and sums all matrix legs of the resolved job. An
+  affected job genuinely absent from the spine still surfaces as a coverage gap,
+  and an artifact with no job graph keeps the previous bare-name behavior.
+
 ### Fixed (pre-flip audit wave 2)
 
 - **2026-07-22** — **Catalog deep-links now use GitHub's real GFM anchor rule.**

--- a/skills/ci-speedup/tests/test_collect_runs_sizing.py
+++ b/skills/ci-speedup/tests/test_collect_runs_sizing.py
@@ -2378,6 +2378,25 @@ def test_name_override_alias_never_widens_the_cross_workflow_fallback(tmp_path):
     assert res.skipped and "coverage gap" in res.detail, res.detail
 
 
+def test_name_override_alias_skips_a_colliding_display_name(tmp_path):
+    # Two job KEYS in one workflow rendering to the SAME display name are one row in
+    # the spine (which indexes by name), so that row's compute belongs to BOTH jobs.
+    # Aliasing either key onto it would bound the finding by the SUM and inflate the
+    # ceiling — a 9,000 credit against a 5,000-min job would read "within measured
+    # compute" off its twin's 5,000. An ambiguous name yields no alias, so this stays
+    # an honest coverage gap (nothing bounded → loud SKIP).
+    doc = _name_doc(9000.0, jobs=("test_unit",))
+    doc["workflow_job_graph"] = {
+        _NAME_WF: {"test_unit": {"name": "Test suite", "needs": [], "matrix": False},
+                   "test_e2e": {"name": "Test suite", "needs": [], "matrix": False}},
+    }
+    doc["runner_minute_spine"]["rows"].append(
+        {"workflow_file": _NAME_WF, "job_name": "Test suite",
+         "billable_equiv_min_per_month": 10000.0})
+    res = _name_result(doc, tmp_path)
+    assert res.skipped and "coverage gap" in res.detail, res.detail
+
+
 def test_name_override_join_without_a_graph_keeps_the_legacy_fallback(tmp_path):
     # An artifact predating `workflow_job_graph` keeps today's behavior: the bare
     # key resolves only through the cross-workflow same-name fallback (553.0), so

--- a/skills/ci-speedup/tests/test_collect_runs_sizing.py
+++ b/skills/ci-speedup/tests/test_collect_runs_sizing.py
@@ -2280,3 +2280,87 @@ def test_door_derive_without_prepass_is_flagged_not_silently_clamped():
         assert f["runner_min_saving"] == 5000.0, "not silently clamped to measured"
     finally:
         del _RM_DOOR_OVERRIDES["OPT_TEST_DERIVE"]
+
+
+# --- issue #2: YAML key ↔ `name:` override join -------------------------------
+# biomejs/biome: OPT33 names its job by YAML KEY (`lint` in pull_request.yml), but
+# the spine records that job under its `name:` OVERRIDE, expanded per matrix leg
+# (`Lint project (depot-ubuntu-24.04-arm-16)` + `(depot-windows-2022)`, Σ 13,381.6
+# min/mo). The bare key missed the join, and the cross-workflow same-name FALLBACK
+# then mis-bound it to an UNRELATED job literally named `lint` in
+# pull_request_markdown.yml (553.0) → false FAIL. The join must resolve key ↔ name
+# through the scanned `workflow_job_graph`, and a same-workflow resolution must
+# always beat the cross-workflow fallback.
+_NAME_WF = ".github/workflows/pull_request.yml"
+_NAME_OTHER_WF = ".github/workflows/pull_request_markdown.yml"
+_NAME_ROWS = [
+    (_NAME_WF, "Lint project (depot-ubuntu-24.04-arm-16)", 2411.8),
+    (_NAME_WF, "Lint project (depot-windows-2022)", 10969.8),   # Σ Lint project = 13,381.6
+    (_NAME_OTHER_WF, "lint", 553.0),                            # UNRELATED job, same bare name
+]
+_NAME_BILLABLE = 13381.6
+_NAME_GRAPH = {
+    _NAME_WF: {"lint": {"name": "Lint project", "needs": [], "matrix": True}},
+    _NAME_OTHER_WF: {"lint": {"name": "lint", "needs": [], "matrix": False}},
+}
+
+
+def _name_doc(saving: float, jobs=("lint",), wf=_NAME_WF, graph=_NAME_GRAPH) -> dict:
+    doc = {"findings": [{"pattern": "OPT33", "workflow_file": wf,
+                         "affected_jobs": list(jobs), "runner_min_saving": saving}],
+           "runner_minute_spine": {"render_ready": True, "rows": [
+               {"workflow_file": w, "job_name": j, "billable_equiv_min_per_month": b}
+               for w, j, b in _NAME_ROWS]}}
+    if graph is not None:
+        doc["workflow_job_graph"] = graph
+    return doc
+
+
+def _name_result(doc: dict, tmp_path):
+    import json
+    vr = _load_verify_report_for_bounds()
+    fp = tmp_path / "name-override-findings.json"
+    fp.write_text(json.dumps(doc), encoding="utf-8")
+    return vr.check_saving_within_measured_compute("# report\n", fp)
+
+
+def test_name_overridden_job_binds_via_the_scanned_job_graph(tmp_path):
+    # THE issue #2 shape. 3187.9 is well within the real job's 13,381.6 measured
+    # compute; pre-fix the key `lint` fell through to the cross-workflow fallback
+    # and bound the unrelated 553.0 job → false FAIL.
+    res = _name_result(_name_doc(3187.9), tmp_path)
+    assert res.ok and not res.skipped, res.detail
+    assert "partial coverage" not in res.detail and "coverage gap" not in res.detail
+
+
+def test_name_override_join_aggregates_matrix_legs_and_beats_the_fallback(tmp_path):
+    # The bound is the SUM of the resolved job's matrix legs (13,381.6) — not one
+    # leg, and never the same-named foreign job (553.0). A credit just above the
+    # summed legs still FAILs, so the wider join never becomes a blanket pass.
+    assert _name_result(_name_doc(_NAME_BILLABLE * 0.99), tmp_path).ok
+    over = _name_result(_name_doc(_NAME_BILLABLE * 1.10), tmp_path)
+    assert not over.ok and not over.skipped
+    assert "13381.6" in over.detail   # bounded by the real job, not the 553.0 namesake
+
+
+def test_name_override_join_resolves_a_display_name_back_to_its_key(tmp_path):
+    # Reverse direction: a finding that names the DISPLAY name resolves the same
+    # way (and a bare leg name still folds into its base's summed compute).
+    assert _name_result(_name_doc(3187.9, jobs=("Lint project",)), tmp_path).ok
+    assert _name_result(
+        _name_doc(3187.9, jobs=("Lint project (depot-windows-2022)",)), tmp_path).ok
+
+
+def test_name_override_join_leaves_an_absent_job_uncovered(tmp_path):
+    # No new severity semantics: a job genuinely absent from the spine stays a
+    # coverage gap (nothing bounded → loud SKIP), exactly as before the fix.
+    res = _name_result(_name_doc(3187.9, jobs=("documentation",)), tmp_path)
+    assert res.skipped and "coverage gap" in res.detail
+
+
+def test_name_override_join_without_a_graph_keeps_the_legacy_fallback(tmp_path):
+    # An artifact predating `workflow_job_graph` keeps today's behavior: the bare
+    # key resolves only through the cross-workflow same-name fallback (553.0), so
+    # the same credit FAILs. The graph is what makes the join correct.
+    res = _name_result(_name_doc(3187.9, graph=None), tmp_path)
+    assert not res.ok and not res.skipped and "553" in res.detail

--- a/skills/ci-speedup/tests/test_collect_runs_sizing.py
+++ b/skills/ci-speedup/tests/test_collect_runs_sizing.py
@@ -2358,6 +2358,26 @@ def test_name_override_join_leaves_an_absent_job_uncovered(tmp_path):
     assert res.skipped and "coverage gap" in res.detail
 
 
+def test_name_override_alias_never_widens_the_cross_workflow_fallback(tmp_path):
+    # A graph-resolved alias is evidence about ITS OWN workflow only. `deploy` in
+    # pull_request.yml renders as `Deploy app` but has NO spine row there; an
+    # UNRELATED `Deploy app` in another workflow bills 50,000. Carrying the alias
+    # into the cross-workflow fallback would bind that foreign compute and let a
+    # 40,000 credit read "within measured compute" — an inflated upper bound
+    # masking an oversized finding. The fallback stays on the LITERAL base, so
+    # this stays an honest coverage gap (nothing bounded → loud SKIP).
+    doc = _name_doc(40000.0, jobs=("deploy",))
+    doc["workflow_job_graph"] = {
+        _NAME_WF: {"deploy": {"name": "Deploy app", "needs": [], "matrix": False}},
+        _NAME_OTHER_WF: {"deploy_app": {"name": "Deploy app", "needs": [], "matrix": False}},
+    }
+    doc["runner_minute_spine"]["rows"].append(
+        {"workflow_file": _NAME_OTHER_WF, "job_name": "Deploy app",
+         "billable_equiv_min_per_month": 50000.0})
+    res = _name_result(doc, tmp_path)
+    assert res.skipped and "coverage gap" in res.detail, res.detail
+
+
 def test_name_override_join_without_a_graph_keeps_the_legacy_fallback(tmp_path):
     # An artifact predating `workflow_job_graph` keeps today's behavior: the bare
     # key resolves only through the cross-workflow same-name fallback (553.0), so

--- a/skills/ci-speedup/tests/verify_report.py
+++ b/skills/ci-speedup/tests/verify_report.py
@@ -3339,11 +3339,23 @@ def check_saving_within_measured_compute(report: str, findings_path: Path | None
     def _identities(wf: str, job: str) -> list[str]:
         """Job bases `job` may appear under in `wf`'s spine rows, literal first (so an already-
         matching name keeps today's binding), then the graph-resolved counterpart identity.
-        Only valid WITHIN `wf` — the cross-workflow fallback must not use these aliases."""
+        Only valid WITHIN `wf` — the cross-workflow fallback must not use these aliases.
+        An AMBIGUOUS display name (two job keys in `wf` rendering to the same name) yields no
+        alias: the spine indexes by that one name, so aliasing a key onto it would bound the
+        finding by BOTH jobs' summed compute and inflate the ceiling. Ambiguity stays an honest
+        coverage gap, same as the cross-workflow rule above."""
         b = _base(job)
         out = [b] if b else []
-        for jid, info in _as_dict(graph.get(wf)).items():
+        jobs_in_wf = _as_dict(graph.get(wf))
+        names: dict[str, int] = {}
+        for jid, info in jobs_in_wf.items():
             nm = _base(_as_dict(info).get("name") or jid)
+            if nm:
+                names[nm] = names.get(nm, 0) + 1
+        for jid, info in jobs_in_wf.items():
+            nm = _base(_as_dict(info).get("name") or jid)
+            if names.get(nm, 0) > 1:
+                continue  # collision: this display name identifies more than one job — no alias.
             # key → its `name:` override, and display name → its key; both directions, one pass.
             for alias in ((nm,) if _base(jid) == b else ((_base(jid),) if nm == b else ())):
                 if alias and alias not in out:

--- a/skills/ci-speedup/tests/verify_report.py
+++ b/skills/ci-speedup/tests/verify_report.py
@@ -3288,7 +3288,10 @@ def check_saving_within_measured_compute(report: str, findings_path: Path | None
     `runner_minute_spine` rows (`billable_equiv_min_per_month`, the sampled-and-extrapolated cost the
     spine already stamps and `check_runner_minute_spine_contract` re-derives), matched to the
     finding's `affected_jobs` by workflow_file + job base name (matrix `(variant)` stripped, the same
-    `_cmp_name`/base join the spine uses). A finding whose jobs ALL resolve to spine rows must have
+    `_cmp_name`/base join the spine uses), resolving a finding's YAML job key against the spine's
+    `name:`-overridden display name through the scanned `workflow_job_graph` (issue #2) so a
+    same-workflow match always beats the cross-workflow same-name fallback. A finding whose jobs ALL
+    resolve to spine rows must have
     saving <= their summed billable compute (directional upper bound + tolerance; L6). SKIPs loud when
     there is no render-ready cost spine, or when savings exist but NONE of them resolve any affected
     job to a spine row — the check bounded nothing, so it SKIPs loud rather than pass green (the
@@ -3315,6 +3318,30 @@ def check_saving_within_measured_compute(report: str, findings_path: Path | None
     def _base(job: str) -> str:
         # Strip a trailing matrix `(variant)` so a finding's bare job name matches its expanded legs.
         return _cmp_name(re.sub(r"\s*\([^()]*\)\s*$", "", str(job or "")).strip())
+
+    # YAML KEY ↔ `name:` OVERRIDE (issue #2). A finding names its job by YAML key (`lint`), but the
+    # spine records the job under its rendered DISPLAY name (`Lint project (depot-windows-2022)`) —
+    # the key misses the join entirely. Resolve both identities through the scanned
+    # `workflow_job_graph` (`{wf: {job_id: {name, ...}}}`, already stamped on the artifact, so no
+    # producer change): key → declared `name:`, and DISPLAY name → key for the reverse direction.
+    # Candidates stay per-workflow, so a same-workflow resolution is always tried before the
+    # cross-workflow same-name fallback below — biome's OPT33 on `lint` bound the unrelated
+    # `pull_request_markdown.yml` job literally named `lint` (553 min/mo) instead of its own job's
+    # 13,381.6, and false-FAILed. An artifact with no graph keeps the bare-name behavior.
+    graph = _as_dict(data.get("workflow_job_graph"))
+
+    def _identities(wf: str, job: str) -> list[str]:
+        """Job bases `job` may appear under in `wf`'s spine rows, literal first (so an already-
+        matching name keeps today's binding), then the graph-resolved counterpart identity."""
+        b = _base(job)
+        out = [b] if b else []
+        for jid, info in _as_dict(graph.get(wf)).items():
+            nm = _base(_as_dict(info).get("name") or jid)
+            # key → its `name:` override, and display name → its key; both directions, one pass.
+            for alias in ((nm,) if _base(jid) == b else ((_base(jid),) if nm == b else ())):
+                if alias and alias not in out:
+                    out.append(alias)
+        return out
 
     compute: dict[tuple[str, str], float] = {}
     for r in rows:
@@ -3357,17 +3384,25 @@ def check_saving_within_measured_compute(report: str, findings_path: Path | None
         seen: set[str] = set()
         for j in jobs:
             b = _base(j)
-            if not b or b in seen:
+            if not b:
                 continue
-            seen.add(b)
+            # Same-workflow identities first (literal, then graph-resolved) — a job that resolves
+            # in its OWN workflow never reaches the cross-workflow fallback, so a foreign namesake
+            # can't win. `compute` already sums a base's matrix legs, so the resolved display name
+            # brings the whole job's compute (all legs) in one figure.
+            cands = _identities(wf, j)
+            key = next(((wf, c) for c in cands if (wf, c) in compute), None)
+            ident = key[1] if key else b
+            if ident in seen:
+                continue
+            seen.add(ident)
             distinct += 1
-            key = (wf, b)
-            if key in compute:
+            if key:
                 matched += 1
                 bound += compute[key]
             else:
                 # Job base present under ANY workflow file (a reusable-workflow caller loses the wf).
-                alt = [v for (w, jb), v in compute.items() if jb == b]
+                alt = [v for (w, jb), v in compute.items() if jb in cands]
                 if alt:
                     matched += 1
                     bound += max(alt)

--- a/skills/ci-speedup/tests/verify_report.py
+++ b/skills/ci-speedup/tests/verify_report.py
@@ -3290,9 +3290,10 @@ def check_saving_within_measured_compute(report: str, findings_path: Path | None
     finding's `affected_jobs` by workflow_file + job base name (matrix `(variant)` stripped, the same
     `_cmp_name`/base join the spine uses), resolving a finding's YAML job key against the spine's
     `name:`-overridden display name through the scanned `workflow_job_graph` (issue #2) so a
-    same-workflow match always beats the cross-workflow same-name fallback. A finding whose jobs ALL
-    resolve to spine rows must have
-    saving <= their summed billable compute (directional upper bound + tolerance; L6). SKIPs loud when
+    same-workflow match always beats the cross-workflow same-name fallback (which stays on the
+    LITERAL base — graph aliases never widen it). A finding whose jobs ALL resolve to spine rows
+    must have saving <= their summed billable compute (directional upper bound + tolerance; L6).
+    SKIPs loud when
     there is no render-ready cost spine, or when savings exist but NONE of them resolve any affected
     job to a spine row — the check bounded nothing, so it SKIPs loud rather than pass green (the
     fragile-join failure mode: if the spine's job-naming ever drifts from `affected_jobs`, every
@@ -3328,11 +3329,17 @@ def check_saving_within_measured_compute(report: str, findings_path: Path | None
     # cross-workflow same-name fallback below — biome's OPT33 on `lint` bound the unrelated
     # `pull_request_markdown.yml` job literally named `lint` (553 min/mo) instead of its own job's
     # 13,381.6, and false-FAILed. An artifact with no graph keeps the bare-name behavior.
+    # Graph-resolved aliases are SAME-WORKFLOW ONLY — they never widen the cross-workflow fallback,
+    # which stays on the LITERAL base exactly as before this fix. An alias is evidence about THIS
+    # workflow's job ("`lint` here renders as `Lint project`"); carrying it into a foreign workflow
+    # would let a job with no spine row of its own bind an unrelated namesake's compute and INFLATE
+    # the upper bound, masking an oversized finding. Unresolvable stays an honest coverage gap.
     graph = _as_dict(data.get("workflow_job_graph"))
 
     def _identities(wf: str, job: str) -> list[str]:
         """Job bases `job` may appear under in `wf`'s spine rows, literal first (so an already-
-        matching name keeps today's binding), then the graph-resolved counterpart identity."""
+        matching name keeps today's binding), then the graph-resolved counterpart identity.
+        Only valid WITHIN `wf` — the cross-workflow fallback must not use these aliases."""
         b = _base(job)
         out = [b] if b else []
         for jid, info in _as_dict(graph.get(wf)).items():
@@ -3402,7 +3409,10 @@ def check_saving_within_measured_compute(report: str, findings_path: Path | None
                 bound += compute[key]
             else:
                 # Job base present under ANY workflow file (a reusable-workflow caller loses the wf).
-                alt = [v for (w, jb), v in compute.items() if jb in cands]
+                # LITERAL base only — graph aliases are same-workflow evidence and must not widen
+                # this cross-workflow match (see `_identities`); a job with no row in its own
+                # workflow stays an honest coverage gap rather than binding a foreign namesake.
+                alt = [v for (w, jb), v in compute.items() if jb == b]
                 if alt:
                     matched += 1
                     bound += max(alt)


### PR DESCRIPTION
## Root cause

`check_saving_within_measured_compute` (verify_report.py) bounds a finding's credited
`runner_min_saving` by the measured billable compute of the jobs it touches. It joined the
finding's `affected_jobs` — which name jobs by **YAML key** — against the runner-minute cost
spine, whose rows carry the **rendered display name** (`name:` override, one row per matrix leg).

A `name:`-overridden job misses that join completely, and the guard then fell through to its
cross-workflow same-name fallback, which binds *any* job in *any* workflow that shares the bare
name. On biomejs/biome:

- OPT33 on `.github/workflows/pull_request.yml` ▸ `lint`, credit **3187.9 min/mo**
- that job's real spine rows: `Lint project (depot-ubuntu-24.04-arm-16)` 2411.8 +
  `Lint project (depot-windows-2022)` 10969.8 = **13,381.6 min/mo**
- what the fallback bound instead: an unrelated job literally named `lint` in
  `pull_request_markdown.yml` = **553.0 min/mo**
- result: false FAIL — *"OPT33 credits 3187.9 min/mo … measure only 553 min/mo"*

The finding was within its job's compute; the guard's join was wrong. `name:` overrides are
extremely common, so this is a gate false-positive on an ordinary repo shape.

## Fix

Verifier-side join only — no producer change. The artifact already stamps
`workflow_job_graph` (`{workflow_file: {job_id: {name, needs, …}}}`), so the guard resolves both
identities from it:

- `_identities(wf, job)` returns the bases a finding's job can appear under in that workflow:
  the literal base first (so an already-matching name keeps today's binding), then the
  graph-resolved counterpart — YAML key → its `name:` override, **and** display name → its key.
- Every **same-workflow** identity is tried before the cross-workflow fallback, so a foreign
  namesake can never win when the job resolves in its own workflow.
- Matrix legs still aggregate: the compute index already sums a base's legs, so the resolved
  display name brings the whole job's compute in one figure (13,381.6, not one leg).
- Dedupe is now keyed on the **resolved** identity, so a finding listing both `lint` and
  `Lint project` counts that job once.
- Aliases are **same-workflow only** — the cross-workflow fallback stays on the literal base, so a
  job with no row in its own workflow can never bind a foreign namesake's compute.
- An **ambiguous display name** (two job keys in one workflow rendering to the same `name:`, hence
  one shared spine row) yields no alias, so a finding is never bounded by its twin's compute.
- Unchanged semantics elsewhere: an affected job genuinely absent from the spine stays a coverage
  gap (per-finding `uncovered` / partial-coverage detail, loud SKIP when nothing bounds), and an
  artifact with no `workflow_job_graph` keeps the previous bare-name behavior.

## Red → green proof

New fixtures in `skills/ci-speedup/tests/test_collect_runs_sizing.py` (committed first, b509359,
before the fix), modeling the biome shape: finding names the YAML key, spine carries the
`name:`-overridden display name across two matrix legs, unrelated same-named job in another
workflow.

Red against the unfixed guard (2 failed, 4 passed):

```
FAILED test_name_overridden_job_binds_via_the_scanned_job_graph
  → OPT33 credits 3187.9 min/mo … measure only 553 min/mo of billable compute
FAILED test_name_override_join_aggregates_matrix_legs_and_beats_the_fallback
```

Green after the fix: `6 passed`.

- `test_name_overridden_job_binds_via_the_scanned_job_graph` — the issue shape passes, with no
  partial/coverage-gap caveat.
- `test_name_override_join_aggregates_matrix_legs_and_beats_the_fallback` — bound is the summed
  legs (13,381.6); a credit 10% above it still FAILs, so the wider join is not a blanket pass.
- `test_name_override_join_resolves_a_display_name_back_to_its_key` — reverse direction + bare leg.
- `test_name_override_join_leaves_an_absent_job_uncovered` — absent job keeps today's coverage-gap
  SKIP (no new severity semantics).
- `test_name_override_join_without_a_graph_keeps_the_legacy_fallback` — graphless artifact keeps
  the old behavior.

## Live-pin re-verification (biomejs/biome, fresh 2026-07-28 capture)

`python3 skills/ci-speedup/tests/verify_report.py --report … --findings …`

- Before: `❌ 1 check(s) failed` (the OPT33 false FAIL).
- After: **rc 0, `✅ all checks passed`**.
- Status diff across all 64 checks: exactly one change, `FAIL → PASS` on
  *"each finding's runner-minute saving is within its jobs' measured compute"*. No new FAILs, no
  check flipped to SKIP. The check now reads: `19 credited saving(s) within measured compute;
  1 bounded on the resolved job subset only (partial coverage): OPT45(8/13 jobs); 3 finding(s)
  had no affected job in the cost spine (coverage gap, not bounded): OPT5(...)` — i.e. the
  pre-existing coverage gaps are still reported honestly, they are not new.

## Tests

Full suite from the repo root (rebased on current `main`): **2575 passed, 15 skipped**. The 15
skips are the environment-dependent baseline set.

## Notes for the reviewer (judgment calls made while running solo)

- **Branch name.** The intended branch `ci-speedup/verify-sizing-join-name-override` was left in
  an unusable state by a local tooling accident (see below), and force-moving a branch ref was not
  permitted in this environment, so the work is on `…-override-3`. Same base commit (e1ada6f),
  same content.
- **Local pre-commit hook is unsafe in a worktree (pre-existing repo bug, not fixed here).**
  `.githooks/pre-commit` runs the full pytest suite *from inside the hook*, and git exports
  `GIT_DIR` / `GIT_INDEX_FILE` to hook children. Fixture tests that shell out to `git` inherit
  those and write into the **real** repository: during this session the hook run repeatedly reset
  this worktree's `HEAD` and truncated its index to a single fixture path (`scripts/x.py`), and
  created stray `init` / `base` commits. Commits here were therefore made with `--no-verify` and
  the identical suite was run directly instead (green, counts above). Worth a follow-up: have the
  hook `unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE` (and/or `env -u`) before invoking pytest.

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

