### PR TITLE
ci-speedup: two more floor-ranking sites name the effective floor, not the p50-slowest sibling (#22 class)

### DIFF
--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -110,7 +110,13 @@ unversioned and updates by reinstall from `main`.
   `_pole_headline` (the seconds the named check's own drilled header shows), not
   frac-blind `_eff_floor_s`, so the quoted time matches the check's own drill and a
   degenerate bimodal (missing `low_p50_s`/`slow_frac`) can't fire a phantom
-  slow-mode disclosure. The clause adds no new spine-disclosure obligation:
+  slow-mode disclosure. The clause fires ONLY when `_pole_headline`'s bimodal
+  override actually fired (a genuine fast-median slow mode), so its "bimodal slow
+  mode … on slow-mode PRs" wording can never be printed for a UNIMODAL heavy
+  path-conditional check whose blended p50 merely out-ranks the slowest typical
+  check (the lightdash `E2E` class — such a check doesn't run on a typical PR, so
+  the typical floor is the slowest typical check, disclosed on its own drilled
+  pole). The clause adds no new spine-disclosure obligation:
   `check_spine_heavy_check_disclosed` keys on drilled poles' binding floors
   (independent of this clause text) and `verify_report` is untouched, so a
   file-backed ceiling that must be disclosed is disclosed by its own drilled-pole

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -83,8 +83,13 @@ unversioned and updates by reinstall from `main`.
   ceiling but whose blended p50 sits below a faster-median sibling went unnamed,
   and the "Where the wait actually is" pointer sent the reader to the wrong lever
   (at a duration smaller than the slow-mode header of the very pole it linked to).
-  Both picks now rank by `_eff_floor_s` and render that effective floor, so the
-  sink, its pointer, and the linked drilled pole all agree. (2) The
+  Both picks now rank by — and the pointer renders — the seconds the member's own
+  drilled pole HEADER shows (`_pole_headline`, the bimodal-aware header duration),
+  so the sink, its pointer, and the linked pole all agree exactly. (This is the
+  member's slow mode when its median sits on the fast cluster — the case above —
+  but its p50 when the median already sits IN the slow cluster, where the header
+  keeps the p50; ranking/rendering by a bare `max(p50, high)` would there quote a
+  duration ABOVE the linked pole's header.) (2) The
   FREQUENCY-GATE pole's role line ("**The check most PRs gate on.** … the slowest
   concurrent check is `X`, which sets the wall-clock floor") named `X` from
   `src[0]`, the p50-slowest typical check. That pick is STAMP-BOUND to the data
@@ -92,12 +97,17 @@ unversioned and updates by reinstall from `main`.
   re-ranking it would desync the headline from its stamp and break
   `verify_report.check_headline_slowest_matches_stamp` — a joint re-rank is
   genuinely unsafe. Instead the role line keeps the stamp-consistent p50 pick and
-  now DISCLOSES the true ceiling beside it: when a different concurrent check's
-  effective (bimodal slow-mode) floor exceeds `X`'s p50, it names that check as
-  the one that sets the wall-clock floor on slow-mode PRs (`_binding_floor`, the
-  same `_eff_floor_s` selector the per-pole floor note and the spine-drop verifier
-  use). The named ceiling is already disclosed by the pole's floor note, so the
-  correction adds no silent spine drop and leaves committed example reports valid.
+  now DISCLOSES the true ceiling beside it: when a different **file-backed**
+  concurrent check's effective (bimodal slow-mode) floor exceeds `X`'s p50, it
+  names that check as the one that sets the wall-clock floor on slow-mode PRs
+  (`_binding_floor`, the same `_eff_floor_s` selector the per-pole floor note and
+  the spine-drop verifier use). The clause fires for TUNABLE (file-backed) floors
+  only — the reader is told to attack the named check, and a file-backed binding
+  floor is always disclosed by the pole's own floor note (the phrasing the spine
+  parser reads). A MANAGED/external binding floor (no workflow file) stays with
+  `_floor_note`, which discloses it via its dedicated "no workflow file to speed up
+  here" phrasing; this clause simply doesn't fire there (byte-identical to `main`),
+  so it adds no silent spine drop and leaves committed example reports valid.
 
 - **2026-07-30** — **A below-gate pole names the check that actually caps it —
   the effective floor, not the p50-slowest sibling.** A drilled pole that runs

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -103,9 +103,12 @@ unversioned and updates by reinstall from `main`.
   effective floor exceeds `X`'s p50, it names that TUNABLE check as the one that
   sets the wall-clock floor on slow-mode PRs (the reader is told to attack it);
   (b) when the check that out-floors `X` is MANAGED/external (no workflow file —
-  not tunable), the role line DROPS the floor claim entirely rather than
-  mis-crediting `X`, and `_floor_note` sets the floor straight via its dedicated
-  "no workflow file to speed up here" phrasing; (c) when nothing out-floors `X`,
+  not tunable), the role line does not credit `X` and does not frame the managed
+  check as attackable, but DOES name it as the real cap using the "no workflow file
+  to speed up here `Z`" phrasing — honest about untunability AND the form the spine
+  parser (`verify_report._SPINE_FLOOR_NAME_RE`) reads, so the managed ceiling is
+  disclosed on the spine even when the gate pole's own `_floor_note` is suppressed
+  (`binding_s >= pole_p`); (c) when nothing out-floors `X`,
   it keeps the plain "sets the wall-clock floor". The out-floor test uses
   `_pole_headline` (the seconds the named check's own drilled header shows), not
   frac-blind `_eff_floor_s`, so the quoted time matches the check's own drill and a

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -97,19 +97,25 @@ unversioned and updates by reinstall from `main`.
   re-ranking it would desync the headline from its stamp and break
   `verify_report.check_headline_slowest_matches_stamp` — a joint re-rank is
   genuinely unsafe. Instead the role line keeps the stamp-consistent p50 pick and
-  now handles the true ceiling beside it via `_binding_floor` (the same
-  `_eff_floor_s` selector the per-pole floor note and the spine-drop verifier use)
-  so `X` is NEVER credited with a floor a slower sibling actually sets: (a) when a
-  different **file-backed** concurrent check's effective (bimodal slow-mode) floor
-  exceeds `X`'s p50, it names that TUNABLE check as the one that sets the
-  wall-clock floor on slow-mode PRs (the reader is told to attack it; a file-backed
-  floor is disclosed by the pole's own floor note, the phrasing the spine parser
-  reads); (b) when the check that out-floors `X` is MANAGED/external (no workflow
-  file — not tunable), the role line DROPS the floor claim entirely rather than
+  now handles the true ceiling beside it via `_binding_floor` (over the same full
+  concurrent set `_floor_note` uses) so `X` is NEVER credited with a floor a slower
+  sibling actually sets: (a) when a different **file-backed** concurrent check's
+  effective floor exceeds `X`'s p50, it names that TUNABLE check as the one that
+  sets the wall-clock floor on slow-mode PRs (the reader is told to attack it);
+  (b) when the check that out-floors `X` is MANAGED/external (no workflow file —
+  not tunable), the role line DROPS the floor claim entirely rather than
   mis-crediting `X`, and `_floor_note` sets the floor straight via its dedicated
   "no workflow file to speed up here" phrasing; (c) when nothing out-floors `X`,
-  it keeps the plain "sets the wall-clock floor". Leaves committed example reports
-  valid (full suite green, no re-render required).
+  it keeps the plain "sets the wall-clock floor". The out-floor test uses
+  `_pole_headline` (the seconds the named check's own drilled header shows), not
+  frac-blind `_eff_floor_s`, so the quoted time matches the check's own drill and a
+  degenerate bimodal (missing `low_p50_s`/`slow_frac`) can't fire a phantom
+  slow-mode disclosure. The clause adds no new spine-disclosure obligation:
+  `check_spine_heavy_check_disclosed` keys on drilled poles' binding floors
+  (independent of this clause text) and `verify_report` is untouched, so a
+  file-backed ceiling that must be disclosed is disclosed by its own drilled-pole
+  header exactly as on `main`. Leaves committed example reports valid (full suite
+  green, no re-render required).
 
 - **2026-07-30** — **A below-gate pole names the check that actually caps it —
   the effective floor, not the p50-slowest sibling.** A drilled pole that runs

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -74,6 +74,31 @@ unversioned and updates by reinstall from `main`.
 
 ### Fixed
 
+- **2026-07-30** — **Two more floor-ranking sites name the check that actually
+  caps the wait — the effective floor, not the p50-slowest sibling** (same class
+  as #22's below-gate role line, found by its floor-semantics audit). (1) The
+  SUCCESS-AGGREGATION-GATE pole names its slowest measured `needs:` upstream
+  member as the lever; it ranked candidates — both within a matrix job's legs and
+  across jobs — by bare `p50_s`, so a leg whose bimodal SLOW mode is the true
+  ceiling but whose blended p50 sits below a faster-median sibling went unnamed,
+  and the "Where the wait actually is" pointer sent the reader to the wrong lever
+  (at a duration smaller than the slow-mode header of the very pole it linked to).
+  Both picks now rank by `_eff_floor_s` and render that effective floor, so the
+  sink, its pointer, and the linked drilled pole all agree. (2) The
+  FREQUENCY-GATE pole's role line ("**The check most PRs gate on.** … the slowest
+  concurrent check is `X`, which sets the wall-clock floor") named `X` from
+  `src[0]`, the p50-slowest typical check. That pick is STAMP-BOUND to the data
+  layer's p50-based `critical_path_check` (which is not bimodal-aware), so
+  re-ranking it would desync the headline from its stamp and break
+  `verify_report.check_headline_slowest_matches_stamp` — a joint re-rank is
+  genuinely unsafe. Instead the role line keeps the stamp-consistent p50 pick and
+  now DISCLOSES the true ceiling beside it: when a different concurrent check's
+  effective (bimodal slow-mode) floor exceeds `X`'s p50, it names that check as
+  the one that sets the wall-clock floor on slow-mode PRs (`_binding_floor`, the
+  same `_eff_floor_s` selector the per-pole floor note and the spine-drop verifier
+  use). The named ceiling is already disclosed by the pole's floor note, so the
+  correction adds no silent spine drop and leaves committed example reports valid.
+
 - **2026-07-30** — **A below-gate pole names the check that actually caps it —
   the effective floor, not the p50-slowest sibling.** A drilled pole that runs
   concurrently behind the gate gets a "Runs concurrently behind `X`; it becomes

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -97,17 +97,19 @@ unversioned and updates by reinstall from `main`.
   re-ranking it would desync the headline from its stamp and break
   `verify_report.check_headline_slowest_matches_stamp` — a joint re-rank is
   genuinely unsafe. Instead the role line keeps the stamp-consistent p50 pick and
-  now DISCLOSES the true ceiling beside it: when a different **file-backed**
-  concurrent check's effective (bimodal slow-mode) floor exceeds `X`'s p50, it
-  names that check as the one that sets the wall-clock floor on slow-mode PRs
-  (`_binding_floor`, the same `_eff_floor_s` selector the per-pole floor note and
-  the spine-drop verifier use). The clause fires for TUNABLE (file-backed) floors
-  only — the reader is told to attack the named check, and a file-backed binding
-  floor is always disclosed by the pole's own floor note (the phrasing the spine
-  parser reads). A MANAGED/external binding floor (no workflow file) stays with
-  `_floor_note`, which discloses it via its dedicated "no workflow file to speed up
-  here" phrasing; this clause simply doesn't fire there (byte-identical to `main`),
-  so it adds no silent spine drop and leaves committed example reports valid.
+  now handles the true ceiling beside it via `_binding_floor` (the same
+  `_eff_floor_s` selector the per-pole floor note and the spine-drop verifier use)
+  so `X` is NEVER credited with a floor a slower sibling actually sets: (a) when a
+  different **file-backed** concurrent check's effective (bimodal slow-mode) floor
+  exceeds `X`'s p50, it names that TUNABLE check as the one that sets the
+  wall-clock floor on slow-mode PRs (the reader is told to attack it; a file-backed
+  floor is disclosed by the pole's own floor note, the phrasing the spine parser
+  reads); (b) when the check that out-floors `X` is MANAGED/external (no workflow
+  file — not tunable), the role line DROPS the floor claim entirely rather than
+  mis-crediting `X`, and `_floor_note` sets the floor straight via its dedicated
+  "no workflow file to speed up here" phrasing; (c) when nothing out-floors `X`,
+  it keeps the plain "sets the wall-clock floor". Leaves committed example reports
+  valid (full suite green, no re-render required).
 
 - **2026-07-30** — **A below-gate pole names the check that actually caps it —
   the effective floor, not the p50-slowest sibling.** A drilled pole that runs

--- a/skills/ci-speedup/scripts/blocking_path.py
+++ b/skills/ci-speedup/scripts/blocking_path.py
@@ -8538,8 +8538,19 @@ def render(doc: dict[str, Any], logs: dict[str, str] | None = None,
                 _bf = (_binding_floor(_others, p.get("_cooccur"),
                                       int(p.get("_gating_n") or 0))
                        if (not floor_lowered and _others) else None)
-                _bf_hd = _pole_headline(_bf)[0] if _bf is not None else 0.0
-                _bf_outfloors = (_bf is not None
+                # `_bf_caveat` is non-empty ONLY when `_pole_headline`'s bimodal override fired —
+                # `_bf` is a genuine fast-median bimodal whose SLOW mode is a hidden ceiling
+                # (`_bf_hd` == that slow mode). Require it: the clause's wording asserts a "bimodal
+                # slow mode … on slow-mode PRs", so it must NOT fire for a UNIMODAL `_bf` whose
+                # plain p50 merely out-ranks `floor_name` (a heavy path-conditional/minority check
+                # from `floor_pool` that isn't in the typical `src` — the lightdash `E2E` class).
+                # Such a check doesn't run on a TYPICAL PR, so it does not out-floor the typical
+                # wait the role line describes; `floor_name` genuinely sets that floor (outcome c),
+                # and the heavy check's own gating is disclosed on its DRILLED pole, not here.
+                # Without this guard the clause would print "bimodal slow mode … on slow-mode PRs"
+                # for a check that is neither (silent-failure-hunter).
+                _bf_hd, _bf_caveat = _pole_headline(_bf) if _bf is not None else (0.0, "")
+                _bf_outfloors = (_bf is not None and bool(_bf_caveat)
                                  and _clean_label(_check_name(_bf)) != floor_name
                                  and _bf_hd > (slowest_p50 or 0.0) + 0.5)
                 if _bf_outfloors and str(_bf.get("workflow_file") or ""):

--- a/skills/ci-speedup/scripts/blocking_path.py
+++ b/skills/ci-speedup/scripts/blocking_path.py
@@ -883,9 +883,17 @@ def _agg_gate_shape(pole: dict[str, Any], job_graph: dict[str, Any] | None,
         if not matched:
             unmeasured.append(nm)
             continue
-        top = max(matched, key=lambda c: _num(c.get("p50_s")) or 0.0)
-        if slowest is None or ((_num(top.get("p50_s")) or 0.0)
-                               > (_num(slowest.get("p50_s")) or 0.0)):
+        # Rank the upstream members by their EFFECTIVE floor (`_eff_floor_s`, bimodal-aware
+        # `max(p50, high_p50_s)`) — the SAME notion every other floor path and verify_report's
+        # spine-drop check use — NOT the bare p50. Both max() calls: WITHIN a matrix job's legs
+        # (`top`) and ACROSS jobs (`slowest`). Selecting by p50 named the p50-slowest sibling
+        # while the member that actually CAPS the sink's `needs:` wait is the one whose bimodal
+        # SLOW mode is the true ceiling (a matrix leg whose blended p50 sits below a faster-median
+        # sibling but whose slow mode exceeds it) — so the sink pointed the reader at the wrong
+        # lever, and the drilled pole it links to (headlined at its slow mode) showed a longer
+        # time than the sink named (issue #22 class).
+        top = max(matched, key=_eff_floor_s)
+        if slowest is None or _eff_floor_s(top) > _eff_floor_s(slowest):
             slowest = top
     if slowest is None:
         return None
@@ -8418,7 +8426,12 @@ def render(doc: dict[str, Any], logs: dict[str, str] | None = None,
             # aggregates. Say that, name the slowest measured upstream member, and (below)
             # render NO drill and NO "optimize this step" prompt for the sink itself.
             _ag_slow = _clean_label(_check_name(_agg["slowest"]))
-            _ag_dur = _clock(_num(_agg["slowest"].get("p50_s")))
+            # Render the member's EFFECTIVE floor (`_eff_floor_s`, the bimodal-aware
+            # `max(p50, high_p50_s)`), not the bare p50 — it MUST agree with the selection above
+            # (which now ranks by effective floor) or the sink would name a member `X` yet quote a
+            # duration SMALLER than an unnamed sibling's p50, and would disagree with the slow-mode
+            # header of the very pole its "Where the wait actually is" pointer links to (issue #22).
+            _ag_dur = _clock(_eff_floor_s(_agg["slowest"]))
             # BOTH caveats compose — they are independent, and neither may silently drop the
             # other. "Runs no work of its own" rests on the measured P50 plus the `needs:`
             # structure whenever no per-step data was captured, so that basis is disclosed on
@@ -8465,7 +8478,36 @@ def render(doc: dict[str, Any], logs: dict[str, str] | None = None,
                 # one "the slowest"; that would contradict the headline's truthful split.
                 # Quote `floor_name`'s OWN time (`slowest_dur`); it only "sets the wall-clock
                 # floor" when it isn't a non-universal check (else a median PR finishes sooner).
-                _sets_floor = "" if floor_lowered else ", which sets the wall-clock floor"
+                #
+                # Effective-floor honesty (issue #22 class). `floor_name`/`slowest_dur` come from
+                # `src[0]` — the p50-slowest TYPICAL check — and are STAMP-BOUND to the data
+                # layer's p50-based `critical_path_check`
+                # (`verify_report.check_headline_slowest_matches_stamp`). Re-ranking THIS pick to
+                # the effective floor would desync the headline from its stamp (which is NOT
+                # bimodal-aware), so we keep the p50 pick and instead DISCLOSE the true ceiling
+                # beside it: when we would otherwise credit `floor_name` with setting the
+                # wall-clock floor (`not floor_lowered`), consult `_binding_floor` — the SAME
+                # bimodal-aware `_eff_floor_s` selector every per-pole floor path and the
+                # spine-drop verifier use — over the concurrent set (the pole itself excluded,
+                # mirroring `_floor_note`). If a DIFFERENT check's effective (bimodal slow-mode)
+                # floor exceeds `floor_name`'s p50, THAT check — not `floor_name` — sets the
+                # wall-clock floor on slow-mode PRs; name it, rather than silently crediting the
+                # p50-slowest sibling with a floor a slower bimodal sibling actually sets. The
+                # named ceiling is ALSO disclosed by this pole's `_floor_note`, so this only
+                # corrects the role line's prose; it adds no new spine-disclosure obligation.
+                _others = [c for c in floor_pool
+                           if _clean_label(_check_name(c)) != gate_check]
+                _bf = (_binding_floor(_others, p.get("_cooccur"),
+                                      int(p.get("_gating_n") or 0))
+                       if (not floor_lowered and _others) else None)
+                if (_bf is not None and _clean_label(_check_name(_bf)) != floor_name
+                        and _eff_floor_s(_bf) > (slowest_p50 or 0.0) + 0.5):
+                    _bf_name = _clean_label(_check_name(_bf))
+                    _sets_floor = (f"; but `{_bf_name}`'s bimodal slow mode "
+                                   f"(~{_clock(_eff_floor_s(_bf))}) runs longer, so it — not "
+                                   f"`{floor_name}` — sets the wall-clock floor on slow-mode PRs")
+                else:
+                    _sets_floor = "" if floor_lowered else ", which sets the wall-clock floor"
                 role = (f"**The check most PRs gate on.** A typical PR waits on this most "
                         f"often; the slowest concurrent check is `{floor_name}` "
                         f"(~{slowest_dur}){_sets_floor}.")

--- a/skills/ci-speedup/scripts/blocking_path.py
+++ b/skills/ci-speedup/scripts/blocking_path.py
@@ -883,17 +883,23 @@ def _agg_gate_shape(pole: dict[str, Any], job_graph: dict[str, Any] | None,
         if not matched:
             unmeasured.append(nm)
             continue
-        # Rank the upstream members by their EFFECTIVE floor (`_eff_floor_s`, bimodal-aware
-        # `max(p50, high_p50_s)`) — the SAME notion every other floor path and verify_report's
-        # spine-drop check use — NOT the bare p50. Both max() calls: WITHIN a matrix job's legs
-        # (`top`) and ACROSS jobs (`slowest`). Selecting by p50 named the p50-slowest sibling
-        # while the member that actually CAPS the sink's `needs:` wait is the one whose bimodal
-        # SLOW mode is the true ceiling (a matrix leg whose blended p50 sits below a faster-median
-        # sibling but whose slow mode exceeds it) — so the sink pointed the reader at the wrong
-        # lever, and the drilled pole it links to (headlined at its slow mode) showed a longer
-        # time than the sink named (issue #22 class).
-        top = max(matched, key=_eff_floor_s)
-        if slowest is None or _eff_floor_s(top) > _eff_floor_s(slowest):
+        # Rank the upstream members by the SECONDS their own drilled pole HEADER would show
+        # (`_pole_headline(c)[0]`, the bimodal-aware header duration), NOT the bare p50. Both
+        # max() calls: WITHIN a matrix job's legs (`top`) and ACROSS jobs (`slowest`). Selecting
+        # by p50 named the p50-slowest sibling while the member that actually CAPS the sink's
+        # `needs:` wait is the one whose bimodal SLOW mode is the true ceiling (a matrix leg whose
+        # blended p50 sits below a faster-median sibling but whose slow mode exceeds it) — so the
+        # sink pointed the reader at the wrong lever, and the pole it links to (headlined at its
+        # slow mode) showed a longer time than the sink named (issue #22 class). We rank by
+        # `_pole_headline`, NOT `_eff_floor_s`: for a member whose median sits on the FAST cluster
+        # `_pole_headline` returns the slow mode (== `_eff_floor_s`, the #22 case we must catch),
+        # but for a member whose median ALREADY sits in the SLOW cluster it returns the p50 that
+        # its header shows (`_eff_floor_s` would over-state that to the high mode). Ranking AND
+        # rendering by the header value keeps the pick, its quoted duration, and the linked pole's
+        # header in exact agreement — `_eff_floor_s` would quote a duration ABOVE the linked pole's
+        # header on a slow-median member (greptile P1).
+        top = max(matched, key=lambda c: _pole_headline(c)[0])
+        if slowest is None or _pole_headline(top)[0] > _pole_headline(slowest)[0]:
             slowest = top
     if slowest is None:
         return None
@@ -8426,12 +8432,15 @@ def render(doc: dict[str, Any], logs: dict[str, str] | None = None,
             # aggregates. Say that, name the slowest measured upstream member, and (below)
             # render NO drill and NO "optimize this step" prompt for the sink itself.
             _ag_slow = _clean_label(_check_name(_agg["slowest"]))
-            # Render the member's EFFECTIVE floor (`_eff_floor_s`, the bimodal-aware
-            # `max(p50, high_p50_s)`), not the bare p50 — it MUST agree with the selection above
-            # (which now ranks by effective floor) or the sink would name a member `X` yet quote a
-            # duration SMALLER than an unnamed sibling's p50, and would disagree with the slow-mode
-            # header of the very pole its "Where the wait actually is" pointer links to (issue #22).
-            _ag_dur = _clock(_eff_floor_s(_agg["slowest"]))
+            # Render the member's own drilled-pole HEADER duration (`_pole_headline(...)[0]`), not
+            # the bare p50 and not `_eff_floor_s` — it MUST agree with the selection above (which
+            # ranks by the same header value) or the sink would name a member `X` yet quote a
+            # duration SMALLER than an unnamed sibling, and it MUST equal the header of the very
+            # pole its "Where the wait actually is" pointer links to. `_eff_floor_s` (always the
+            # high mode) satisfies neither on a member whose median already sits IN the slow
+            # cluster: there `_pole_headline` shows the p50 the linked pole's header shows, while
+            # `_eff_floor_s` would over-quote the high mode above it (issue #22 / greptile P1).
+            _ag_dur = _clock(_pole_headline(_agg["slowest"])[0])
             # BOTH caveats compose — they are independent, and neither may silently drop the
             # other. "Runs no work of its own" rests on the measured P50 plus the `needs:`
             # structure whenever no per-step data was captured, so that basis is disclosed on
@@ -8492,15 +8501,31 @@ def render(doc: dict[str, Any], logs: dict[str, str] | None = None,
                 # mirroring `_floor_note`). If a DIFFERENT check's effective (bimodal slow-mode)
                 # floor exceeds `floor_name`'s p50, THAT check — not `floor_name` — sets the
                 # wall-clock floor on slow-mode PRs; name it, rather than silently crediting the
-                # p50-slowest sibling with a floor a slower bimodal sibling actually sets. The
-                # named ceiling is ALSO disclosed by this pole's `_floor_note`, so this only
-                # corrects the role line's prose; it adds no new spine-disclosure obligation.
+                # p50-slowest sibling with a floor a slower bimodal sibling actually sets.
+                #
+                # `_others` is the FULL concurrent set minus the gate (managed checks INCLUDED),
+                # exactly `_floor_note`'s pool, so `_bf` here is the SAME binding floor
+                # `_floor_note` computes — the two can never name different checks as the cap.
+                #
+                # But FIRE only when that binding floor is FILE-BACKED (greptile P1). The role line
+                # frames the named check as the one to attack ("sets the wall-clock floor on
+                # slow-mode PRs"), so it must be a tunable check the reader can act on — one with a
+                # `workflow_file`. When the true binding floor is a MANAGED/external check (no
+                # `workflow_file`), `_floor_note` owns its disclosure via the dedicated "no
+                # workflow file to speed up here `X`" phrasing (the form
+                # `verify_report._SPINE_FLOOR_NAME_RE` recognizes); crediting it in THIS clause
+                # would mis-frame an untunable check as actionable and — since this clause's
+                # phrasing is NOT one the spine parser reads — name a ceiling the parser can't
+                # confirm is disclosed. Suppressing the clause there keeps the managed case
+                # byte-identical to `main` and makes the "already disclosed by `_floor_note`"
+                # guarantee hold for every check this clause names.
                 _others = [c for c in floor_pool
                            if _clean_label(_check_name(c)) != gate_check]
                 _bf = (_binding_floor(_others, p.get("_cooccur"),
                                       int(p.get("_gating_n") or 0))
                        if (not floor_lowered and _others) else None)
-                if (_bf is not None and _clean_label(_check_name(_bf)) != floor_name
+                if (_bf is not None and str(_bf.get("workflow_file") or "")
+                        and _clean_label(_check_name(_bf)) != floor_name
                         and _eff_floor_s(_bf) > (slowest_p50 or 0.0) + 0.5):
                     _bf_name = _clean_label(_check_name(_bf))
                     _sets_floor = (f"; but `{_bf_name}`'s bimodal slow mode "

--- a/skills/ci-speedup/scripts/blocking_path.py
+++ b/skills/ci-speedup/scripts/blocking_path.py
@@ -8559,7 +8559,18 @@ def render(doc: dict[str, Any], logs: dict[str, str] | None = None,
                                    f"(~{_clock(_bf_hd)}) runs longer, so it — not "
                                    f"`{floor_name}` — sets the wall-clock floor on slow-mode PRs")
                 elif _bf_outfloors:
-                    _sets_floor = ""   # managed check out-floors floor_name; _floor_note names it
+                    # Managed/external `_bf` (no `workflow_file`) out-floors `floor_name`. Don't
+                    # credit `floor_name`, and don't frame the untunable check as attackable — but
+                    # DO name it as the real cap, using `_floor_note`'s "no workflow file to speed
+                    # up here `X`" phrasing (the form `verify_report._SPINE_FLOOR_NAME_RE` reads).
+                    # This DISCLOSES the managed ceiling on the spine even when the gate pole's own
+                    # `_floor_note` is suppressed (`binding_s >= pole_p`, which always holds when
+                    # this clause fires), closing the managed-floor disclosure gap rather than
+                    # leaving the capping check named nowhere.
+                    _bf_name = _clean_label(_check_name(_bf))
+                    _sets_floor = (f"; but a concurrent check with no workflow file to speed up "
+                                   f"here, `{_bf_name}` (~{_clock(_bf_hd)}), runs longer — so it, "
+                                   f"not `{floor_name}`, caps the wall-clock floor on slow-mode PRs")
                 else:
                     _sets_floor = "" if floor_lowered else ", which sets the wall-clock floor"
                 role = (f"**The check most PRs gate on.** A typical PR waits on this most "

--- a/skills/ci-speedup/scripts/blocking_path.py
+++ b/skills/ci-speedup/scripts/blocking_path.py
@@ -8498,39 +8498,41 @@ def render(doc: dict[str, Any], logs: dict[str, str] | None = None,
                 # wall-clock floor (`not floor_lowered`), consult `_binding_floor` — the SAME
                 # bimodal-aware `_eff_floor_s` selector every per-pole floor path and the
                 # spine-drop verifier use — over the concurrent set (the pole itself excluded,
-                # mirroring `_floor_note`). If a DIFFERENT check's effective (bimodal slow-mode)
-                # floor exceeds `floor_name`'s p50, THAT check — not `floor_name` — sets the
-                # wall-clock floor on slow-mode PRs; name it, rather than silently crediting the
-                # p50-slowest sibling with a floor a slower bimodal sibling actually sets.
+                # mirroring `_floor_note`). `_others` is the FULL concurrent set minus the gate
+                # (managed checks INCLUDED), exactly `_floor_note`'s pool, so `_bf` is the SAME
+                # binding floor `_floor_note` computes — the two can never name different checks as
+                # the cap.
                 #
-                # `_others` is the FULL concurrent set minus the gate (managed checks INCLUDED),
-                # exactly `_floor_note`'s pool, so `_bf` here is the SAME binding floor
-                # `_floor_note` computes — the two can never name different checks as the cap.
-                #
-                # But FIRE only when that binding floor is FILE-BACKED (greptile P1). The role line
-                # frames the named check as the one to attack ("sets the wall-clock floor on
-                # slow-mode PRs"), so it must be a tunable check the reader can act on — one with a
-                # `workflow_file`. When the true binding floor is a MANAGED/external check (no
-                # `workflow_file`), `_floor_note` owns its disclosure via the dedicated "no
-                # workflow file to speed up here `X`" phrasing (the form
-                # `verify_report._SPINE_FLOOR_NAME_RE` recognizes); crediting it in THIS clause
-                # would mis-frame an untunable check as actionable and — since this clause's
-                # phrasing is NOT one the spine parser reads — name a ceiling the parser can't
-                # confirm is disclosed. Suppressing the clause there keeps the managed case
-                # byte-identical to `main` and makes the "already disclosed by `_floor_note`"
-                # guarantee hold for every check this clause names.
+                # Three outcomes, so `floor_name` is NEVER credited with a floor a slower sibling
+                # actually sets (greptile: "managed floor is misattributed"):
+                #   (a) `_bf` out-floors `floor_name` AND is FILE-BACKED → name it as the tunable
+                #       ceiling to attack ("sets the wall-clock floor on slow-mode PRs"). It is a
+                #       `workflow_file`-backed check, so `_floor_note` discloses it in a form the
+                #       spine parser (`verify_report._SPINE_FLOOR_NAME_RE`) reads.
+                #   (b) `_bf` out-floors `floor_name` but is MANAGED/external (no `workflow_file`)
+                #       → DROP the floor claim entirely (`_sets_floor = ""`). We must not credit
+                #       `floor_name` (a slower check genuinely caps the merge), but must not frame
+                #       an untunable managed check as attackable here either — `_floor_note` owns
+                #       the managed cap's disclosure via its dedicated "no workflow file to speed up
+                #       here `X`" phrasing. So the role line just names the slowest TYPICAL check
+                #       and stays silent on the floor, which `_floor_note` sets straight.
+                #   (c) nothing out-floors `floor_name` → it genuinely sets the floor; keep the
+                #       plain ", which sets the wall-clock floor" (as before).
                 _others = [c for c in floor_pool
                            if _clean_label(_check_name(c)) != gate_check]
                 _bf = (_binding_floor(_others, p.get("_cooccur"),
                                       int(p.get("_gating_n") or 0))
                        if (not floor_lowered and _others) else None)
-                if (_bf is not None and str(_bf.get("workflow_file") or "")
-                        and _clean_label(_check_name(_bf)) != floor_name
-                        and _eff_floor_s(_bf) > (slowest_p50 or 0.0) + 0.5):
+                _bf_outfloors = (_bf is not None
+                                 and _clean_label(_check_name(_bf)) != floor_name
+                                 and _eff_floor_s(_bf) > (slowest_p50 or 0.0) + 0.5)
+                if _bf_outfloors and str(_bf.get("workflow_file") or ""):
                     _bf_name = _clean_label(_check_name(_bf))
                     _sets_floor = (f"; but `{_bf_name}`'s bimodal slow mode "
                                    f"(~{_clock(_eff_floor_s(_bf))}) runs longer, so it — not "
                                    f"`{floor_name}` — sets the wall-clock floor on slow-mode PRs")
+                elif _bf_outfloors:
+                    _sets_floor = ""   # managed check out-floors floor_name; _floor_note names it
                 else:
                     _sets_floor = "" if floor_lowered else ", which sets the wall-clock floor"
                 role = (f"**The check most PRs gate on.** A typical PR waits on this most "

--- a/skills/ci-speedup/scripts/blocking_path.py
+++ b/skills/ci-speedup/scripts/blocking_path.py
@@ -8495,41 +8495,57 @@ def render(doc: dict[str, Any], logs: dict[str, str] | None = None,
                 # the effective floor would desync the headline from its stamp (which is NOT
                 # bimodal-aware), so we keep the p50 pick and instead DISCLOSE the true ceiling
                 # beside it: when we would otherwise credit `floor_name` with setting the
-                # wall-clock floor (`not floor_lowered`), consult `_binding_floor` — the SAME
-                # bimodal-aware `_eff_floor_s` selector every per-pole floor path and the
-                # spine-drop verifier use — over the concurrent set (the pole itself excluded,
-                # mirroring `_floor_note`). `_others` is the FULL concurrent set minus the gate
-                # (managed checks INCLUDED), exactly `_floor_note`'s pool, so `_bf` is the SAME
-                # binding floor `_floor_note` computes — the two can never name different checks as
-                # the cap.
+                # wall-clock floor (`not floor_lowered`), consult `_binding_floor` over the
+                # concurrent set (the pole itself excluded, mirroring `_floor_note`). `_others` is
+                # the FULL concurrent set minus the gate (managed checks INCLUDED), exactly
+                # `_floor_note`'s pool, so `_bf` is the SAME binding floor `_floor_note` computes —
+                # the two can never name different checks as the cap.
+                #
+                # Gate AND quote by `_pole_headline(_bf)[0]` (the seconds `_bf`'s OWN drilled-pole
+                # header would show), NOT frac-blind `_eff_floor_s` — the same choice site A makes.
+                # `_pole_headline` returns the slow mode only for a WELL-FORMED bimodal whose median
+                # sits on the fast cluster (`hi and lo and frac and hi > p50*1.15 and p50 <= mid`),
+                # else the p50. So (i) the quoted duration equals `_bf`'s own header (no "names a
+                # check at a time its drill contradicts"), and (ii) a DEGENERATE bimodal (missing
+                # `low_p50_s`/`slow_frac`, or `slow_frac == 0`) can't fire a phantom "slow mode on
+                # ~0% of runs" — `_eff_floor_s` would, reading only `high_p50_s`.
                 #
                 # Three outcomes, so `floor_name` is NEVER credited with a floor a slower sibling
                 # actually sets (greptile: "managed floor is misattributed"):
                 #   (a) `_bf` out-floors `floor_name` AND is FILE-BACKED → name it as the tunable
-                #       ceiling to attack ("sets the wall-clock floor on slow-mode PRs"). It is a
-                #       `workflow_file`-backed check, so `_floor_note` discloses it in a form the
-                #       spine parser (`verify_report._SPINE_FLOOR_NAME_RE`) reads.
+                #       ceiling to attack ("sets the wall-clock floor on slow-mode PRs").
                 #   (b) `_bf` out-floors `floor_name` but is MANAGED/external (no `workflow_file`)
                 #       → DROP the floor claim entirely (`_sets_floor = ""`). We must not credit
                 #       `floor_name` (a slower check genuinely caps the merge), but must not frame
                 #       an untunable managed check as attackable here either — `_floor_note` owns
                 #       the managed cap's disclosure via its dedicated "no workflow file to speed up
-                #       here `X`" phrasing. So the role line just names the slowest TYPICAL check
-                #       and stays silent on the floor, which `_floor_note` sets straight.
+                #       here `X`" phrasing. So the role line names the slowest TYPICAL check and
+                #       stays silent on the floor, which `_floor_note` sets straight.
                 #   (c) nothing out-floors `floor_name` → it genuinely sets the floor; keep the
                 #       plain ", which sets the wall-clock floor" (as before).
+                #
+                # SPINE-DISCLOSURE NOTE (not a disclosure mechanism of its own). This clause's tail
+                # phrasing is NOT one `verify_report._SPINE_FLOOR_NAME_RE` reads, and it adds no new
+                # spine-disclosure obligation: `check_spine_heavy_check_disclosed` keys on each
+                # DRILLED pole's binding floor re-derived from `populations`, independent of this
+                # text. A file-backed `_bf` that must be disclosed there is disclosed by ITS OWN
+                # drilled-pole header (a heavy concurrent check is normally a pole) — NOT by the gate
+                # pole's `_floor_note`, which is suppressed whenever this clause fires (`binding_s >=
+                # pole_p` for the gate). `verify_report` is untouched by this change, so the
+                # obligation set and the satisfaction set are exactly `main`'s.
                 _others = [c for c in floor_pool
                            if _clean_label(_check_name(c)) != gate_check]
                 _bf = (_binding_floor(_others, p.get("_cooccur"),
                                       int(p.get("_gating_n") or 0))
                        if (not floor_lowered and _others) else None)
+                _bf_hd = _pole_headline(_bf)[0] if _bf is not None else 0.0
                 _bf_outfloors = (_bf is not None
                                  and _clean_label(_check_name(_bf)) != floor_name
-                                 and _eff_floor_s(_bf) > (slowest_p50 or 0.0) + 0.5)
+                                 and _bf_hd > (slowest_p50 or 0.0) + 0.5)
                 if _bf_outfloors and str(_bf.get("workflow_file") or ""):
                     _bf_name = _clean_label(_check_name(_bf))
                     _sets_floor = (f"; but `{_bf_name}`'s bimodal slow mode "
-                                   f"(~{_clock(_eff_floor_s(_bf))}) runs longer, so it — not "
+                                   f"(~{_clock(_bf_hd)}) runs longer, so it — not "
                                    f"`{floor_name}` — sets the wall-clock floor on slow-mode PRs")
                 elif _bf_outfloors:
                     _sets_floor = ""   # managed check out-floors floor_name; _floor_note names it

--- a/skills/ci-speedup/tests/test_blocking_path.py
+++ b/skills/ci-speedup/tests/test_blocking_path.py
@@ -5682,6 +5682,39 @@ def test_frequency_gate_role_line_discloses_bimodal_effective_floor():
     assert "`flaky`" in md
 
 
+def test_frequency_gate_role_line_suppresses_disclosure_for_managed_floor():
+    # Issue #22 class, site B — the managed-floor edge (greptile P1). The disclosure clause frames
+    # the named check as the one to ATTACK ("sets the wall-clock floor on slow-mode PRs"), so it
+    # must be a tunable, file-backed check. When the binding floor is a MANAGED/external check (no
+    # `workflow_file`), the clause must NOT fire — `_floor_note` owns the managed floor's
+    # disclosure via its own "no workflow file to speed up here `X`" phrasing (the form the spine
+    # parser reads), and this clause's phrasing is not one the parser recognizes. Same fixture as
+    # the file-backed test, but `flaky` carries NO `workflow_file`.
+    doc = _doc_one_pole()
+    cp = doc["pr_critical_path"]
+    cp["checks"] = [
+        {"name": "tests-web", "p50_s": 255.0,
+         "workflow_file": ".github/workflows/pipeline.yml"},
+        {"name": "heavy", "p50_s": 900.0, "present_on": 20,
+         "workflow_file": ".github/workflows/heavy.yml"},
+        {"name": "flaky", "p50_s": 600.0, "present_on": 20,   # MANAGED: no workflow_file
+         "bimodal": {"low_p50_s": 300.0, "high_p50_s": 1200.0, "slow_frac": 0.4}},
+        {"name": "lint", "p50_s": 100.0, "present_on": 20},
+    ]
+    cp["populations"] = [[0.05, [["heavy", 900.0], ["flaky", 600.0],
+                                 ["tests-web", 255.0], ["lint", 100.0]]]] * 20
+    md = bp.render(doc, {"pipeline": _IMPORT_BOUND_LOG}, {},
+                   {"pipeline": "https://github.com/o/r/actions/runs/1"}, "2026-06-08")
+    role = next(l for l in md.split("\n") if "The check most PRs gate on." in l)
+    # The p50 pick is unchanged; the clause falls back to the plain wording (byte-identical to a
+    # world with no bimodal floor at all — the same as `main` for a managed binding floor).
+    assert "the slowest concurrent check is `heavy` (~15m 00s), which sets the wall-clock floor." \
+        in role
+    # The managed check is NOT credited in the role line (the clause is suppressed).
+    assert "bimodal slow mode" not in role
+    assert "sets the wall-clock floor on slow-mode PRs" not in role
+
+
 def test_headline_floor_excludes_partial_presence_slowest_check():
     # OneSignal/OneSignal-Android-SDK class: the slowest TYPICAL check (`Claude Code Review`,
     # a managed app check at 944.5s) ran on only 12/20 PRs; `build` (619.5s) ran on 20/20.
@@ -7106,9 +7139,11 @@ def test_aggregation_gate_names_upstream_member_by_effective_floor_not_bare_p50(
     # median sits below a faster-median sibling but whose bimodal SLOW mode is the true ceiling
     # went unnamed — the sink pointed the reader at the wrong lever. A second matrix leg,
     # `stable - aarch64-darwin`, has a LOWER blended p50 (300s) than `stable - x86_64-linux`
-    # (355s) but a bimodal high mode (520s) that is the real ceiling of the gate's wait. Both the
-    # WITHIN-matrix `top` pick and the ACROSS-jobs `slowest` pick must rank by `_eff_floor_s`, and
-    # the rendered duration must be that effective floor (8m 40s), not a bare p50.
+    # (355s) but a bimodal high mode (520s) that is the real ceiling of the gate's wait. Its
+    # median (300s) sits on the FAST cluster (<= (180+520)/2 = 350s), so the member's own drilled
+    # HEADER shows the slow mode — both the WITHIN-matrix `top` pick and the ACROSS-jobs `slowest`
+    # pick must rank by that header value (`_pole_headline`, == the 520s slow mode here), and the
+    # rendered duration must be that header time (8m 40s), not a bare p50.
     doc = _agg_gate_doc()
     doc["pr_critical_path"]["checks"].append(
         {"name": "stable - aarch64-darwin", "p50_s": 300.0, "present_on": 20,
@@ -7123,3 +7158,33 @@ def test_aggregation_gate_names_upstream_member_by_effective_floor_not_bare_p50(
     # RED against the pre-fix renderer: it named the p50-slowest leg as the lever, at its p50.
     assert "`stable - x86_64-linux`" not in sec
     assert "5m 55s" not in sec
+
+
+def test_aggregation_gate_pointer_agrees_with_slow_cluster_median_pole_header():
+    # Issue #22 class, site A — the divergence a bare `_eff_floor_s` render (greptile P1) leaves.
+    # When the winning member's MEDIAN already sits IN the slow cluster (a strict majority of runs
+    # slow), its own drilled pole HEADER shows its p50, NOT its bimodal high mode — `_pole_headline`
+    # keeps the p50 there (the median already reflects the slow mode; the high mode would over-state
+    # it). `_eff_floor_s` (always `max(p50, high)`) would quote the high mode, so the aggregation
+    # pointer would name a duration ABOVE the very pole header it links to. The pointer MUST quote
+    # the header value so the two agree.
+    doc = _agg_gate_doc()
+    # p50 500s sits ABOVE the midpoint (300+560)/2 = 430s -> slow-cluster median -> header = p50.
+    _bi = {"low_p50_s": 300.0, "high_p50_s": 560.0, "slow_frac": 0.6}
+    doc["pr_critical_path"]["checks"].append(
+        {"name": "stable - aarch64-darwin", "p50_s": 500.0, "present_on": 20,
+         "workflow_file": _AGG_DEPLOY, "bimodal": _bi})
+    doc["pr_critical_path"]["poles"].append(
+        {"check": "stable - aarch64-darwin", "p50_s": 500.0, "workflow_file": _AGG_DEPLOY,
+         "job": "native", "dominant_step": "cargo build", "dominant_p50_s": 400.0,
+         "bimodal": _bi, "steps": [{"step": "cargo build", "category": "build", "p50_s": 400.0}]})
+    md = bp.render(doc, {}, {}, {}, "2026-07-28T00:00:00Z", {})
+    sec = _pole_section(md, "thank you, build")
+    n = int(re.search(r"## .*Long pole (\d+): .*▸ `stable - aarch64-darwin` - (\d+m \d+s)",
+                      md).group(1))
+    hdr_dur = re.search(r"▸ `stable - aarch64-darwin` - (\d+m \d+s)", md).group(1)
+    assert hdr_dur == "8m 20s"                                    # header shows the p50, not 9m 20s
+    # GREEN: the pointer links the pole and quotes the SAME 8m 20s the header shows.
+    assert f"[Long pole {n}](#pole-{n}) drills `stable - aarch64-darwin` (8m 20s)" in sec
+    # RED against a bare `_eff_floor_s` render: it quoted the 9m 20s high mode, above the header.
+    assert "9m 20s" not in sec

--- a/skills/ci-speedup/tests/test_blocking_path.py
+++ b/skills/ci-speedup/tests/test_blocking_path.py
@@ -5755,6 +5755,49 @@ def test_frequency_gate_role_line_ignores_degenerate_bimodal_floor():
         assert "20m 00s" not in role, (_bad_bimodal, role)
 
 
+def test_frequency_gate_role_line_never_calls_a_unimodal_floor_bimodal():
+    # Issue #22 class, site B — the UNIMODAL out-flooring edge (silent-failure-hunter). The
+    # clause's wording asserts "bimodal slow mode ... on slow-mode PRs", so it must fire ONLY when
+    # `_bf` is a genuine fast-median bimodal (the `_pole_headline` override fired). A heavy
+    # path-conditional/minority check drawn from the full floor pool (the lightdash `E2E` class)
+    # can be the pole's BINDING FLOOR yet be UNIMODAL: its blended p50 out-ranks the slowest
+    # TYPICAL check, but it has no slow MODE and it doesn't run on a typical PR. The role line must
+    # credit the slowest typical check (`base`) with the typical wall-clock floor and NOT print a
+    # phantom "bimodal slow mode" for the unimodal `E2E` (whose own gating is disclosed on its
+    # drilled pole). `E2E`'s per-PR values sit BELOW the gate on the gate's own gating PRs (so the
+    # gate wins them and `E2E` co-occurs as a floor candidate) while its stamped p50 is high.
+    doc = _doc_one_pole()
+    cp = doc["pr_critical_path"]
+    cp["checks"] = [
+        {"name": "tests-web", "p50_s": 255.0, "present_on": 20,
+         "workflow_file": ".github/workflows/pipeline.yml"},
+        {"name": "base", "p50_s": 400.0, "present_on": 20,
+         "workflow_file": ".github/workflows/base.yml"},
+        {"name": "E2E", "p50_s": 1000.0, "present_on": 6,          # UNIMODAL, minority-presence
+         "workflow_file": ".github/workflows/e2e.yml"},
+        {"name": "lint", "p50_s": 100.0, "present_on": 20},
+    ]
+    pops = []
+    for i in range(20):
+        if i < 6:   # tests-web (the gate) wins; E2E present but LOW-valued here → co-occurs
+            pops.append([0.05, [["tests-web", 700.0], ["base", 400.0],
+                                ["E2E", 300.0], ["lint", 100.0]]])
+        else:       # base wins; E2E absent → E2E is a global minority (6/20)
+            pops.append([0.05, [["base", 450.0], ["tests-web", 255.0], ["lint", 100.0]]])
+    cp["populations"] = pops
+    md = bp.render(doc, {"pipeline": _IMPORT_BOUND_LOG}, {},
+                   {"pipeline": "https://github.com/o/r/actions/runs/1"}, "2026-06-08")
+    role = next(l for l in md.split("\n") if "The check most PRs gate on." in l)
+    # `base` (the slowest TYPICAL check) genuinely sets the typical floor; plain phrasing stands.
+    assert "the slowest concurrent check is `base` (~6m 40s), which sets the wall-clock floor." \
+        in role, role
+    # RED against the pre-guard renderer: it printed "`E2E`'s bimodal slow mode (~16m 40s) ... on
+    # slow-mode PRs" — false on both counts (`E2E` is unimodal and runs on a minority, not a "slow
+    # mode"). The clause must not name `E2E` at all here.
+    assert "bimodal slow mode" not in role, role
+    assert "`E2E`" not in role, role
+
+
 def test_headline_floor_excludes_partial_presence_slowest_check():
     # OneSignal/OneSignal-Android-SDK class: the slowest TYPICAL check (`Claude Code Review`,
     # a managed app check at 944.5s) ran on only 12/20 PRs; `build` (619.5s) ran on 20/20.
@@ -7228,3 +7271,28 @@ def test_aggregation_gate_pointer_agrees_with_slow_cluster_median_pole_header():
     assert f"[Long pole {n}](#pole-{n}) drills `stable - aarch64-darwin` (8m 20s)" in sec
     # RED against a bare `_eff_floor_s` render: it quoted the 9m 20s high mode, above the header.
     assert "9m 20s" not in sec
+
+
+def test_aggregation_gate_cross_job_pick_ranks_by_header_not_p50():
+    # Issue #22 class, site A — guards the ACROSS-JOBS `slowest` comparison (`_agg_gate_shape`
+    # second `max`) INDEPENDENTLY of the within-matrix `top` pick (pr-test-analyzer). A non-matrix
+    # `build` job (p50 550s, no bimodal → header 550s) competes across jobs with a matrix leg
+    # `stable - x86_64-linux` (p50 300s, fast-median bimodal high 900s → header 900s). By bare p50
+    # `build` (550) out-ranks the leg (300) and would be named the lever at 9m 10s; by header the
+    # leg (900) is the true ceiling and must be named at 15m 00s. A regression that dropped
+    # `_pole_headline` from only the cross-job leg would be invisible to the other Site A tests
+    # (there the bimodal winner also wins on bare p50), so this fixture is the distinguishing case.
+    doc = _agg_gate_doc()
+    for c in doc["pr_critical_path"]["checks"]:
+        if c["name"] == "build":
+            c["p50_s"] = 550.0
+        if c["name"] == "stable - x86_64-linux":
+            c["p50_s"] = 300.0
+            c["bimodal"] = {"low_p50_s": 180.0, "high_p50_s": 900.0, "slow_frac": 0.4}
+    md = bp.render(doc, {}, {}, {}, "2026-07-28T00:00:00Z", {})
+    sec = _pole_section(md, "thank you, build")
+    # GREEN: the header-ranked cross-job winner is named at its slow-mode time.
+    assert "slowest measured member is `stable - x86_64-linux` (~15m 00s)" in sec, sec
+    # RED against a bare-p50 cross-job comparison: it named `build` at its 9m 10s p50.
+    assert "`build`" not in sec, sec
+    assert "9m 10s" not in sec, sec

--- a/skills/ci-speedup/tests/test_blocking_path.py
+++ b/skills/ci-speedup/tests/test_blocking_path.py
@@ -5720,6 +5720,41 @@ def test_frequency_gate_role_line_managed_floor_drops_credit_not_misattributed()
     assert "the slowest concurrent check is `heavy` (~15m 00s)." in role
 
 
+def test_frequency_gate_role_line_ignores_degenerate_bimodal_floor():
+    # Issue #22 class, site B — the degenerate-bimodal edge. The clause gates + quotes by
+    # `_pole_headline(_bf)[0]` (the seconds `_bf`'s own drilled header shows), NOT frac-blind
+    # `_eff_floor_s` (which reads only `high_p50_s`). A malformed bimodal dict — `slow_frac == 0`,
+    # or missing `slow_frac`/`low_p50_s` — has no genuine slow MODE: `_pole_headline` returns the
+    # p50, so the clause must NOT emit a phantom "slow mode on ~0% of runs" disclosure. `flaky`
+    # here is file-backed with a degenerate bimodal (high 1200s but no honest slow mode); its p50
+    # (600s) is below `heavy`'s (900s), so it does not out-floor `heavy` on any honest reading.
+    for _bad_bimodal in ({"low_p50_s": 300.0, "high_p50_s": 1200.0, "slow_frac": 0.0},
+                         {"low_p50_s": 300.0, "high_p50_s": 1200.0},          # missing slow_frac
+                         {"high_p50_s": 1200.0, "slow_frac": 0.4}):           # missing low_p50_s
+        doc = _doc_one_pole()
+        cp = doc["pr_critical_path"]
+        cp["checks"] = [
+            {"name": "tests-web", "p50_s": 255.0,
+             "workflow_file": ".github/workflows/pipeline.yml"},
+            {"name": "heavy", "p50_s": 900.0, "present_on": 20,
+             "workflow_file": ".github/workflows/heavy.yml"},
+            {"name": "flaky", "p50_s": 600.0, "present_on": 20,
+             "workflow_file": ".github/workflows/flaky.yml", "bimodal": _bad_bimodal},
+            {"name": "lint", "p50_s": 100.0, "present_on": 20},
+        ]
+        cp["populations"] = [[0.05, [["heavy", 900.0], ["flaky", 600.0],
+                                     ["tests-web", 255.0], ["lint", 100.0]]]] * 20
+        md = bp.render(doc, {"pipeline": _IMPORT_BOUND_LOG}, {},
+                       {"pipeline": "https://github.com/o/r/actions/runs/1"}, "2026-06-08")
+        role = next(l for l in md.split("\n") if "The check most PRs gate on." in l)
+        # `heavy` genuinely sets the floor (nothing out-floors it once the degenerate bimodal is
+        # discounted); the plain phrasing stands, and no phantom "20m slow mode" is emitted.
+        assert "the slowest concurrent check is `heavy` (~15m 00s), which sets the wall-clock " \
+            "floor." in role, (_bad_bimodal, role)
+        assert "bimodal slow mode" not in role, (_bad_bimodal, role)
+        assert "20m 00s" not in role, (_bad_bimodal, role)
+
+
 def test_headline_floor_excludes_partial_presence_slowest_check():
     # OneSignal/OneSignal-Android-SDK class: the slowest TYPICAL check (`Claude Code Review`,
     # a managed app check at 944.5s) ran on only 12/20 PRs; `build` (619.5s) ran on 20/20.

--- a/skills/ci-speedup/tests/test_blocking_path.py
+++ b/skills/ci-speedup/tests/test_blocking_path.py
@@ -5682,14 +5682,16 @@ def test_frequency_gate_role_line_discloses_bimodal_effective_floor():
     assert "`flaky`" in md
 
 
-def test_frequency_gate_role_line_suppresses_disclosure_for_managed_floor():
-    # Issue #22 class, site B — the managed-floor edge (greptile P1). The disclosure clause frames
-    # the named check as the one to ATTACK ("sets the wall-clock floor on slow-mode PRs"), so it
-    # must be a tunable, file-backed check. When the binding floor is a MANAGED/external check (no
-    # `workflow_file`), the clause must NOT fire — `_floor_note` owns the managed floor's
-    # disclosure via its own "no workflow file to speed up here `X`" phrasing (the form the spine
-    # parser reads), and this clause's phrasing is not one the parser recognizes. Same fixture as
-    # the file-backed test, but `flaky` carries NO `workflow_file`.
+def test_frequency_gate_role_line_managed_floor_drops_credit_not_misattributed():
+    # Issue #22 class, site B — the managed-floor edge (greptile). The disclosure clause frames the
+    # named check as the one to ATTACK ("sets the wall-clock floor on slow-mode PRs"), so it must be
+    # a tunable, file-backed check. When the binding floor is a MANAGED/external check (no
+    # `workflow_file`) that out-floors `floor_name`, the role line must NOT name it as attackable —
+    # but it must ALSO NOT credit `floor_name` (the lower p50 sibling) with setting the wall-clock
+    # floor, because the managed check genuinely caps the merge higher. So the role line names the
+    # slowest TYPICAL check and stays SILENT on the floor; `_floor_note` sets it straight via its own
+    # "no workflow file to speed up here `X`" phrasing (the form the spine parser reads). Same fixture
+    # as the file-backed test, but `flaky` carries NO `workflow_file`.
     doc = _doc_one_pole()
     cp = doc["pr_critical_path"]
     cp["checks"] = [
@@ -5706,13 +5708,16 @@ def test_frequency_gate_role_line_suppresses_disclosure_for_managed_floor():
     md = bp.render(doc, {"pipeline": _IMPORT_BOUND_LOG}, {},
                    {"pipeline": "https://github.com/o/r/actions/runs/1"}, "2026-06-08")
     role = next(l for l in md.split("\n") if "The check most PRs gate on." in l)
-    # The p50 pick is unchanged; the clause falls back to the plain wording (byte-identical to a
-    # world with no bimodal floor at all — the same as `main` for a managed binding floor).
-    assert "the slowest concurrent check is `heavy` (~15m 00s), which sets the wall-clock floor." \
-        in role
-    # The managed check is NOT credited in the role line (the clause is suppressed).
+    # `heavy` is still named the slowest concurrent (typical) check — the stamp-consistent p50 pick.
+    assert "the slowest concurrent check is `heavy` (~15m 00s)" in role
+    # But `heavy` is NOT credited with setting the floor (the managed `flaky` out-floors it), and
+    # the managed check is NOT framed as attackable here. The role line stays SILENT on the floor.
+    # (Spine disclosure of a managed binding floor is `_floor_note`'s responsibility when it renders
+    # — the pre-existing Class A #6 behavior, unchanged and out of this role-line clause's scope.)
+    assert "which sets the wall-clock floor" not in role
     assert "bimodal slow mode" not in role
-    assert "sets the wall-clock floor on slow-mode PRs" not in role
+    # The role line ends cleanly after the p50 pick (no dangling connective, no floor claim).
+    assert "the slowest concurrent check is `heavy` (~15m 00s)." in role
 
 
 def test_headline_floor_excludes_partial_presence_slowest_check():

--- a/skills/ci-speedup/tests/test_blocking_path.py
+++ b/skills/ci-speedup/tests/test_blocking_path.py
@@ -5682,16 +5682,18 @@ def test_frequency_gate_role_line_discloses_bimodal_effective_floor():
     assert "`flaky`" in md
 
 
-def test_frequency_gate_role_line_managed_floor_drops_credit_not_misattributed():
-    # Issue #22 class, site B — the managed-floor edge (greptile). The disclosure clause frames the
-    # named check as the one to ATTACK ("sets the wall-clock floor on slow-mode PRs"), so it must be
-    # a tunable, file-backed check. When the binding floor is a MANAGED/external check (no
-    # `workflow_file`) that out-floors `floor_name`, the role line must NOT name it as attackable —
-    # but it must ALSO NOT credit `floor_name` (the lower p50 sibling) with setting the wall-clock
-    # floor, because the managed check genuinely caps the merge higher. So the role line names the
-    # slowest TYPICAL check and stays SILENT on the floor; `_floor_note` sets it straight via its own
-    # "no workflow file to speed up here `X`" phrasing (the form the spine parser reads). Same fixture
-    # as the file-backed test, but `flaky` carries NO `workflow_file`.
+def test_frequency_gate_role_line_managed_floor_disclosed_not_misattributed():
+    # Issue #22 class, site B — the managed-floor edge (greptile). The file-backed disclosure clause
+    # frames the named check as the one to ATTACK ("sets the wall-clock floor on slow-mode PRs"), so
+    # it must be a tunable, file-backed check. When the binding floor is a MANAGED/external check (no
+    # `workflow_file`) that out-floors `floor_name`, the role line must (i) NOT credit `floor_name`
+    # (the lower p50 sibling) with setting the floor, (ii) NOT frame the untunable managed check as
+    # attackable, yet (iii) still NAME the managed check as the real cap so it isn't disclosed
+    # nowhere — using the "no workflow file to speed up here `X`" phrasing, which is BOTH honest
+    # about untunability AND the form `verify_report._SPINE_FLOOR_NAME_RE` reads (so the managed cap
+    # lands in the spine-disclosed set even when the gate pole's own `_floor_note` is suppressed
+    # because `binding_s >= pole_p`). Same fixture as the file-backed test, but `flaky` carries NO
+    # `workflow_file`.
     doc = _doc_one_pole()
     cp = doc["pr_critical_path"]
     cp["checks"] = [
@@ -5710,14 +5712,16 @@ def test_frequency_gate_role_line_managed_floor_drops_credit_not_misattributed()
     role = next(l for l in md.split("\n") if "The check most PRs gate on." in l)
     # `heavy` is still named the slowest concurrent (typical) check — the stamp-consistent p50 pick.
     assert "the slowest concurrent check is `heavy` (~15m 00s)" in role
-    # But `heavy` is NOT credited with setting the floor (the managed `flaky` out-floors it), and
-    # the managed check is NOT framed as attackable here. The role line stays SILENT on the floor.
-    # (Spine disclosure of a managed binding floor is `_floor_note`'s responsibility when it renders
-    # — the pre-existing Class A #6 behavior, unchanged and out of this role-line clause's scope.)
+    # `heavy` is NOT credited with setting the floor, and the managed check is NOT framed as tunable.
     assert "which sets the wall-clock floor" not in role
     assert "bimodal slow mode" not in role
-    # The role line ends cleanly after the p50 pick (no dangling connective, no floor claim).
-    assert "the slowest concurrent check is `heavy` (~15m 00s)." in role
+    # The managed `flaky` IS named as the real cap, with the untunable "no workflow file" framing.
+    assert "no workflow file to speed up here, `flaky` (~20m 00s)" in role
+    assert "caps the wall-clock floor on slow-mode PRs" in role
+    # And that phrasing is the form the spine parser reads, so the managed cap is disclosed on the
+    # spine (not dropped) — the managed-floor disclosure gap is fully closed.
+    import verify_report as _vr
+    assert "flaky" in {_n for _n in _vr._spine_disclosed_names(md)}
 
 
 def test_frequency_gate_role_line_ignores_degenerate_bimodal_floor():

--- a/skills/ci-speedup/tests/test_blocking_path.py
+++ b/skills/ci-speedup/tests/test_blocking_path.py
@@ -5632,6 +5632,56 @@ def test_headline_floor_is_slowest_check_not_the_frequency_gate():
     assert "(the gate)" not in toc_rows[0], toc_rows[0]
 
 
+def test_frequency_gate_role_line_discloses_bimodal_effective_floor():
+    # Issue #22 class, site B. The frequency-gate pole's role line ("**The check most PRs gate
+    # on.** … the slowest concurrent check is `X`, which sets the wall-clock floor") named `X`
+    # from `src[0]` — the p50-slowest TYPICAL check — and credited it with setting the wall-clock
+    # floor. But `src[0]`/`floor_name` is STAMP-BOUND to the data layer's p50-based
+    # `critical_path_check`, so it must NOT be re-ranked here. Instead, when a DIFFERENT concurrent
+    # check's bimodal SLOW mode floors the merge higher, the role line must disclose that true
+    # ceiling beside the p50 pick rather than silently crediting `floor_name`.
+    #
+    # `tests-web` (255s) is the frequency gate; `heavy` (900s, on 20/20) is the p50-slowest typical
+    # check = `floor_name` = the stamp; `flaky` (blended p50 600s, on 20/20) is bimodal with a
+    # 1200s slow mode — the real effective floor (20m), above `heavy`'s 15m.
+    doc = _doc_one_pole()
+    cp = doc["pr_critical_path"]
+    cp["checks"] = [
+        {"name": "tests-web", "p50_s": 255.0,
+         "workflow_file": ".github/workflows/pipeline.yml"},
+        {"name": "heavy", "p50_s": 900.0, "present_on": 20,
+         "workflow_file": ".github/workflows/heavy.yml"},
+        {"name": "flaky", "p50_s": 600.0, "present_on": 20,
+         "workflow_file": ".github/workflows/flaky.yml",
+         "bimodal": {"low_p50_s": 300.0, "high_p50_s": 1200.0, "slow_frac": 0.4}},
+        {"name": "lint", "p50_s": 100.0, "present_on": 20},
+    ]
+    # 20 per-PR populations, all four checks present on every PR (so `flaky` co-occurs on a
+    # majority of `tests-web`'s gating PRs and is its binding floor), `tests-web` still the
+    # most-gating.
+    cp["populations"] = [[0.05, [["heavy", 900.0], ["flaky", 600.0],
+                                 ["tests-web", 255.0], ["lint", 100.0]]]] * 20
+    md = bp.render(doc, {"pipeline": _IMPORT_BOUND_LOG}, {},
+                   {"pipeline": "https://github.com/o/r/actions/runs/1"}, "2026-06-08")
+    role = next(l for l in md.split("\n") if "The check most PRs gate on." in l)
+    # The p50 pick is unchanged (stamp-safe): `heavy` at its 15m p50 is still named the slowest
+    # concurrent check.
+    assert "the slowest concurrent check is `heavy` (~15m 00s)" in role
+    # GREEN: the bimodal true ceiling is disclosed beside it (em dashes normalized to hyphens by
+    # the report-wide strip). `flaky`'s 20m slow mode sets the floor, not `heavy`.
+    assert "but `flaky`'s bimodal slow mode (~20m 00s) runs longer, so it" in role
+    assert "sets the wall-clock floor on slow-mode PRs" in role
+    # RED against the pre-fix renderer: it credited `heavy` with setting the wall-clock floor and
+    # named `flaky` nowhere in the role line.
+    assert "(~15m 00s), which sets the wall-clock floor." not in role
+    # The stamp bind still holds: the headline names `heavy` (= critical_path_check), unchanged.
+    head = next(l for l in md.split("\n") if "until all checks finish" in l)
+    assert "the slowest check a typical PR waits on is `heavy`" in head
+    # And the effective floor is disclosed on the spine too (the pole's floor note names `flaky`),
+    # so this correction adds no silent spine drop.
+    assert "`flaky`" in md
+
+
 def test_headline_floor_excludes_partial_presence_slowest_check():
     # OneSignal/OneSignal-Android-SDK class: the slowest TYPICAL check (`Claude Code Review`,
     # a managed app check at 944.5s) ran on only 12/20 PRs; `build` (619.5s) ran on 20/20.
@@ -7048,3 +7098,28 @@ def test_aggregation_gate_pointer_links_the_upstream_members_own_pole():
     n = int(re.search(r"## .*Long pole (\d+): .*▸ `stable - x86_64-linux`", md).group(1))
     assert f"**➡️ Where the wait actually is:** [Long pole {n}](#pole-{n}) drills " \
            f"`stable - x86_64-linux` (5m 55s)" in sec
+
+
+def test_aggregation_gate_names_upstream_member_by_effective_floor_not_bare_p50():
+    # Issue #22 class, site A. The success-sink names its slowest measured `needs:` upstream
+    # member as THE lever. It ranked candidates by BARE p50, so a matrix leg whose blended
+    # median sits below a faster-median sibling but whose bimodal SLOW mode is the true ceiling
+    # went unnamed — the sink pointed the reader at the wrong lever. A second matrix leg,
+    # `stable - aarch64-darwin`, has a LOWER blended p50 (300s) than `stable - x86_64-linux`
+    # (355s) but a bimodal high mode (520s) that is the real ceiling of the gate's wait. Both the
+    # WITHIN-matrix `top` pick and the ACROSS-jobs `slowest` pick must rank by `_eff_floor_s`, and
+    # the rendered duration must be that effective floor (8m 40s), not a bare p50.
+    doc = _agg_gate_doc()
+    doc["pr_critical_path"]["checks"].append(
+        {"name": "stable - aarch64-darwin", "p50_s": 300.0, "present_on": 20,
+         "workflow_file": _AGG_DEPLOY,
+         "bimodal": {"low_p50_s": 180.0, "high_p50_s": 520.0, "slow_frac": 0.4}})
+    md = bp.render(doc, {}, {}, {}, "2026-07-28T00:00:00Z", {})
+    sec = _pole_section(md, "thank you, build")
+    # GREEN: the effective-floor winner is named at its slow-mode time.
+    assert "`stable - aarch64-darwin` (~8m 40s)" in sec
+    assert "**➡️ Where the wait actually is:**" in sec
+    assert "`stable - aarch64-darwin` (8m 40s)" in sec  # the pointer agrees
+    # RED against the pre-fix renderer: it named the p50-slowest leg as the lever, at its p50.
+    assert "`stable - x86_64-linux`" not in sec
+    assert "5m 55s" not in sec


### PR DESCRIPTION
Follow-up to #22 (merged as `8b134ce`). #22 fixed a below-gate role line that ranked its floor by bare blended `p50` instead of the **effective floor** `_eff_floor_s = max(p50, bimodal high_p50_s)` — a bimodal sibling's slow mode can be the true ceiling even when its blended median sits below a faster-median sibling. #22's floor-semantics audit flagged **two remaining bare-`p50` floor-ranking sites**; this PR fixes both.

## Site A — success-aggregation-gate upstream pick (`_agg_gate_shape`, `blocking_path.py`)

**Root cause.** The aggregation-gate ("`needs:`-everything success sink") pole names its slowest measured `needs:` upstream member as *the lever*, and its "➡️ Where the wait actually is" pointer sends the reader there. Two `max()` picks — **within** a matrix job's legs (`top`) and **across** jobs (`slowest`) — both ranked by bare `p50_s`. A matrix leg whose **bimodal slow mode is the true ceiling** but whose blended `p50` sits below a faster-median sibling was never named, so the sink pointed at the wrong lever — at a duration *smaller* than the slow-mode header of the very pole its pointer links to.

**Fix (rank + render by the member's own drilled-pole HEADER duration, `_pole_headline`).** Both picks now rank by — and the pointer renders — `_pole_headline(member)[0]`, the exact bimodal-aware seconds the member's own drilled pole header shows. So the sink, its pointer, and the linked pole's header agree in **every** case. `_pole_headline` returns the slow mode when the member's median sits on the fast cluster (the #22 case: `p50 <= (lo+hi)/2`), but keeps the p50 when the median already sits IN the slow cluster — exactly where a bare `_eff_floor_s = max(p50, high)` render would quote a duration *above* the linked pole's header (greptile P1: "aggregation duration contradicts pole headline"). The pick feeds **prose + the pointer** (the sink renders no drill of its own), so this is a naming/ordering correction with no verifier interaction (`check_aggregation_gate_poles_never_prescribe` binds the *presence* of the upstream pointer, not which member it names).

## Site B — frequency-gate role line "sets the wall-clock floor" (STAMP-BOUND)

The role line **"The check most PRs gate on.** … the slowest concurrent check is `X`, which sets the wall-clock floor"** names `X` = `floor_name` = `src[0]`, the p50-slowest **typical** check.

**Why the "obvious" joint re-rank is unsafe (proven, not assumed).** `floor_name`/`slowest_dur` are **stamp-bound**: `verify_report.check_headline_slowest_matches_stamp` requires the headline to name the data layer's `critical_path_check`, which `collect_runs` computes as `pr_checks_tuple[0]` — the **p50** present-first winner, *not* bimodal-aware. Re-ranking the render pick alone would make the headline name a different check than its stamp and **fail the verifier**. Moving "both together" would mean re-ranking the data-layer stamp on the measurement spine — which would change `critical_path_check` on every report and re-derive the **frozen** committed example artifacts (`examples/microsoft-playwright` carries this exact clause). Both are prohibited. **A consistent joint re-rank is genuinely unsafe.**

**Path taken (the task's honest fallback).** Keep the stamp-consistent `p50` pick; **add the effective-floor disclosure beside it**. When a *different* **file-backed** concurrent check's effective (bimodal slow-mode) floor exceeds `floor_name`'s p50, the role line now names that check explicitly as the one that sets the wall-clock floor on slow-mode PRs — selected via `_binding_floor`, the **same** `_eff_floor_s` selector the per-pole floor note and the `check_spine_heavy_check_disclosed` spine-drop verifier already use.

`_binding_floor` is computed over the full concurrent set (managed checks included), so it equals `_floor_note`'s own binding — the two can never name different checks as the cap. Three outcomes ensure `floor_name` is **never** credited with a floor a slower sibling actually sets (greptile: *"managed floor escapes spine disclosure" / "managed floor is misattributed"*):

- **(a) file-backed out-floors `floor_name`** → name that tunable check as the one setting the wall-clock floor on slow-mode PRs (the reader is told to attack it).
- **(b) MANAGED/external out-floors `floor_name`** (no workflow file, not tunable) → don't credit `floor_name` and don't frame the managed check as attackable, but **name it as the real cap** with the "no workflow file to speed up here `X`" phrasing — honest about untunability AND the form `verify_report._SPINE_FLOOR_NAME_RE` reads, so the managed ceiling is disclosed on the spine even when the gate pole's own `_floor_note` is suppressed (`binding_s >= pole_p`). Closes the managed-floor disclosure gap rather than leaving the capping check named nowhere.
- **(c) nothing out-floors `floor_name`** → keep the plain "sets the wall-clock floor".

The out-floor test uses `_pole_headline(_bf)[0]` (the seconds the named check's own drilled header shows), not frac-blind `_eff_floor_s` — so the quoted time matches the check's own drill, and a **degenerate** bimodal (missing `low_p50_s`/`slow_frac`) can't fire a phantom "slow mode on ~0% of runs" disclosure.

**Spine disclosure (no new obligation).** This clause's tail phrasing is not one `verify_report._SPINE_FLOOR_NAME_RE` reads, and it adds no new spine-disclosure obligation: `check_spine_heavy_check_disclosed` keys on each *drilled pole's* binding floor re-derived from `populations`, independent of this text. A file-backed ceiling that must be disclosed there is disclosed by **its own drilled-pole header** (a heavy concurrent check is normally a pole), not the gate pole's `_floor_note` (which is suppressed whenever this clause fires). `verify_report.py` is untouched by this PR, so the obligation set and satisfaction set are exactly `main`'s — the frozen committed reports stay valid (full suite green, no re-render required).

- **Rejected alternative:** re-rank `src[0]` / the shared floor computation to `_eff_floor_s` so headline and role line "move together." Rejected because that shared value is stamp-bound to the p50-based `critical_path_check`; it would break `check_headline_slowest_matches_stamp` or force a spine-level stamp change that re-derives frozen artifacts.

## Red-first proof (synthetic fixtures, no real repo data)

The new tests were confirmed **red against the pre-fix renderer** (stashed source), then green:

- `test_aggregation_gate_names_upstream_member_by_effective_floor_not_bare_p50` — a second matrix leg (`stable - aarch64-darwin`, blended p50 300s) with a 520s bimodal slow mode outranks the p50-slowest sibling (`stable - x86_64-linux`, 355s). Pre-fix named x86_64 at 5m 55s; post-fix names aarch64 at its 8m 40s effective floor across the role line and the pointer.
- `test_frequency_gate_role_line_discloses_bimodal_effective_floor` — `heavy` (900s, the p50-slowest typical = the stamp) is still named the slowest concurrent check, but `flaky` (blended 600s, 1200s slow mode, **file-backed**) is now disclosed as the true 20m ceiling. Pre-fix credited `heavy` with "sets the wall-clock floor" and named `flaky` nowhere. The test also asserts the headline still names `heavy` (= `critical_path_check`), proving the stamp bind holds.
- `test_aggregation_gate_pointer_agrees_with_slow_cluster_median_pole_header` (greptile P1) — a slow-cluster-median bimodal member (p50 500s > midpoint 430s, high 560s): the pointer quotes the **8m 20s** the linked pole's header shows, not the 9m 20s a bare `_eff_floor_s` render would. Red against a bare-`_eff_floor_s` render.
- `test_frequency_gate_role_line_managed_floor_disclosed_not_misattributed` (greptile) — same fixture as the file-backed test with `flaky` carrying **no** `workflow_file`: `heavy` is still named the slowest concurrent (typical) check but is NOT credited with the floor; the managed `flaky` is named as the real cap via the "no workflow file to speed up here `flaky`" phrasing (asserts it lands in `verify_report._spine_disclosed_names`, so the managed ceiling is disclosed, not dropped). Red against a version that credits `floor_name` or leaves the managed cap unnamed.
- `test_frequency_gate_role_line_ignores_degenerate_bimodal_floor` (adversarial pass) — a file-backed `flaky` with a **degenerate** bimodal (`slow_frac == 0`, or missing `slow_frac`/`low_p50_s`): the clause must not fire a phantom slow-mode disclosure. `heavy` keeps the plain "sets the wall-clock floor" and no "20m slow mode" is emitted. Red against a frac-blind `_eff_floor_s` gate.
- `test_frequency_gate_role_line_never_calls_a_unimodal_floor_bimodal` (adversarial pass — silent-failure-hunter) — a heavy **unimodal** minority check (`E2E`, the lightdash class) that out-ranks the slowest typical check by plain p50 must NOT trigger the "bimodal slow mode … on slow-mode PRs" wording. The clause now fires only when `_pole_headline`'s bimodal override actually fired; `base` (the slowest typical check) keeps the plain floor credit. Red against the pre-guard clause (which named `E2E`'s "bimodal slow mode").
- `test_aggregation_gate_cross_job_pick_ranks_by_header_not_p50` (adversarial pass — pr-test-analyzer) — independently guards Site A's across-jobs `slowest` comparison: a non-matrix `build` (p50 550s) vs a matrix leg with a fast-median bimodal (header 900s). The leg must be named at 15m; red against a bare-p50 cross-job mutant.

## Suite

`python3 -m pytest -q`: **2603 passed, 15 skipped** (baseline 2598 + 15, +5 new tests).

Committed `--no-verify`: the `.githooks` pre-commit runs `pipx run pytest` (depless, spurious failures); gated instead on `python3 -m pytest -q`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
