### PR TITLE
tests: git-env isolation + repo-state tripwire (worktree corruption incident)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -18,11 +18,23 @@ Guard 2 — tripwire: record the repo's HEAD / branch / bareness before
 the first test and verify them after the last. If any test mutates the
 real repo again — by this vector or a new one — the suite fails loudly
 at session end instead of leaving silent corruption.
+
+Scope of Guard 2: it watches exactly the three invariants a hijacked repo
+violates (it gets re-pointed, re-branched, or flipped bare) — the incident's
+signature. It is a deliberately narrow backstop, NOT a working-tree audit:
+Guard 1 is the actual prevention, and a status/index snapshot would
+false-positive on the ``__pycache__`` the suite itself writes. A net HEAD
+move from any source trips it — including a developer committing in this
+checkout while the ~70s suite runs; that loud stop is intended. If the git
+state can't be read at start (or re-read at end), the tripwire says so
+loudly (a warning to stderr) rather than passing — or falsely alarming —
+in silence.
 """
 from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -36,7 +48,13 @@ for _var in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR",
     os.environ.pop(_var, None)
 
 
-def _repo_state() -> dict | None:
+def _guard_warn(msg: str) -> None:
+    """Loud, non-fatal notice to stderr — used when the tripwire cannot do its
+    job so 'guard inactive/inconclusive' is never mistaken for 'guard passed'."""
+    print(f"REPO-STATE TRIPWIRE: {msg}", file=sys.stderr, flush=True)
+
+
+def _repo_state() -> dict[str, str] | None:
     """(HEAD sha, symbolic branch, core.bare) of THIS repo — None outside git."""
     def probe(*args: str) -> str | None:
         try:
@@ -55,14 +73,32 @@ def _repo_state() -> dict | None:
 
 
 def pytest_sessionstart(session):
-    session.config._repo_guard_state = _repo_state()
+    state = _repo_state()
+    session.config._repo_guard_state = state
+    if state is None:
+        # No baseline (git missing/timeout, or not a git repo) => nothing to
+        # compare against at session end. Fail-open is unavoidable here, but it
+        # must not be SILENT: announce that the tripwire is inactive for this run.
+        _guard_warn(
+            "INACTIVE — could not read this repo's git state at session start; "
+            "repo corruption during this run will NOT be detected."
+        )
 
 
 def pytest_sessionfinish(session, exitstatus):
     before = getattr(session.config, "_repo_guard_state", None)
     if before is None:
-        return
+        return  # already announced at session start; nothing to compare against
     after = _repo_state()
+    if after is None:
+        # Re-read failed at session end. That is INCONCLUSIVE (a transient git
+        # hiccup), not proof of mutation — do not cry corruption. Say so loudly
+        # instead of raising a misleading "a test mutated this repo" tripwire.
+        _guard_warn(
+            "INCONCLUSIVE — could not re-read this repo's git state at session "
+            f"end (baseline was {before}); drift could not be verified."
+        )
+        return
     if after != before:
         raise pytest.UsageError(
             "REPO-STATE TRIPWIRE: a test mutated this repository's git state "

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,73 @@
+"""Repo-wide pytest guards: git-environment isolation + a repo-state tripwire.
+
+Incident, 2026-07-30: the pre-commit hook ran this suite from a LINKED
+WORKTREE. In worktrees, git exports its repo-addressing environment
+(GIT_DIR, GIT_INDEX_FILE, ...) to hooks as ABSOLUTE paths; every
+`subprocess.run(["git", ...])` in every test inherited it, so a fixture
+test's `git init/add/commit` sequence executed against the REAL
+repository's metadata instead of its pytest tmp_path — re-initializing
+the developer checkout as bare and walking `main` onto a fixture commit.
+(Normal checkouts were never bitten: there the addressing is relative and
+resolves harmlessly inside each test's cwd.)
+
+Guard 1 — scrub the addressing env at import time, before any test runs:
+no git subprocess anywhere in the suite can be redirected at a repo it
+did not name itself.
+
+Guard 2 — tripwire: record the repo's HEAD / branch / bareness before
+the first test and verify them after the last. If any test mutates the
+real repo again — by this vector or a new one — the suite fails loudly
+at session end instead of leaving silent corruption.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent
+
+# Guard 1: at import time — before collection, before any test subprocess.
+for _var in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR",
+             "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+             "GIT_NAMESPACE"):
+    os.environ.pop(_var, None)
+
+
+def _repo_state() -> dict | None:
+    """(HEAD sha, symbolic branch, core.bare) of THIS repo — None outside git."""
+    def probe(*args: str) -> str | None:
+        try:
+            r = subprocess.run(["git", "-C", str(_REPO_ROOT), *args],
+                               capture_output=True, text=True, timeout=10)
+        except (OSError, subprocess.SubprocessError):
+            return None
+        return r.stdout.strip() if r.returncode == 0 else None
+
+    head = probe("rev-parse", "HEAD")
+    if head is None:
+        return None
+    return {"head": head,
+            "branch": probe("symbolic-ref", "-q", "HEAD") or "(detached)",
+            "bare": probe("config", "core.bare") or "false"}
+
+
+def pytest_sessionstart(session):
+    session.config._repo_guard_state = _repo_state()
+
+
+def pytest_sessionfinish(session, exitstatus):
+    before = getattr(session.config, "_repo_guard_state", None)
+    if before is None:
+        return
+    after = _repo_state()
+    if after != before:
+        raise pytest.UsageError(
+            "REPO-STATE TRIPWIRE: a test mutated this repository's git state "
+            f"during the run — before={before} after={after}. No test may touch "
+            "the real repo (2026-07-30 incident: a fixture repo's git commands "
+            "escaped via inherited GIT_DIR and rewrote the developer checkout). "
+            "Find the test whose git subprocess is not confined to its tmp_path."
+        )

--- a/tests/test_repo_guards.py
+++ b/tests/test_repo_guards.py
@@ -1,0 +1,163 @@
+"""Regression proof for the repo-root ``conftest.py`` guards (PR #18 / the
+2026-07-30 worktree-corruption incident).
+
+Guard 1 (import-time ``GIT_*`` scrub) and Guard 2 (repo-state tripwire) are the
+kind of safety code that passes silently when broken: the whole suite stays green
+whether the scrub loop exists or not, because nothing ELSE exercises a hostile
+``GIT_DIR``, and the tripwire's ``raise`` never runs in a normal, non-mutating
+run. So a refactor that deletes the scrub or inverts the drift compare would ship
+with CI green. These tests red-prove both guards.
+
+The Guard-1 proof runs a NESTED pytest in a subprocess with a hostile absolute
+``GIT_DIR`` exported into the child env, pointing at a throwaway *victim* repo —
+exactly the incident vector. With the real conftest's scrub loaded, the inner
+test's ``git commit`` cannot reach the victim; a negative control WITHOUT the
+scrub proves the victim IS reachable, so the positive assertion has teeth.
+Everything stays inside ``tmp_path``; ``GIT_DIR`` never points at the real repo
+(that would trip this very suite's own Guard 2).
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+_CONFTEST = _REPO / "conftest.py"
+
+
+# ---------------------------------------------------------------------------
+# Guard 1 — the import-time GIT_* scrub (end-to-end, nested pytest subprocess)
+# ---------------------------------------------------------------------------
+
+def _git(*args: str, cwd: Path):
+    return subprocess.run(["git", *args], cwd=str(cwd),
+                          capture_output=True, text=True)
+
+
+def _make_victim(tmp_path: Path):
+    """A throwaway repo with one commit; return (path, head_sha, core.bare)."""
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    _git("init", "-q", cwd=victim)
+    _git("-c", "user.email=a@b.c", "-c", "user.name=t",
+         "commit", "-q", "--allow-empty", "-m", "base", cwd=victim)
+    head = _git("rev-parse", "HEAD", cwd=victim).stdout.strip()
+    bare = _git("config", "core.bare", cwd=victim).stdout.strip()
+    assert head and bare == "false"
+    return victim, head, bare
+
+
+# Inner test: attempt a commit with NO -C and NO explicit GIT_DIR, so it inherits
+# whatever repo-addressing env the parent exported. No assertion here — the OUTER
+# test judges the vector by the victim's state, not this test's pass/fail.
+_INNER_TEST = (
+    "import subprocess\n"
+    "def test_attempt_commit():\n"
+    "    subprocess.run(['git', '-c', 'user.email=x@x.c', '-c', 'user.name=x',\n"
+    "                    'commit', '--allow-empty', '-m', 'pwn-attempt'],\n"
+    "                   capture_output=True)\n"
+)
+
+
+def _run_inner(proj: Path, victim: Path, *, with_scrub: bool):
+    proj.mkdir()
+    (proj / "test_inner.py").write_text(_INNER_TEST, encoding="utf-8")
+    if with_scrub:
+        # The REAL guard under test — a byte copy of the root conftest.
+        (proj / "conftest.py").write_text(
+            _CONFTEST.read_text(encoding="utf-8"), encoding="utf-8")
+    env = dict(os.environ)
+    env["GIT_DIR"] = str((victim / ".git").resolve())  # the hostile inheritance
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", str(proj),
+         "-p", "no:cacheprovider", "-q"],
+        cwd=str(proj), env=env, capture_output=True, text=True,
+    )
+
+
+def test_scrub_protects_victim_repo(tmp_path: Path):
+    """WITH the real conftest scrub loaded, a nested test's git commit cannot
+    reach a repo it inherited via GIT_DIR — the victim is byte-identical after."""
+    victim, head0, bare0 = _make_victim(tmp_path)
+    _run_inner(tmp_path / "proj", victim, with_scrub=True)
+    assert _git("rev-parse", "HEAD", cwd=victim).stdout.strip() == head0
+    assert _git("config", "core.bare", cwd=victim).stdout.strip() == bare0
+
+
+def test_negative_control_victim_clobbered_without_scrub(tmp_path: Path):
+    """Teeth check: WITHOUT the scrub, the IDENTICAL inner commit DOES reach the
+    victim (HEAD moves). Proves the positive test passes because of the scrub, not
+    because the inherited-GIT_DIR vector was inert to begin with."""
+    victim, head0, _ = _make_victim(tmp_path)
+    _run_inner(tmp_path / "proj", victim, with_scrub=False)
+    assert _git("rev-parse", "HEAD", cwd=victim).stdout.strip() != head0
+
+
+# ---------------------------------------------------------------------------
+# Guard 2 — the repo-state tripwire (unit tests on the session hooks)
+# ---------------------------------------------------------------------------
+
+def _load_conftest():
+    """Load the root conftest as an isolated module so we can drive its hooks and
+    monkeypatch _repo_state. (Re-running its import-time scrub is a harmless no-op —
+    the GIT_* vars are already gone from this process's environ.)"""
+    spec = importlib.util.spec_from_file_location(
+        "_root_conftest_under_test", _CONFTEST)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeSession:
+    def __init__(self):
+        self.config = type("_Cfg", (), {})()
+
+
+def test_tripwire_raises_on_drift(monkeypatch):
+    mod = _load_conftest()
+    session = _FakeSession()
+    monkeypatch.setattr(mod, "_repo_state",
+                        lambda: {"head": "aaa", "branch": "refs/heads/main", "bare": "false"})
+    mod.pytest_sessionstart(session)
+    monkeypatch.setattr(mod, "_repo_state",
+                        lambda: {"head": "bbb", "branch": "refs/heads/main", "bare": "false"})
+    with pytest.raises(pytest.UsageError):
+        mod.pytest_sessionfinish(session, 0)
+
+
+def test_tripwire_silent_when_no_drift(monkeypatch):
+    mod = _load_conftest()
+    session = _FakeSession()
+    state = {"head": "aaa", "branch": "refs/heads/main", "bare": "false"}
+    monkeypatch.setattr(mod, "_repo_state", lambda: dict(state))
+    mod.pytest_sessionstart(session)
+    mod.pytest_sessionfinish(session, 0)  # must not raise — unchanged state
+
+
+def test_tripwire_inactive_and_loud_when_no_baseline(monkeypatch, capsys):
+    """Missing baseline must fail OPEN but LOUD, never silently: sessionfinish
+    does not raise, and 'INACTIVE' is announced on stderr (the silent fail-open fix)."""
+    mod = _load_conftest()
+    session = _FakeSession()
+    monkeypatch.setattr(mod, "_repo_state", lambda: None)
+    mod.pytest_sessionstart(session)
+    mod.pytest_sessionfinish(session, 0)  # must not raise despite no baseline
+    assert "INACTIVE" in capsys.readouterr().err
+
+
+def test_tripwire_inconclusive_not_alarm_when_end_read_fails(monkeypatch, capsys):
+    """A failed re-read at session end is INCONCLUSIVE, not proof of mutation:
+    it must warn, not raise the misleading 'a test mutated this repo' tripwire."""
+    mod = _load_conftest()
+    session = _FakeSession()
+    monkeypatch.setattr(mod, "_repo_state",
+                        lambda: {"head": "aaa", "branch": "b", "bare": "false"})
+    mod.pytest_sessionstart(session)
+    monkeypatch.setattr(mod, "_repo_state", lambda: None)  # re-read fails at end
+    mod.pytest_sessionfinish(session, 0)  # must NOT raise
+    assert "INCONCLUSIVE" in capsys.readouterr().err


### PR DESCRIPTION
## What

Root `conftest.py` with two guards, from a live incident (2026-07-30):

**The incident.** The pre-commit hook ran the full suite from a *linked git worktree*. In worktrees, git hands hooks its repo-addressing environment (`GIT_DIR`, `GIT_INDEX_FILE`, …) as **absolute paths**; every `subprocess.run(["git", …])` in every test inherited them. A fixture test's `git init / add / commit` sequence therefore executed against the developer's real checkout instead of its pytest tmp dir — re-initializing the repo as bare and walking `main` onto a fixture commit ("base"). Working files were unaffected; history survived and was restored from the reflog + GitHub. Normal checkouts were never bitten because the addressing is relative there and resolves harmlessly inside each test's cwd — which is why hundreds of prior runs were green.

**Guard 1 — env scrub at import time**: `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_COMMON_DIR`, `GIT_OBJECT_DIRECTORY`, `GIT_ALTERNATE_OBJECT_DIRECTORIES`, `GIT_NAMESPACE` are removed before any test runs, so no test git call can be redirected at a repo it did not name itself.

**Guard 2 — repo-state tripwire**: HEAD / branch / bareness of this repo are recorded before the first test and re-verified after the last; any drift fails the session loudly with the incident context — so this vector, or any new one, can never again corrupt silently.

**Red-proof**: in a sandbox clone, exporting a hostile absolute `GIT_DIR` and running the fixture test reproduced the corruption (repo flipped bare) without the guard, and is completely inert with it — suite green, repo state byte-identical.

Full suite: 2,588 passed under the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)