### PR TITLE
ci-speedup: aggregation-gate poles render the honest upstream story, never an optimize-this-3s-check prompt (#1)

### DIFF
--- a/maintainers/ci-speedup/scripts/grader_seeds.py
+++ b/maintainers/ci-speedup/scripts/grader_seeds.py
@@ -56,7 +56,7 @@ EXCLUDE = "exclude"       # run/harness artifact → never a skill bug
 # The committed, reviewable TRIAGE ALLOWLIST. Keyed by the live `verify_report.Check.name` string
 # (what `run_checks` actually yields) so the classification can be applied at runtime and the
 # "every check is classified" invariant is directly testable; the originating `check_*` function
-# name is in the trailing comment for cross-reference with spec §2-A. 61 AUTO_SEED / 1 EXCLUDE /
+# name is in the trailing comment for cross-reference with spec §2-A. 62 AUTO_SEED / 1 EXCLUDE /
 # 2 TRIAGE — a new `verify_report` check makes `test_every_check_is_classified` go red until it's
 # classified here (so no check is ever left undisposed).
 TRIAGE_ALLOWLIST = {
@@ -74,6 +74,7 @@ TRIAGE_ALLOWLIST = {
     "every rendered finding pattern exists in the findings JSON": AUTO_SEED,                        # check_rendered_patterns_exist
     "every data-driven finding carries a measured signal (no unsupported claims)": AUTO_SEED,       # check_data_driven_have_signal
     "report drills every gating pole, each with a hand-off prompt": AUTO_SEED,                      # check_speed_poles_complete
+    "aggregation-gate poles tell the upstream story, never an optimize-this prompt": AUTO_SEED,    # check_aggregation_gate_poles_never_prescribe
     "each rendered pole's drill belongs to its own job (no cross-job log leak)": AUTO_SEED,         # check_pole_drill_belongs_to_its_job
     "every 🤖 gap-fill evidence line is verbatim from the captured job log (issue #106)": AUTO_SEED,  # check_gap_fill_evidence_grounded
     "no spine-dropped check is also framed on the merge-gating critical path": AUTO_SEED,           # check_dropped_check_not_framed_on_path
@@ -168,6 +169,7 @@ CHECK_CLASS = {
     "every rendered finding pattern exists in the findings JSON": "fabricated-or-unsupported-finding",  # rendered claim not backed by findings
     "every data-driven finding carries a measured signal (no unsupported claims)": "estimated-not-measured",  # exact match
     "report drills every gating pole, each with a hand-off prompt": "missing-second-pole-or-finding",  # a required pole/finding is missing
+    "aggregation-gate poles tell the upstream story, never an optimize-this prompt": "prescribed-a-fix",  # an "optimize this step" prompt over a `needs:`-only success sink that runs no work
     "each rendered pole's drill belongs to its own job (no cross-job log leak)": "fabricated-or-unsupported-finding",  # a drill misattributed to the wrong job's evidence
     "every 🤖 gap-fill evidence line is verbatim from the captured job log (issue #106)": "fabricated-or-unsupported-finding",  # a quoted evidence line not in the captured log = a fabricated/altered quote
     "no spine-dropped check is also framed on the merge-gating critical path": "mis-ranked-lever",  # spine/critical-path framing error

--- a/maintainers/ci-speedup/tests/test_grader_seeds.py
+++ b/maintainers/ci-speedup/tests/test_grader_seeds.py
@@ -38,7 +38,7 @@ def test_every_check_is_classified():
 
 def test_classification_counts_match_spec():
     counts = Counter(gs.TRIAGE_ALLOWLIST.values())
-    assert counts[gs.AUTO_SEED] == 61   # +1 (pre-flip audit: static-only banner matches CI shape — no dormant-repo hedge at a live no-PR-gating repo, no "no run timing" beside priced timed runs);
+    assert counts[gs.AUTO_SEED] == 62   # +1 (pre-flip audit: static-only banner matches CI shape — no dormant-repo hedge at a live no-PR-gating repo, no "no run timing" beside priced timed runs);
     # +2 (issue #114: crowned cluster lever is on the merge-gating spine — no off-spine crown; issue #115: headline leads with the observed wall when the chain sum diverges from the makespan);
     # +1 (issue #106: every 🤖 gap-fill evidence line is verbatim from the captured job log — the injection-residual grounding backstop);
     # +1 (fence-escaping: code fences are balanced — no stray ``` breaks out of a fence / desyncs the verifier's fence split);
@@ -64,6 +64,7 @@ def test_classification_counts_match_spec():
     # +1 (payload-binned-as-build class — the OPT72 misroute guard, nrwl/nx).
     # +1 (MEASURED CAUSE never asserts unrendered timeline steps — the nrwl/nx playwright-parallel fix).
     # +1 (#12: no fileless/managed status check crowns the headline — disclosed as PR-lifetime latency).
+    # +1 (#1: aggregation-gate poles tell the upstream story, never an optimize-this prompt).
     assert counts[gs.EXCLUDE] == 1
     assert counts[gs.TRIAGE] == 2
 

--- a/skills/ci-speedup/ARCHITECTURE.md
+++ b/skills/ci-speedup/ARCHITECTURE.md
@@ -1561,7 +1561,10 @@ catalog pattern lacking a registered detector in
   a `measured_signal`; Tier-2 rows re-derive from the stamped measured basis,
   neutrality certificates, de-overlapped totals, and billing rates; and the
   report drills **one fully-formed long pole per independent gating check** (>=2
-  when >=2 gate), each ending in a hand-off prompt.
+  when >=2 gate), each ending in a hand-off prompt — the sole exception being an
+  **aggregation gate** (§12.6b), which carries no drill and no prompt by design
+  and is held to the mirror-image invariant instead (it must name its slowest
+  upstream member and prescribe nothing).
 
 ## 8. Reproducibility & determinism
 
@@ -2708,6 +2711,53 @@ The honesty guard is a re-derivation invariant, not a renderer patch: each
 **fails any static-only report that has a measured merge-path long pole**. A cron/release-only
 repo (timed but on no merge-path event) stays legitimately static-only; an older findings
 JSON without the `events` stamp declines to fire rather than false-flag.
+
+### 12.6b The aggregation gate — the degenerate chain SINK (issue #1)
+
+Many repos make a single trivial job the **one required status check**: it runs no
+work, `needs:` everything else in its workflow, and exists only so branch
+protection has one name to require (vercel/next.js `thank you, build` — job
+`buildPassed`, `needs: [deploy-target, build, build-wasm, build-native]`, body
+`run: exit 1` behind an `if:`, P50 **3s**). Because it gates every PR it is
+correctly crowned by pole frequency — but the generic pole render then handed the
+reader a drill placeholder and a "capture timing, then optimize this step" agent
+prompt over a 3-second no-op: correct data, **inert advice**, at the very first
+thing a reader sees.
+
+`blocking_path._agg_gate_shape` detects the shape at render time from artifact
+data already stamped (`workflow_job_graph` + the check spine — no producer
+change): **(a)** headline P50 <= `_AGG_GATE_TRIVIAL_S` (30s — below any real
+hosted-runner job's checkout+setup floor); **(b)** the pole's job is a *terminal*
+node whose transitive `needs:` closure (>= 2 jobs) covers **every non-terminal job
+in its workflow** — uncovered siblings must themselves be terminal, which is
+exactly the shape of an `if:`-conditional peer sink (`publishRelease`), so
+"effectively all the other jobs" is expressed structurally rather than by reading
+`if:` (which the scanned graph does not carry); **(c)** no captured/sampled step
+above the trivial threshold (step data is a *disqualifier* only — a 3s gate is
+never drilled, and the role line discloses when the shape rests on structure
+alone); **(d)** at least one upstream member resolves to a **measured** check, so
+the report can name where the wait actually is. Duration alone never matches: a
+real 3s `lint` job with no `needs:` coverage keeps the ordinary rendering.
+
+On a match the pole renders a `pole_role_line` claim saying what it is — an
+aggregation gate whose wait IS its `needs:` upstream — names the slowest measured
+upstream member with its P50, and closes with a pointer to the pole that drills
+that member (an anchor when it renders, otherwise a named check plus what a re-run
+would do — never a dead link). It renders **no drill, no floor note, and no agent
+prompt**. Crowning/ranking is untouched (the frequency crown is correct data), and
+a sink that is itself a **modal-chain member** keeps the chain-stage framing (the
+chain model already frames it as serialized; no double-framing). A pole carrying a
+matched log-detector leaf or a routed structural lever also keeps today's render —
+there the drill is not inert, and suppressing it would silently drop a measured
+lever.
+
+Two coupled invariants hold the seam:
+`verify_report.check_speed_poles_complete` **exempts** such a pole from the
+"every pole ends in a prompt" rule, and
+`check_aggregation_gate_poles_never_prescribe` **fails** any aggregation-framed
+pole that carries a prompt, omits the upstream pointer, or whose shape does not
+re-derive from `findings.json` (`_agg_gate_pole_keys`, mirroring the renderer) —
+so the exemption can never launder a genuinely stunted pole.
 
 ### 12.7 The coverage-gap fallback — never dead-end on an unrecognised stack
 

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -38,6 +38,40 @@ unversioned and updates by reinstall from `main`.
 
 ### Fixed
 
+- **2026-07-28** — **An aggregation-gate pole tells the honest upstream story
+  instead of prompting the reader to optimize a 3-second no-op** (issue #1). Many
+  repos make one trivial job the single required status check: it runs no work,
+  `needs:` everything else in its workflow, and exists only so branch protection
+  has one name to require (vercel/next.js `thank you, build` — job `buildPassed`,
+  `needs: [deploy-target, build, build-wasm, build-native]`, body `run: exit 1`,
+  P50 **3s**). Because it gates every PR it was correctly crowned Long pole 1 by
+  frequency — and then rendered with a drill placeholder plus a "capture timing,
+  then optimize this step" agent prompt: correct data, inert advice, at the first
+  thing a reader sees. `blocking_path._agg_gate_shape` now detects the shape at
+  render time from data the artifact already stamps (`workflow_job_graph` + the
+  check spine — no producer change): trivial P50 (<= 30s, below any real hosted
+  job's checkout+setup floor), a *terminal* job whose transitive `needs:` closure
+  (>= 2 jobs) covers every non-terminal job in its workflow (uncovered siblings
+  must themselves be terminal — the shape of an `if:`-conditional peer sink like
+  `publishRelease`), no sampled step above that threshold, and at least one
+  upstream member with measured timing. Such a pole now renders a role line
+  saying what it is — its wait IS its `needs:` upstream — names the slowest
+  measured upstream member with its P50, and points at the pole that drills it
+  (an anchor when it renders, otherwise the check name and what a re-run does —
+  never a dead link), with **no drill, no floor note and no agent prompt**.
+  Structure, not duration, is the test: a real 3s `lint` job with no `needs:`
+  coverage renders byte-identically to before. Crowning and ranking are
+  unchanged, a sink that is a modal-chain member keeps its chain-stage framing
+  (no double-framing), and a pole with a matched log-detector leaf or a routed
+  structural lever keeps its drill (there the advice is not inert, and dropping
+  it would lose a measured lever). `verify_report` gained the matching pair:
+  `check_speed_poles_complete` exempts such a pole from the every-pole-has-a-
+  prompt rule, and the new `check_aggregation_gate_poles_never_prescribe` fails
+  any aggregation-framed pole that carries a prompt, omits the upstream pointer,
+  or whose shape does not re-derive from `findings.json` — so the exemption can
+  never launder a genuinely stunted pole. ARCHITECTURE §12.6b documents the
+  shape; SKILL.md 5b carries the matching self-audit carve-out.
+
 - **2026-07-28** — **The physical-bound sizing guard now joins a finding's jobs
   through the scanned job graph, never a cross-workflow name match** (issue #2).
   `verify_report.check_saving_within_measured_compute` matched a finding's

--- a/skills/ci-speedup/SKILL.md
+++ b/skills/ci-speedup/SKILL.md
@@ -267,11 +267,11 @@ different repo/path"). Only the delivery mechanism varies; the contract is **age
      + a path to fix each pole* — and **surface any shortfall yourself**
      rather than shipping a technically-rendered report and waiting for the
      user to notice. Flag (don't silently ship) any pole that is a bare
-     timeline, is missing its drill / root cause / hand-off prompt, or omits
-     the next-biggest lever as a second finding. The dead-end ban (4a) and the
-     5a gate are specific instances; generalize the instinct so an
-     *unanticipated* goal-failure is caught by your own judgment, not only by
-     the operator.
+     timeline, is missing its drill / root cause / hand-off prompt (an
+     aggregation gate has none by design — it points at its slowest `needs:`
+     upstream member), or omits the next-biggest lever as a second finding.
+     The dead-end ban (4a) and 5a are instances; generalize the instinct so an
+     *unanticipated* goal-failure is caught by you, not only by the operator.
    - **5/5a/5b are an INTERNAL gate — run them, never narrate them.** The
      verification run, the symmetric-pole check, and the self-audit are quality
      controls for *you*, not output. Never tell the user "all checks passed",

--- a/skills/ci-speedup/scripts/blocking_path.py
+++ b/skills/ci-speedup/scripts/blocking_path.py
@@ -760,6 +760,141 @@ def _floor_note(pole: dict[str, Any],
         + _recoverable_reconciliation(addr_leg, _tw), ""]
 
 
+# ── Aggregation gate (the degenerate chain SINK) ─────────────────────────────────────
+# A "success-aggregation gate" is the trivial job whose ONLY purpose is to `needs:` a set
+# of real jobs so that ONE check can be the single required status check — vercel/next.js'
+# `thank you, build` (job `buildPassed`: `needs: [deploy-target, build, build-wasm,
+# build-native]`, body `run: exit 1` behind an `if:`, P50 3s, required). Crowning it is
+# CORRECT data (it literally gates every PR), but drilling it and handing the reader a
+# "capture timing, then optimize this step" prompt is INERT advice: there is nothing inside
+# a 3-second no-op to speed, and moving it off the PR path defeats the reason it exists.
+# Its wait IS its `needs:` upstream, so the honest lever is the slowest upstream member.
+#
+# THRESHOLD. `_AGG_GATE_TRIVIAL_S` = 30s: a hosted-runner job that does any real work
+# (checkout + toolchain setup alone) clears 30s comfortably, so a check whose P50 sits under
+# it did nothing but wait on `needs:`. Duration ALONE never matches — it is one necessary
+# condition of a STRUCTURAL test (terminal node + covers every non-terminal job in its
+# workflow); a genuinely fast real job (a 3s lint) fails the structure test and keeps
+# today's rendering.
+_AGG_GATE_TRIVIAL_S = 30.0
+
+
+def _agg_job_produces_check(job_name: str, is_matrix: bool, check: str) -> bool:
+    """True iff a workflow job whose display `name:` is `job_name` (matrix-flagged iff
+    `is_matrix`) produces the check-run named `check`. Mirrors the scanned check->job
+    matching used elsewhere in the pipeline (exact display name; a matrix `name:` template
+    with `${{ … }}` holes compiled to `.+?`; a static matrix job's `Name (leg…)` legs). An
+    ENTIRELY-placeholder template is refused — a match-anything `^.+?$` would bind any
+    check-run and let this gate name an unrelated check as "the slowest upstream member"."""
+    if not job_name:
+        return False
+    if job_name == check:
+        return True
+    if "${{" in job_name:
+        parts = re.split(r"\$\{\{.*?\}\}", job_name)
+        if not any(p.strip() for p in parts):
+            return False  # degenerate all-placeholder template
+        return bool(re.match("^" + ".+?".join(re.escape(p) for p in parts) + "$", check))
+    if is_matrix:
+        return bool(re.match("^" + re.escape(job_name) + r"(?: \(.*\))?$", check))
+    return False
+
+
+def _agg_gate_shape(pole: dict[str, Any], job_graph: dict[str, Any] | None,
+                    checks: list[dict[str, Any]],
+                    timeline: dict[str, Any] | None = None) -> dict[str, Any] | None:
+    """The aggregation-gate shape for `pole`, or None when it doesn't match.
+
+    ALL of the following must hold (structure first — duration alone never matches):
+
+    (a) TRIVIAL — the check's headline P50 is <= `_AGG_GATE_TRIVIAL_S` (see above).
+    (b) TERMINAL SINK COVERING ITS WORKFLOW — the pole's job is a terminal node (no job in
+        the workflow `needs:` it) and its TRANSITIVE `needs:` closure contains every
+        NON-terminal job in that workflow. Uncovered siblings must themselves be terminal,
+        which is exactly the shape of an `if:`-conditional peer (next.js' `publishRelease`,
+        `deploy-tarball`): a conditional peer sink is never something the gate could
+        `needs:`, so "effectively all the other jobs" is expressed STRUCTURALLY rather than
+        by reading `if:` (which the scanned graph does not carry). The closure must hold
+        >= 2 jobs, so a single-parent `needs: [build]` stage — a chain member, not an
+        aggregation sink — never matches.
+    (c) NO SUBSTANTIVE WORK OF ITS OWN — step data is used only as a DISQUALIFIER, because
+        it usually does not exist for a check like this (a 3s gate is never drilled). When
+        per-step data IS present and any step exceeds the trivial threshold, the job does
+        real work and the shape is refused. With no step data, (a)+(b) stand on their own
+        and the rendered role line discloses that.
+    (d) A NAMED, MEASURED UPSTREAM — at least one member of the `needs:` closure resolves to
+        a measured check. Without one there is no honest "the real lever is over there" to
+        point at, so the pole keeps today's rendering rather than trading an inert prompt
+        for a contentless role line.
+
+    Returns `{"job_id", "upstream" (job ids), "slowest" (the measured check dict),
+    "unmeasured" (upstream display names with no measured check), "steps_known"}`."""
+    head_s, _ = _pole_headline(pole)
+    if head_s > _AGG_GATE_TRIVIAL_S:
+        return None
+    wf = str(pole.get("workflow_file") or "")
+    jobs = _as_dict(_as_dict(job_graph).get(wf))
+    if not jobs:
+        return None  # no scanned graph for this workflow — the shape is unknowable
+    check = str(pole.get("check") or "")
+    jid = str(pole.get("job") or "")
+    if jid not in jobs:
+        # The pole's `job` may be a DISPLAY name (or absent); resolve it back to the YAML key.
+        cands = [k for k, meta in jobs.items()
+                 if _agg_job_produces_check(str(_as_dict(meta).get("name") or k),
+                                            bool(_as_dict(meta).get("matrix")), check)]
+        if len(cands) != 1:
+            return None  # unresolvable or ambiguous identity — never guess
+        jid = cands[0]
+    needs_of = {k: [str(n) for n in _as_list(_as_dict(m).get("needs"))]
+                for k, m in jobs.items()}
+    depended_on = {n for ns in needs_of.values() for n in ns}
+    if jid in depended_on:
+        return None  # something `needs:` it — a chain stage, not a terminal sink
+    closure: set[str] = set()
+    frontier = list(needs_of.get(jid) or [])
+    while frontier:
+        n = frontier.pop()
+        if n in closure or n not in jobs:
+            continue
+        closure.add(n)
+        frontier.extend(needs_of.get(n) or [])
+    if len(closure) < 2:
+        return None
+    non_terminal = {k for k in jobs if k in depended_on}
+    if not non_terminal <= closure:
+        return None
+    _step_durs = [_num(_as_dict(s).get("dur_s"))
+                  for s in _as_list(_as_dict(timeline).get("steps"))]
+    _step_durs += [_num(_as_dict(s).get("p50_s")) for s in _as_list(pole.get("steps"))]
+    if any((d or 0.0) > _AGG_GATE_TRIVIAL_S for d in _step_durs):
+        return None  # it does substantive work of its own
+    # Resolve each upstream job to its measured check(s) IN THE SAME WORKFLOW — a
+    # cross-workflow same-name check is a different job entirely.
+    slowest: dict[str, Any] | None = None
+    unmeasured: list[str] = []
+    for j in sorted(closure):
+        meta = _as_dict(jobs.get(j))
+        nm = str(meta.get("name") or j)
+        matched = [_as_dict(c) for c in checks
+                   if str(_as_dict(c).get("workflow_file") or "") == wf
+                   and _agg_job_produces_check(nm, bool(meta.get("matrix")),
+                                               _check_name(_as_dict(c)))]
+        if not matched:
+            unmeasured.append(nm)
+            continue
+        top = max(matched, key=lambda c: _num(c.get("p50_s")) or 0.0)
+        if slowest is None or ((_num(top.get("p50_s")) or 0.0)
+                               > (_num(slowest.get("p50_s")) or 0.0)):
+            slowest = top
+    if slowest is None:
+        return None
+    return {"job_id": jid, "upstream": sorted(closure), "slowest": slowest,
+            "unmeasured": unmeasured,
+            "steps_known": bool(_as_list(_as_dict(timeline).get("steps"))
+                                or _as_list(pole.get("steps")))}
+
+
 # Wall-clock severity dot for a long-pole title, by the gate's measured P50 wait:
 # 🔴 >= 5m, 🟠 2-5m, 🟡 < 2m. Makes each finding's impact tier scannable in its title.
 _SEV_HIGH_S = 300.0
@@ -8248,6 +8383,20 @@ def render(doc: dict[str, Any], logs: dict[str, str] | None = None,
         head_s, bi_caveat = _pole_headline(p)
         dur = _clock(head_s)
         _raw_check = str(p.get("check", ""))
+        # AGGREGATION-GATE (success-sink) detection — issue #1, see `_agg_gate_shape`. Three
+        # deliberate carve-outs: a modal-chain MEMBER keeps the chain-stage framing (the chain
+        # rendering wins; never double-frame), and a pole carrying real measured content of its
+        # own — a matched log-detector leaf, or a structural lever routed to it — keeps today's
+        # rendering, because there the drill/prompt is NOT inert and suppressing it would
+        # silently drop a measured lever that renders nowhere else.
+        _agg_key = pole_owner_keys.get(id(p))
+        _agg = None
+        if (not (chain_active and _raw_check in set(_chain_modal))
+                and _pole_leaves[id(p)][1] is None
+                and not _structural_for_pole(p, all_findings)):
+            _agg = _agg_gate_shape(
+                p, doc.get("workflow_job_graph"), list(checks or src),
+                steps.get(_agg_key) if _agg_key is not None else None)
         if chain_active and _raw_check in set(_chain_modal):
             # ENG-1 PR-N2: a chain MEMBER must never carry the concurrent
             # framing — `needs:` serializes it; its time ADDS to the headline
@@ -8263,6 +8412,34 @@ def render(doc: dict[str, Any], logs: dict[str, str] | None = None,
                     "the chain wait in the headline rather than overlapping it; "
                     "time cut here helps until the next-longest competing path "
                     "gates instead.")))
+        elif _agg:
+            # AGGREGATION GATE (issue #1). Crowning it is correct — it really is the check
+            # most PRs gate on — but its wait is NOT its own: it is the `needs:` upstream it
+            # aggregates. Say that, name the slowest measured upstream member, and (below)
+            # render NO drill and NO "optimize this step" prompt for the sink itself.
+            _ag_slow = _clean_label(_check_name(_agg["slowest"]))
+            _ag_dur = _clock(_num(_agg["slowest"].get("p50_s")))
+            _ag_tail = ""
+            if _agg["unmeasured"]:
+                _ag_tail = (f" ({_count_noun(len(_agg['unmeasured']), 'upstream job')} had no "
+                            "measured check timing in this sample, so the slowest upstream "
+                            "member could be a heavier one.)")
+            elif not _agg["steps_known"]:
+                _ag_tail = (" (No per-step data was captured for this check; the shape is read "
+                            "from its `needs:` structure and its measured P50.)")
+            role = cs.add(claims.Claim(
+                kind="pole_role_line", subject=check,
+                fields={"dur": dur, "job_id": str(_agg["job_id"]),
+                        "upstream_n": len(_agg["upstream"]),
+                        "upstream_slowest": _ag_slow, "upstream_dur": _ag_dur},
+                rendered=_strip_emdashes(
+                    f"**Aggregation gate — it exists to be the single required check.** Its "
+                    f"job (`{_agg['job_id']}`) runs no work of its own ({dur}); it `needs:` "
+                    f"{_count_noun(len(_agg['upstream']), 'upstream job')} so one check can "
+                    f"stand for all of them. So its {dur} is not the wait — the wait IS that "
+                    f"`needs:` upstream, whose slowest measured member is `{_ag_slow}` "
+                    f"(~{_ag_dur}). That member, not this check, is the lever."
+                    + _ag_tail)))
         elif p is blocker:
             if not npop:
                 # Claims layer (pole_role_line): the blocker pole's role label.
@@ -8457,6 +8634,34 @@ def render(doc: dict[str, Any], logs: dict[str, str] | None = None,
             out += [_LEAF_CROWN_MARKER.format(fk=str(leaf.get("fix_key", ""))), ""]
         if bi_caveat:
             out += [bi_caveat, ""]
+        if _agg:
+            # AGGREGATION GATE (issue #1): the section ENDS at the honest pointer. No
+            # per-step drill and no "capture timing, then optimize this step" agent prompt
+            # for the sink itself — both are inert over a job that runs no work, and the
+            # prompt actively misdirects (there is nothing to speed, and moving it off the
+            # PR path defeats the single-required-check job it does). The `_floor_note`
+            # ("what a change here can buy") is skipped for the same reason: a change HERE
+            # buys nothing, which is exactly what the role line just said. The reader is
+            # pointed at the pole that drills the slowest upstream member, or told which
+            # check it is when it isn't among the rendered poles (never a dead link).
+            _ag_wf = str(_agg["slowest"].get("workflow_file") or p.get("workflow_file") or "")
+            _ag_pole_i = next(
+                (j for j, pw in enumerate(pole_wfs, 1)
+                 if _clean_label(str(pw.get("check", ""))) == _ag_slow
+                 and str(pw.get("workflow_file") or "") == _ag_wf), None)
+            if _ag_pole_i is not None:
+                out += [f"**➡️ Where the wait actually is:** [Long pole {_ag_pole_i}]"
+                        f"(#pole-{_ag_pole_i}) drills `{_ag_slow}` ({_ag_dur}) - the slowest "
+                        "measured member of this gate's `needs:` upstream. Attack it there; "
+                        "this check follows it down for free.", ""]
+            else:
+                out += [f"**➡️ Where the wait actually is:** `{_ag_slow}` ({_ag_dur}), the "
+                        "slowest measured member of this gate's `needs:` upstream. It is not "
+                        "among the long poles drilled in this report (it ranks below them, or "
+                        "its own job timing wasn't sampled), so there is no step-level drill "
+                        "for it here - a re-run that samples it will drill it. Attack it "
+                        "there; this check follows it down for free.", ""]
+            continue
         out += _floor_note(p, floor_pool)
         # A data-driven match is on-path only if ANY joined finding is NOT `spine_rare`; a match
         # made up solely of presence-demoted (opt-in/rare) findings is still coverage, but the

--- a/skills/ci-speedup/scripts/blocking_path.py
+++ b/skills/ci-speedup/scripts/blocking_path.py
@@ -8419,14 +8419,19 @@ def render(doc: dict[str, Any], logs: dict[str, str] | None = None,
             # render NO drill and NO "optimize this step" prompt for the sink itself.
             _ag_slow = _clean_label(_check_name(_agg["slowest"]))
             _ag_dur = _clock(_num(_agg["slowest"].get("p50_s")))
+            # BOTH caveats compose — they are independent, and neither may silently drop the
+            # other. "Runs no work of its own" rests on the measured P50 plus the `needs:`
+            # structure whenever no per-step data was captured, so that basis is disclosed on
+            # its own terms even when an unmeasured upstream member is ALSO disclosed (an
+            # `elif` hid the weaker basis exactly when the sample was thinnest — greptile P1).
             _ag_tail = ""
             if _agg["unmeasured"]:
-                _ag_tail = (f" ({_count_noun(len(_agg['unmeasured']), 'upstream job')} had no "
-                            "measured check timing in this sample, so the slowest upstream "
-                            "member could be a heavier one.)")
-            elif not _agg["steps_known"]:
-                _ag_tail = (" (No per-step data was captured for this check; the shape is read "
-                            "from its `needs:` structure and its measured P50.)")
+                _ag_tail += (f" ({_count_noun(len(_agg['unmeasured']), 'upstream job')} had no "
+                             "measured check timing in this sample, so the slowest upstream "
+                             "member could be a heavier one.)")
+            if not _agg["steps_known"]:
+                _ag_tail += (" (No per-step data was captured for this check; the shape is read "
+                             "from its `needs:` structure and its measured P50.)")
             role = cs.add(claims.Claim(
                 kind="pole_role_line", subject=check,
                 fields={"dur": dur, "job_id": str(_agg["job_id"]),
@@ -8644,10 +8649,17 @@ def render(doc: dict[str, Any], logs: dict[str, str] | None = None,
             # buys nothing, which is exactly what the role line just said. The reader is
             # pointed at the pole that drills the slowest upstream member, or told which
             # check it is when it isn't among the rendered poles (never a dead link).
+            # IDENTITY, not presentation: the pole this links to is matched on the RAW check
+            # name + workflow file — the same (name, file) identity the spine carries. Matching
+            # on the CLEANED display label instead would fold two distinct checks whose labels
+            # normalize together (`@scope/lint` and `lint` both clean to `lint`) and link the
+            # gate's pointer at an unrelated pole's drill (greptile P2; the #13 name-join
+            # lesson). `_ag_slow` stays the DISPLAY label only.
             _ag_wf = str(_agg["slowest"].get("workflow_file") or p.get("workflow_file") or "")
+            _ag_raw = _check_name(_agg["slowest"])
             _ag_pole_i = next(
                 (j for j, pw in enumerate(pole_wfs, 1)
-                 if _clean_label(str(pw.get("check", ""))) == _ag_slow
+                 if _check_name(pw) == _ag_raw
                  and str(pw.get("workflow_file") or "") == _ag_wf), None)
             if _ag_pole_i is not None:
                 out += [f"**➡️ Where the wait actually is:** [Long pole {_ag_pole_i}]"

--- a/skills/ci-speedup/tests/test_blocking_path.py
+++ b/skills/ci-speedup/tests/test_blocking_path.py
@@ -6906,3 +6906,30 @@ def test_agg_gate_shape_structural_conditions():
                                if c["workflow_file"] != _AGG_DEPLOY]) is None
     # No scanned graph for the workflow → the shape is unknowable, never guessed.
     assert bp._agg_gate_shape(poles["thank you, build"], {}, checks) is None
+
+
+def test_aggregation_gate_discloses_both_thin_data_caveats():
+    # Both caveats are independent and BOTH must render: an unmeasured upstream member (the
+    # named "slowest" could be beaten by one with no timing) AND the absence of per-step data
+    # (which is what "runs no work of its own" rests on, together with the measured P50). An
+    # `elif` dropped the second exactly when the sample was thinnest.
+    md = bp.render(_agg_gate_doc(), {}, {}, {}, "2026-07-28T00:00:00Z", {})
+    sec = _pole_section(md, "thank you, build")
+    assert "had no measured check timing in this sample" in sec
+    assert "No per-step data was captured for this check" in sec
+
+
+def test_aggregation_gate_pointer_links_the_upstream_members_own_pole():
+    # When the slowest upstream member IS itself a rendered pole, the pointer links to THAT
+    # pole's anchor — matched on the raw check name + workflow file (the spine's identity),
+    # never on the cleaned display label, which can fold two distinct checks together.
+    doc = _agg_gate_doc()
+    doc["pr_critical_path"]["poles"].append(
+        {"check": "stable - x86_64-linux", "p50_s": 355.0, "workflow_file": _AGG_DEPLOY,
+         "job": "native", "dominant_step": "cargo build", "dominant_p50_s": 300.0,
+         "steps": [{"step": "cargo build", "category": "build", "p50_s": 300.0}]})
+    md = bp.render(doc, {}, {}, {}, "2026-07-28T00:00:00Z", {})
+    sec = _pole_section(md, "thank you, build")
+    n = int(re.search(r"## .*Long pole (\d+): .*▸ `stable - x86_64-linux`", md).group(1))
+    assert f"**➡️ Where the wait actually is:** [Long pole {n}](#pole-{n}) drills " \
+           f"`stable - x86_64-linux` (5m 55s)" in sec

--- a/skills/ci-speedup/tests/test_blocking_path.py
+++ b/skills/ci-speedup/tests/test_blocking_path.py
@@ -6725,3 +6725,184 @@ def test_single_backtick_name_stays_symmetric_between_heading_and_verifier():
     assert bp._clean_label("run `unit` tests") == "run 'unit' tests"
     assert bp._clean_label("x ``y`` z") == "x ''y'' z"
     assert bp._clean_label("guard shard 2/4") == "guard shard 2/4"
+
+
+# ── Aggregation-gate poles (issue #1) ─────────────────────────────────────────────────
+# A success-aggregation gate is the trivial job that exists ONLY to `needs:` a set of real
+# jobs so ONE check can be the single required status check (vercel/next.js `thank you,
+# build`: job `buildPassed`, `needs: [deploy-target, build, build-wasm, build-native]`, body
+# `run: exit 1`, P50 3s, required). Crowning it by frequency is CORRECT data; drilling it and
+# prompting "capture timing, then optimize this step" is inert advice over a 3-second no-op.
+# The renderer must instead tell the honest upstream story and point at the slowest member.
+
+_AGG_DEPLOY = ".github/workflows/deploy.yml"
+_AGG_CI = ".github/workflows/ci.yml"
+
+
+def _agg_gate_doc() -> dict:
+    """Two workflows. `deploy.yml` carries the SINK (`thank you, build`, 3s, terminal, its
+    transitive `needs:` covering every non-terminal job) plus a conditional peer sink
+    (`Potentially publish release`, terminal and uncovered — the `publishRelease` shape).
+    `ci.yml` carries the near-miss: a real 3s `lint` job that `needs:` nothing."""
+    return {
+        "repo": "acme/site", "repo_visibility": "public",
+        "scanned_at": "2026-07-28T00:00:00Z", "commit_sha": "09e8243",
+        "skill_commit_sha": "dd51d85", "findings": [],
+        "data_sources": {"runs_sampled": 20, "jobs_sampled": 60, "workflows_analyzed": 2},
+        "workflow_job_graph": {
+            _AGG_DEPLOY: {
+                "target": {"name": "deploy-target", "needs": []},
+                "build": {"name": "build", "needs": ["target"]},
+                "matrixgen": {"name": "generate-native-matrix", "needs": ["target"]},
+                "native": {"name": "stable - ${{ matrix.target }}", "matrix": True,
+                           "needs": ["target", "matrixgen"]},
+                "publish": {"name": "Potentially publish release",
+                            "needs": ["target", "build", "native"]},
+                "gate": {"name": "thank you, build", "needs": ["target", "build", "native"]},
+            },
+            _AGG_CI: {
+                "lint": {"name": "lint", "needs": []},
+                "unit": {"name": "unit", "needs": []},
+            },
+        },
+        "pr_critical_path": {
+            "sampled_pr_count": 20, "sample_target": 20, "sample_complete": True,
+            "check_present_n_pr": 20, "critical_path_check": "unit",
+            "poles": [
+                {"check": "unit", "p50_s": 600.0, "workflow_file": _AGG_CI, "job": "unit",
+                 "dominant_step": "Run tests", "dominant_p50_s": 480.0,
+                 "steps": [{"step": "Checkout", "category": "setup", "p50_s": 20.0},
+                           {"step": "Run tests", "category": "test", "p50_s": 480.0}]},
+                {"check": "thank you, build", "p50_s": 3.0, "workflow_file": _AGG_DEPLOY,
+                 "job": "gate", "timing_source": "pr_check_runs", "steps": []},
+                {"check": "lint", "p50_s": 3.0, "workflow_file": _AGG_CI, "job": "lint",
+                 "dominant_step": "Run eslint", "dominant_p50_s": 2.0,
+                 "steps": [{"step": "Run eslint", "category": "lint", "p50_s": 2.0}]},
+            ],
+            "checks": [
+                {"name": "unit", "p50_s": 600.0, "present_on": 20, "workflow_file": _AGG_CI},
+                {"name": "stable - x86_64-linux", "p50_s": 355.0, "present_on": 20,
+                 "workflow_file": _AGG_DEPLOY},
+                {"name": "build", "p50_s": 240.0, "present_on": 20,
+                 "workflow_file": _AGG_DEPLOY},
+                {"name": "deploy-target", "p50_s": 19.0, "present_on": 20,
+                 "workflow_file": _AGG_DEPLOY},
+                {"name": "thank you, build", "p50_s": 3.0, "present_on": 20,
+                 "workflow_file": _AGG_DEPLOY},
+                {"name": "lint", "p50_s": 3.0, "present_on": 20, "workflow_file": _AGG_CI},
+            ],
+            "populations": [],
+        },
+    }
+
+
+def _pole_section(md: str, check: str) -> str:
+    """The `## … Long pole N: … ▸ <check>` section body for `check`."""
+    i = md.index(f"▸ `{check}`")
+    i = md.rindex("\n## ", 0, i)
+    j = md.find("\n## ", i + 4)
+    return md[i:j if j != -1 else len(md)]
+
+
+def test_aggregation_gate_pole_tells_the_upstream_story_not_a_prompt():
+    # The whole fix (issue #1): the `needs:`-everything 3s sink renders the honest role line,
+    # names its slowest MEASURED upstream member, points the reader there — and carries NO
+    # drill and NO "optimize this step" agent prompt.
+    md = bp.render(_agg_gate_doc(), {}, {}, {}, "2026-07-28T00:00:00Z", {})
+    sec = _pole_section(md, "thank you, build")
+    assert "**Aggregation gate" in sec
+    assert "it exists to be the single required check" in sec
+    assert "runs no work of its own" in sec
+    # The slowest upstream is the matrix leg (355s), resolved through the `${{ }}` name
+    # template — not the sink's own 3s and not the unrelated `unit` pole in the other workflow.
+    assert "`stable - x86_64-linux` (~5m 55s)" in sec
+    assert "**➡️ Where the wait actually is:**" in sec
+    # The two inert artifacts are gone.
+    assert "🤖 Prompt for your coding agent" not in sec
+    assert "Level 2" not in sec
+    assert "before optimizing" not in sec
+    # The OTHER poles are untouched — each still drills and hands off.
+    assert "🤖 Prompt for your coding agent" in _pole_section(md, "unit")
+
+
+def test_aggregation_gate_pole_role_line_is_a_registered_claim():
+    # Claims parity: the role line is a `pole_role_line` Claim whose rendered sentence appears
+    # verbatim in the report, exactly like its neighbouring role lines.
+    md = bp.render(_agg_gate_doc(), {}, {}, {}, "2026-07-28T00:00:00Z", {})
+    cs = bp._LAST_CLAIMS
+    agg = [c for c in cs.claims
+           if c.kind == "pole_role_line" and "Aggregation gate" in c.rendered]
+    assert len(agg) == 1
+    assert agg[0].subject == "thank you, build"
+    assert agg[0].fields["upstream_slowest"] == "stable - x86_64-linux"
+    for c in cs.claims:
+        assert c.rendered in md, f"claim not byte-identical in the report: {c.rendered!r}"
+
+
+def test_aggregation_gate_near_miss_renders_byte_identically(monkeypatch):
+    # A real 3s `lint` job with NO `needs:` coverage must keep today's rendering exactly —
+    # duration alone never triggers the framing. Pinned byte-for-byte against the renderer
+    # with detection disabled (the pre-fix behaviour).
+    doc = _agg_gate_doc()
+    after = _pole_section(bp.render(doc, {}, {}, {}, "2026-07-28T00:00:00Z", {}), "lint")
+    monkeypatch.setattr(bp, "_agg_gate_shape", lambda *a, **k: None)
+    before = _pole_section(bp.render(doc, {}, {}, {}, "2026-07-28T00:00:00Z", {}), "lint")
+    assert after == before
+    assert "**Aggregation gate" not in after
+    assert "🤖 Prompt for your coding agent" in after
+
+
+def test_aggregation_gate_yields_to_the_chain_member_framing(monkeypatch):
+    # A sink that IS a modal-chain member keeps the chain-stage rendering (`thank you, next`
+    # as stage 3/3): the chain model already frames it as serialized, and double-framing it
+    # would contradict that. Pinned byte-for-byte against detection-disabled rendering.
+    doc = _agg_gate_doc()
+    doc["pr_critical_path"]["chain_summary"] = {
+        "modal_chain": ["build", "stable - x86_64-linux", "thank you, build"],
+        "chain_p50_s": 598.0}
+    after = _pole_section(bp.render(doc, {}, {}, {}, "2026-07-28T00:00:00Z", {}),
+                          "thank you, build")
+    monkeypatch.setattr(bp, "_agg_gate_shape", lambda *a, **k: None)
+    before = _pole_section(bp.render(doc, {}, {}, {}, "2026-07-28T00:00:00Z", {}),
+                           "thank you, build")
+    assert after == before
+    assert "Stage 3/3 of the" in after and "gate chain" in after
+    assert "**Aggregation gate" not in after
+
+
+def test_agg_gate_shape_structural_conditions():
+    # The shape helper itself: each condition is load-bearing.
+    doc = _agg_gate_doc()
+    graph = doc["workflow_job_graph"]
+    checks = doc["pr_critical_path"]["checks"]
+    poles = {p["check"]: p for p in doc["pr_critical_path"]["poles"]}
+    hit = bp._agg_gate_shape(poles["thank you, build"], graph, checks)
+    assert hit and hit["job_id"] == "gate"
+    # The closure walks TRANSITIVELY: `matrixgen` is reached via `native`, so the
+    # conditional peer sink `publish` is the only uncovered job — and it is terminal.
+    assert hit["upstream"] == ["build", "matrixgen", "native", "target"]
+    assert bp._clean_label(bp._check_name(hit["slowest"])) == "stable - x86_64-linux"
+    # (a) duration: a job doing real work never matches on structure alone.
+    heavy = dict(poles["thank you, build"], p50_s=180.0)
+    assert bp._agg_gate_shape(heavy, graph, checks) is None
+    # (b) coverage: a non-terminal job outside the closure → not an aggregation sink.
+    gapped = json.loads(json.dumps(graph))
+    gapped[_AGG_DEPLOY]["extra"] = {"name": "extra", "needs": ["target"]}
+    gapped[_AGG_DEPLOY]["afterextra"] = {"name": "afterextra", "needs": ["extra"]}
+    assert bp._agg_gate_shape(poles["thank you, build"], gapped, checks) is None
+    # (b) a single-parent stage (a chain member's shape) needs >= 2 upstream jobs.
+    thin = json.loads(json.dumps(graph))
+    thin[_AGG_DEPLOY]["gate"]["needs"] = ["build"]
+    assert bp._agg_gate_shape(poles["thank you, build"], thin, checks) is None
+    # (b) the near-miss lint job: trivial, but `needs:` nothing.
+    assert bp._agg_gate_shape(poles["lint"], graph, checks) is None
+    # (c) step data DISQUALIFIES when it shows real work.
+    busy = dict(poles["thank you, build"],
+                steps=[{"step": "Run the suite", "p50_s": 400.0}])
+    assert bp._agg_gate_shape(busy, graph, checks) is None
+    # (d) no measured upstream check → nothing honest to point at.
+    assert bp._agg_gate_shape(poles["thank you, build"], graph,
+                              [c for c in checks
+                               if c["workflow_file"] != _AGG_DEPLOY]) is None
+    # No scanned graph for the workflow → the shape is unknowable, never guessed.
+    assert bp._agg_gate_shape(poles["thank you, build"], {}, checks) is None

--- a/skills/ci-speedup/tests/test_verify_report_self.py
+++ b/skills/ci-speedup/tests/test_verify_report_self.py
@@ -114,7 +114,15 @@ def test_phase0_literals_stay_coupled_to_the_renderer():
                     # permanent no-op (it fires only on a rare gap-fill pole), so pin both fragments —
                     # the em-dash-free "verbatim from the captured job log" is the contiguous one.
                     "🤖 LLM root-cause analysis",
-                    "verbatim from the captured job log"):
+                    "verbatim from the captured job log",
+                    # The aggregation-gate role line + upstream pointer (issue #1).
+                    # `check_aggregation_gate_poles_never_prescribe` finds such a pole by the role
+                    # marker and asserts the pointer is present; `check_speed_poles_complete`
+                    # exempts it from the prompt requirement on the same marker. A renderer reword
+                    # would silently drop BOTH — the exemption (false FAIL on a correct report)
+                    # and the invariant (a permanent no-op).
+                    "**Aggregation gate",
+                    "**➡️ Where the wait actually is:**"):
         assert literal in renderer, f"renderer no longer emits {literal!r} — update verify_report"
         assert literal in verifier, f"verify_report lost the {literal!r} coupling literal"
 
@@ -1159,6 +1167,122 @@ def test_poles_complete_fails_on_external_check_misbound_to_a_file(tmp_path: Pat
             {"check": "Redirect rules - tokio-rs", "workflow_file": _ci, "job": "wasm32-wasip1",
              "timing_source": "pr_check_runs", "p50_s": 22.0}]}}
     assert _tag_for(_good(), _POLES, tmp_path, findings=findings) == "FAIL"
+
+
+# ── Aggregation-gate poles (issue #1) ────────────────────────────────────────────────────
+# A `needs:`-everything success sink (next.js `thank you, build`: 3s, `run: exit 1`) renders
+# the honest upstream story INSTEAD of a drill + "optimize this step" prompt. Two coupled
+# guards: `check_speed_poles_complete` must EXEMPT such a pole from its prompt requirement,
+# and `check_aggregation_gate_poles_never_prescribe` must FAIL any aggregation-framed pole
+# that carries a prompt, lacks the upstream pointer, or isn't re-derivable from the findings.
+_AGG_GATE = "aggregation-gate poles"
+_AGG_WF = ".github/workflows/deploy.yml"
+_AGG_FINDINGS = {
+    "workflow_job_graph": {_AGG_WF: {
+        "target": {"name": "target", "needs": []},
+        "build": {"name": "build", "needs": ["target"]},
+        # A conditional PEER sink (uncovered by the gate's needs, but itself terminal) —
+        # the `publishRelease` shape the "effectively all" rule must tolerate.
+        "publish": {"name": "Potentially publish release", "needs": ["target", "build"]},
+        "gate": {"name": "thank you, build", "needs": ["target", "build"]}}},
+    "pr_critical_path": {"poles": [
+        {"check": "thank you, build", "workflow_file": _AGG_WF, "job": "gate",
+         "p50_s": 3.0, "timing_source": "pr_check_runs"}],
+        "checks": [{"name": "build", "workflow_file": _AGG_WF, "p50_s": 355.0},
+                   {"name": "target", "workflow_file": _AGG_WF, "p50_s": 19.0},
+                   {"name": "thank you, build", "workflow_file": _AGG_WF, "p50_s": 3.0}]}}
+
+
+def _agg_report(*, prompt: bool = False, pointer: bool = True, framed: bool = True) -> str:
+    """The `_good()` report with its pole rewritten as an aggregation-gate pole."""
+    role = ("**Aggregation gate - it exists to be the single required check.** Its job "
+            "(`gate`) runs no work of its own (3s); it `needs:` 2 upstream jobs so one check "
+            "can stand for all of them. So its 3s is not the wait - the wait IS that `needs:` "
+            "upstream, whose slowest measured member is `build` (~5m 55s). That member, not "
+            "this check, is the lever."
+            if framed else "**The check most PRs gate on.**")
+    body = [f"## Long pole 1: `deploy.yml` ▸ thank you, build - 3s", "", role, ""]
+    if pointer:
+        body += ["**➡️ Where the wait actually is:** `build` (5m 55s), the slowest measured "
+                 "member of this gate's `needs:` upstream.", ""]
+    if prompt:
+        body += ["#### 🤖 Prompt for your coding agent", "", "```text",
+                 "ci-speedup measured the root cause below but does NOT prescribe the fix -",
+                 "capture timing, then optimize the dominant step.", "```", ""]
+    old = _good().split("## Long pole 1:", 1)[1].split("## 🗄️ Data sources", 1)[0]
+    return _good().replace("## Long pole 1:" + old, "\n".join(body) + "\n")
+
+
+def test_aggregation_gate_pole_ships_without_a_prompt(tmp_path: Path):
+    # GREEN both ways: the honest render passes the new invariant AND is exempted from the
+    # "every pole carries a prompt" rule (which FAILs it without the exemption — the
+    # pre-fix behaviour this test pins).
+    rep = _agg_report()
+    assert _tag_for(rep, _AGG_GATE, tmp_path, findings=_AGG_FINDINGS) == "PASS"
+    assert _tag_for(rep, _POLES, tmp_path, findings=_AGG_FINDINGS) == "PASS"
+    # The exemption is findings-gated, not framing-gated: with NO findings to re-derive the
+    # shape from, the promptless pole is still a bare pole and FAILs.
+    assert _tag_for(rep, _POLES, tmp_path) == "FAIL"
+
+
+def test_aggregation_gate_pole_with_an_optimize_prompt_fails(tmp_path: Path):
+    # RED: the exact defect from issue #1 — a `needs:`-everything 3s sink handed an
+    # "optimize this step" agent prompt.
+    assert _tag_for(_agg_report(prompt=True), _AGG_GATE, tmp_path,
+                    findings=_AGG_FINDINGS) == "FAIL"
+
+
+def test_aggregation_framing_without_the_pointer_fails(tmp_path: Path):
+    # RED: framing with no upstream pointer is a dead end — the reader is told the lever is
+    # elsewhere and never told where.
+    assert _tag_for(_agg_report(pointer=False), _AGG_GATE, tmp_path,
+                    findings=_AGG_FINDINGS) == "FAIL"
+
+
+def test_aggregation_framing_unsupported_by_the_job_graph_fails(tmp_path: Path):
+    # RED: the framing may never be applied to a pole that isn't structurally a sink. Here the
+    # gate `needs:` nothing, so the shape doesn't re-derive from the job graph.
+    bad = copy.deepcopy(_AGG_FINDINGS)
+    bad["workflow_job_graph"][_AGG_WF]["gate"]["needs"] = []
+    assert _tag_for(_agg_report(), _AGG_GATE, tmp_path, findings=bad) == "FAIL"
+
+
+def test_aggregation_check_skips_when_no_pole_is_framed(tmp_path: Path):
+    # A report with no aggregation-gate pole neither passes nor fails on this axis.
+    assert _tag_for(_agg_report(framed=True, prompt=False).replace(
+        "**Aggregation gate", "**The check most PRs gate on."), _AGG_GATE, tmp_path,
+        findings=_AGG_FINDINGS) == "SKIP"
+
+
+def test_agg_gate_pole_keys_rederives_the_shape(tmp_path: Path):
+    # Unit-level: the verifier's re-derivation mirrors `blocking_path._agg_gate_shape` —
+    # trivial P50 + terminal sink covering every non-terminal job + a measured upstream.
+    vr = _load_verify_report()
+
+    def _keys(doc: dict):
+        fp = tmp_path / "f.json"
+        fp.write_text(json.dumps(doc), encoding="utf-8")
+        return vr._agg_gate_pole_keys(fp)
+
+    assert _keys(_AGG_FINDINGS) == {("deploy.yml", vr._cmp_name("thank you, build"))}
+    # Not trivial (a 3-minute job does real work) → no match on duration alone.
+    heavy = copy.deepcopy(_AGG_FINDINGS)
+    heavy["pr_critical_path"]["poles"][0]["p50_s"] = 180.0
+    assert _keys(heavy) == set()
+    # A trivial job that `needs:` nothing (the 3s-lint near miss) → no match.
+    lint = copy.deepcopy(_AGG_FINDINGS)
+    lint["workflow_job_graph"][_AGG_WF]["gate"]["needs"] = []
+    assert _keys(lint) == set()
+    # Coverage gap: a non-terminal job outside the closure → not an aggregation sink.
+    gap = copy.deepcopy(_AGG_FINDINGS)
+    gap["workflow_job_graph"][_AGG_WF]["extra"] = {"name": "extra", "needs": ["target"]}
+    gap["workflow_job_graph"][_AGG_WF]["after"] = {"name": "after", "needs": ["extra"]}
+    assert _keys(gap) == set()
+    # No measured upstream check → nothing honest to point at → no match.
+    unmeasured = copy.deepcopy(_AGG_FINDINGS)
+    unmeasured["pr_critical_path"]["checks"] = [
+        {"name": "thank you, build", "workflow_file": _AGG_WF, "p50_s": 3.0}]
+    assert _keys(unmeasured) == set()
 
 
 def test_vr_produces_check_mirrors_engine_degenerate_rule():

--- a/skills/ci-speedup/tests/verify_report.py
+++ b/skills/ci-speedup/tests/verify_report.py
@@ -1520,6 +1520,135 @@ def _external_check_misbound_offenders(findings_path: Path | None) -> list[str] 
 # `test_phase0_literals_stay_coupled_to_the_renderer` so a reword breaks both sides in lockstep.)
 _NO_PER_STEP_DRILL = "No per-step breakdown was captured"
 
+# ── Aggregation-gate poles (issue #1) ────────────────────────────────────────────────────
+# A success-aggregation gate is the trivial job that exists ONLY to `needs:` a set of real
+# jobs so one check can be the single required status check (next.js' `thank you, build`:
+# job `buildPassed`, `needs: [deploy-target, build, build-wasm, build-native]`, P50 3s).
+# `blocking_path._agg_gate_shape` detects that shape and renders the honest upstream story
+# INSTEAD of a drill + "optimize this step" prompt — so such a pole legitimately carries no
+# agent prompt, and `check_speed_poles_complete`'s prompt requirement must not false-FAIL it.
+# The exemption is NOT taken on the report's word: the shape is RE-DERIVED from findings.json
+# (`workflow_job_graph` + `pr_critical_path`), and the rendered section must also show the
+# renderer's aggregation framing — findings-derived structure AND honest rendering, both.
+# The paired invariant lives in `check_aggregation_gate_poles_never_prescribe`.
+# (Literals pinned to the renderer by `test_phase0_literals_stay_coupled_to_the_renderer`.)
+_AGG_GATE_ROLE_MARKER = "**Aggregation gate"
+_AGG_GATE_POINTER_MARKER = "**➡️ Where the wait actually is:**"
+_VR_AGG_GATE_TRIVIAL_S = 30.0
+
+
+def _agg_gate_pole_keys(findings_path: Path | None) -> set[tuple[str, str]]:
+    """`{(wf_base, _cmp_name(check))}` for every `pr_critical_path.poles[*]` matching the
+    aggregation-gate shape, re-derived from findings.json alone — mirroring
+    `blocking_path._agg_gate_shape` (a) trivial P50, (b) terminal job whose transitive
+    `needs:` closure (>= 2 jobs) covers every non-terminal job in its workflow, (c) no
+    sampled step above the trivial threshold, (d) >= 1 upstream member with a measured check.
+
+    Deliberately re-derived (never read off the rendered report): the render is what this
+    guard is auditing. The renderer's additional carve-outs (a modal-chain member, or a pole
+    that matched a log detector / carries a routed structural lever) can only make the
+    renderer render MORE than this set — and those poles all carry a prompt, so they never
+    reach the exemption's `bare` list anyway."""
+    if not findings_path:
+        return set()
+    data, err = _load_findings_doc(findings_path)
+    if err:
+        return set()
+    graph = _as_dict(data.get("workflow_job_graph"))
+    cp = _as_dict(data.get("pr_critical_path"))
+    checks = [_as_dict(c) for c in _as_list(cp.get("checks"))]
+    out: set[tuple[str, str]] = set()
+    for pole in _as_list(cp.get("poles")):
+        pole = _as_dict(pole)
+        if (_num(pole.get("p50_s")) or 0.0) > _VR_AGG_GATE_TRIVIAL_S:
+            continue
+        wf = str(pole.get("workflow_file") or "")
+        jobs = _as_dict(graph.get(wf))
+        if not jobs:
+            continue
+        check = str(pole.get("check") or "")
+        jid = str(pole.get("job") or "")
+        if jid not in jobs:
+            cands = [k for k, meta in jobs.items()
+                     if _vr_job_produces_check(str(_as_dict(meta).get("name") or k),
+                                               bool(_as_dict(meta).get("matrix")), check)]
+            if len(cands) != 1:
+                continue
+            jid = cands[0]
+        needs_of = {k: [str(n) for n in _as_list(_as_dict(m).get("needs"))]
+                    for k, m in jobs.items()}
+        depended_on = {n for ns in needs_of.values() for n in ns}
+        if jid in depended_on:
+            continue
+        closure: set[str] = set()
+        frontier = list(needs_of.get(jid) or [])
+        while frontier:
+            n = frontier.pop()
+            if n in closure or n not in jobs:
+                continue
+            closure.add(n)
+            frontier.extend(needs_of.get(n) or [])
+        if len(closure) < 2 or not {k for k in jobs if k in depended_on} <= closure:
+            continue
+        if any((_num(_as_dict(s).get("p50_s")) or 0.0) > _VR_AGG_GATE_TRIVIAL_S
+               for s in _as_list(pole.get("steps"))):
+            continue
+        measured = any(
+            str(c.get("workflow_file") or "") == wf
+            and _vr_job_produces_check(
+                str(_as_dict(jobs.get(j)).get("name") or j),
+                bool(_as_dict(jobs.get(j)).get("matrix")),
+                str(c.get("name") or c.get("check") or ""))
+            for j in closure for c in checks)
+        if measured:
+            out.add((_wf_base(wf), _cmp_name(check)))
+    return out
+
+
+def check_aggregation_gate_poles_never_prescribe(
+        report: str, findings_path: Path | None) -> Check:
+    """An aggregation-gate pole must render the honest upstream story and NOTHING that tells
+    the reader to optimize a job that runs no work (issue #1).
+
+    Two directions, both re-derived from findings.json (`_agg_gate_pole_keys`):
+
+    - A pole rendered with the aggregation framing must genuinely BE one structurally, and
+      must carry the "where the wait actually is" pointer at the slowest upstream member —
+      framing without the structure, or without the pointer, is a dead end.
+    - A pole rendered with the aggregation framing must carry NO `🤖 Prompt for your coding
+      agent`: that prompt asks the reader to capture timing and speed up a 3-second no-op,
+      which is exactly the inert advice this shape exists to suppress. (The complementary
+      exemption in `check_speed_poles_complete` lets such a pole ship without a prompt; this
+      is the invariant that keeps the exemption from being a hole.)"""
+    name = "aggregation-gate poles tell the upstream story, never an optimize-this prompt"
+    framed = [(wf, check, body) for wf, check, body in _pole_header_sections(report)
+              if _AGG_GATE_ROLE_MARKER in body]
+    if not framed:
+        return Check(name, True, "no aggregation-gate pole rendered", skipped=True)
+    keys = _agg_gate_pole_keys(findings_path)
+    if findings_path and not keys:
+        return Check(name, False,
+                     f"{len(framed)} pole(s) render the aggregation-gate framing, but findings.json "
+                     "supports NO pole of that shape (re-derived from workflow_job_graph + "
+                     "pr_critical_path) - the framing must never be applied to a pole that isn't "
+                     "structurally a `needs:`-everything success sink")
+    bad: list[str] = []
+    for wf, check, body in framed:
+        where = f"`{wf}` ▸ {check}"
+        if findings_path and (_wf_base(wf), _cmp_name(check)) not in keys:
+            bad.append(f"{where}: framed as an aggregation gate but findings don't re-derive "
+                       "that shape for it")
+        if "Prompt for your coding agent" in body:
+            bad.append(f"{where}: carries an agent prompt over a job that runs no work - "
+                       "the sink must point at its slowest upstream member instead")
+        if _AGG_GATE_POINTER_MARKER not in body:
+            bad.append(f"{where}: no upstream pointer - the reader is left with a role line "
+                       "and nowhere to go")
+    if bad:
+        return Check(name, False, "; ".join(bad[:4]))
+    return Check(name, True, f"{len(framed)} aggregation-gate pole(s): each re-derives from the "
+                 "job graph, points at its slowest upstream member, and prescribes nothing")
+
 
 def check_speed_poles_complete(report: str, findings_path: Path | None) -> Check:
     """The report must drill one fully-formed long pole per independent gating check
@@ -1648,8 +1777,20 @@ def check_speed_poles_complete(report: str, findings_path: Path | None) -> Check
         return Check(name, False, f"long pole(s) {stunted} carry NO per-step breakdown - a "
                      "bare/stunted pole (a timeline with no drill, per SKILL.md 5a), not the "
                      "same drill as pole 1 (it hands off a prompt over an empty drill)")
+    # AGGREGATION-GATE exemption (issue #1). A pole whose job exists only to `needs:` the
+    # rest of its workflow (a 3s success sink) renders the honest upstream story INSTEAD of a
+    # drill + prompt — a prompt there would tell the reader to speed up a job that runs no
+    # work. Exempt ONLY when the shape re-derives from findings.json AND the section actually
+    # carries the renderer's aggregation framing; `check_aggregation_gate_poles_never_prescribe`
+    # holds the other half (such a pole must carry the upstream pointer and no prompt), so the
+    # exemption can't launder a genuinely stunted pole.
+    _agg_keys = _agg_gate_pole_keys(findings_path)
+    _agg_exempt = {i for i, (wf, check, body)
+                   in enumerate(_pole_header_sections(report), 1)
+                   if _AGG_GATE_ROLE_MARKER in body
+                   and (_wf_base(wf), _cmp_name(check)) in _agg_keys}
     bare = [i + 1 for i, s in enumerate(sections)
-            if "Prompt for your coding agent" not in s]
+            if "Prompt for your coding agent" not in s and (i + 1) not in _agg_exempt]
     if bare:
         return Check(name, False, f"long pole(s) {bare} lack an agent prompt - a bare/"
                      "stunted pole, not the same drill as pole 1")
@@ -7537,6 +7678,7 @@ def run_checks(report, report_path, findings_path, skill_repo, clone=None):
         check_rendered_patterns_exist(report, findings_path),
         check_data_driven_have_signal(findings_path),
         check_speed_poles_complete(report, findings_path),
+        check_aggregation_gate_poles_never_prescribe(report, findings_path),
         check_pole_drill_belongs_to_its_job(report, findings_path),
         check_gap_fill_evidence_grounded(report, findings_path),
         check_dropped_check_not_framed_on_path(report, findings_path),

--- a/skills/ci-speedup/tests/verify_report.py
+++ b/skills/ci-speedup/tests/verify_report.py
@@ -1784,13 +1784,17 @@ def check_speed_poles_complete(report: str, findings_path: Path | None) -> Check
     # carries the renderer's aggregation framing; `check_aggregation_gate_poles_never_prescribe`
     # holds the other half (such a pole must carry the upstream pointer and no prompt), so the
     # exemption can't launder a genuinely stunted pole.
+    # Keyed by the section BODY, never by ordinal: `_pole_sections` and `_pole_header_sections`
+    # split on the same header line and so yield byte-identical bodies, but their header
+    # patterns differ (the latter also requires the `` `wf` ▸ check `` shape) — a header that
+    # ever fails the stricter pattern would shift the ordinals and move the exemption onto a
+    # DIFFERENT pole. Matching on bodies cannot drift that way.
     _agg_keys = _agg_gate_pole_keys(findings_path)
-    _agg_exempt = {i for i, (wf, check, body)
-                   in enumerate(_pole_header_sections(report), 1)
-                   if _AGG_GATE_ROLE_MARKER in body
-                   and (_wf_base(wf), _cmp_name(check)) in _agg_keys}
+    _agg_exempt_bodies = {body for wf, check, body in _pole_header_sections(report)
+                          if _AGG_GATE_ROLE_MARKER in body
+                          and (_wf_base(wf), _cmp_name(check)) in _agg_keys}
     bare = [i + 1 for i, s in enumerate(sections)
-            if "Prompt for your coding agent" not in s and (i + 1) not in _agg_exempt]
+            if "Prompt for your coding agent" not in s and s not in _agg_exempt_bodies]
     if bare:
         return Check(name, False, f"long pole(s) {bare} lack an agent prompt - a bare/"
                      "stunted pole, not the same drill as pole 1")


### PR DESCRIPTION
## Root cause

Many repos make one trivial job the **single required status check**: it runs no work, `needs:` everything else in its workflow, and exists only so branch protection has one name to require. On vercel/next.js that is `thank you, build` — job `buildPassed`, `needs: [deploy-target, build, build-wasm, build-native]`, body `run: exit 1` behind an `if:`, **P50 3s**, required.

Because it gates every PR it is **correctly crowned Long pole 1 by frequency** (the data is right). The generic pole renderer then attached a drill placeholder and a 🤖 agent prompt telling the reader to "capture timing … before optimizing" a 3-second no-op. Correct data, **inert advice**, on the very first thing a next.js-shaped reader sees. Verify passed 0 FAILs on that report, so nothing caught it.

The original instance (`thank you, next`) is now absorbed by the chain model (stage 3/3); the live gap was a sink living in a *different* workflow than the modeled chain.

## The shape (and its thresholds)

`blocking_path._agg_gate_shape` detects it at render time from data the artifact **already stamps** (`workflow_job_graph` + the check spine) — no producer change, so producer/renderer/verifier stay consistent. All of:

- **(a) trivial** — headline P50 <= `_AGG_GATE_TRIVIAL_S` = **30s**. Justified in a comment: a hosted-runner job that does any real work clears checkout + toolchain setup well past 30s. Duration alone never matches.
- **(b) terminal sink covering its workflow** — the pole's job is a *terminal* node (nothing `needs:` it) whose **transitive** `needs:` closure (>= 2 jobs) contains **every non-terminal job** in its workflow. Uncovered siblings must themselves be terminal — exactly the shape of an `if:`-conditional peer sink (`publishRelease`, `deploy-tarball`), so "effectively all the other jobs" is expressed *structurally* rather than by reading `if:` (which the scanned graph does not carry).
- **(c) no substantive work of its own** — step data is a **disqualifier only** (a 3s gate is never drilled, so it usually has none): if a captured timeline or sampled step list shows any step over the threshold, the shape is refused. With no step data, (a)+(b) stand and the role line discloses that.
- **(d) a named, measured upstream** — at least one closure member resolves to a measured check (same workflow, via the `name:`/matrix-template matcher, degenerate all-placeholder templates refused). Without one there is nothing honest to point at, so the pole keeps today's rendering rather than trading an inert prompt for a contentless role line.

Carve-outs: a **modal-chain member** keeps the chain-stage framing (the chain rendering wins, no double-framing); a pole with a matched **log-detector leaf** or a routed **structural lever** keeps today's render (there the drill is not inert, and suppressing it would silently drop a measured lever). Crowning/ranking is untouched.

## Before / after — pole 1 (live next.js artifact)

**Before**

```
## 🟡 Long pole 1: `build_and_deploy.yml` ▸ `thank you, build` - 3s

**The check most PRs gate on.** A typical PR waits on this most often; the slowest concurrent check is `test cargo unit / build` (~13m 42s). …

Level 2 - workflow-job drill withheld for this PR check-run gate.
- The check-run P50 is 3s across sampled PRs.
- Re-run after a pull_request … job sample exists to capture the dominant step before optimizing.

#### 🤖 Prompt for your coding agent
… NEXT STEP
- Capture this workflow on a pull_request … run and rerun ci-speedup before changing workflow steps. Once developer-event job timing exists, optimize the measured dominant step from the refreshed report.
```

**After**

```
## 🟡 Long pole 1: `build_and_deploy.yml` ▸ `thank you, build` - 3s

**Aggregation gate - it exists to be the single required check.** Its job (`buildPassed`) runs no work of its own (3s); it `needs:` 5 upstream jobs so one check can stand for all of them. So its 3s is not the wait - the wait IS that `needs:` upstream, whose slowest measured member is `stable - x86_64-unknown-linux-gnu - node@20` (~5m 55s). That member, not this check, is the lever. (1 upstream job had no measured check timing in this sample, so the slowest upstream member could be a heavier one.) (No per-step data was captured for this check; the shape is read from its `needs:` structure and its measured P50.) Note: the … chain (14m 56s) gates the merge ahead of this check …

**➡️ Where the wait actually is:** `stable - x86_64-unknown-linux-gnu - node@20` (5m 55s), the slowest measured member of this gate's `needs:` upstream. It is not among the long poles drilled in this report (it ranks below them, or its own job timing wasn't sampled), so there is no step-level drill for it here - a re-run that samples it will drill it. Attack it there; this check follows it down for free.
```

No drill, no prompt, no dead link.

## Claims layer + verifier

The role line is a registered `pole_role_line` **Claim** (same kind/fields discipline as its neighbours; `_strip_emdashes` at construction for manifest↔prose parity), pinned by a test asserting every claim's `rendered` is byte-identical in the report.

`check_speed_poles_complete` would have **false-FAILed** the fixed report ("long pole(s) [1] lack an agent prompt"), so it is extended in this PR:

- it now **exempts** an aggregation-gate pole from the prompt requirement — but only when the shape **re-derives from findings.json** (`_agg_gate_pole_keys`, mirroring the renderer) *and* the section carries the renderer's framing;
- the new **`check_aggregation_gate_poles_never_prescribe`** holds the mirror image: an aggregation-framed pole must carry no agent prompt, must carry the upstream pointer, and must re-derive from the job graph — so the exemption can't launder a stunted pole. Classified `AUTO_SEED` / `prescribed-a-fix` in `grader_seeds.py`.

Renderer literals (`**Aggregation gate`, `**➡️ Where the wait actually is:**`) are pinned by `test_phase0_literals_stay_coupled_to_the_renderer`.

## Proof

**Red before green (renderer)** — `skills/ci-speedup/tests/test_blocking_path.py`:
- aggregation-gate fixture (cross-workflow sink, conditional peer sink, matrix-template upstream): honest framing + slowest-upstream naming + pointer, **no prompt, no Level 2**, other poles untouched;
- **near-miss**: a real 3s `lint` job with no `needs:` coverage renders **byte-identically** to the detector-disabled renderer, and still has its prompt;
- **chain-member pin**: a sink that is a modal-chain member renders **byte-identically** to the detector-disabled renderer and keeps "Stage 3/3 … gate chain";
- unit coverage of each shape condition (duration, coverage gap, single-parent closure, busy steps, no measured upstream, no graph).

**Red before green (verifier)** — `skills/ci-speedup/tests/test_verify_report_self.py`: promptless agg pole PASSes both checks with findings and still FAILs the poles gate without findings; an agg pole **with** a prompt FAILs; framing **without** the pointer FAILs; framing **unsupported by the job graph** FAILs; no framed pole → SKIP; plus a unit test of `_agg_gate_pole_keys`.

**Live evidence re-render** (the exact `--log/--steps/--mag/--captured-at` args from the repro's `run.log`, output written only to worktree scratch):
- diff vs the committed repro report: **only pole 1's section** changed (plus the expected `scripts tree` provenance token) — poles 2–5, the map, appendix and data sources are byte-identical;
- `verify_report.py --report report-after.md --findings findings.json` → **rc 0, all checks passed** (was rc 1 with the new invariant registered before the exemption).

**Full suite**: `python3 -m pytest -q` → **2588 passed, 15 skipped** (baseline 2575/15; +13 new tests).

Docs: `CHANGELOG.md` dated 2026-07-28 under Fixed; `ARCHITECTURE.md` §12.6b + the §7 verification contract; `SKILL.md` 5b self-audit carve-out (body stays at 499/500 lines).

## Review pass (172872b)

- **Pointer joins on identity, not presentation.** The "where the wait actually is" link resolves the upstream member's own pole by raw check name + workflow file (the spine's identity), never by the cleaned display label — two checks whose labels normalize together (`@scope/lint` / `lint`) can no longer link the pointer at an unrelated pole's drill. Not reachable end-to-end today (`_same_matrix` folds colliding labels before `pole_wfs`), but the pointer shouldn't lean on that coincidence — same class as #13.
- **Both thin-data caveats compose.** An `elif` dropped the "no per-step data was captured" disclosure whenever an unmeasured upstream member was also disclosed — i.e. exactly when the sample was thinnest and "runs no work of its own" leaned hardest on structure + P50. Both now render (visible in the After block above).
- **The verifier's exemption keys on the pole section body, not its ordinal** — `_pole_sections` and `_pole_header_sections` use different header patterns, so an ordinal could shift the exemption onto a different pole.
- Live pins re-verified after the change: next.js re-render + `verify_report` **rc 0**; biome (no aggregation gate) re-renders **byte-identically to `main`** modulo the provenance token.

## Follow-ups (not blockers)

- The `**➡️ Where the wait actually is:**` pointer repeats the role line's measured figure but is not itself a registered `Claim`, so a divergence between the two sentences wouldn't be caught by the manifest↔prose parity guard. Worth registering it (or deriving it from the role-line claim's fields) in a follow-up.
- The shape's coverage rule allows uncovered *terminal* siblings (the `if:`-conditional peer-sink carve-out). A workflow with genuinely independent terminal jobs (a `docs` job nothing needs) therefore still matches. The framing stays true for the reader — the sink's own wait really is its `needs:` upstream — but "one check can stand for all of them" is scoped to the closure, not the whole workflow. Revisit if a real repo renders confusingly.

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

