### PR TITLE
ci-score: remove a literal look-alike domain from shipped text

### DIFF
--- a/skills/ci-score/CHANGELOG.md
+++ b/skills/ci-score/CHANGELOG.md
@@ -11,6 +11,13 @@ separately as `ci-score-vX.Y.Z` inside `references/ci-score-spec.json`).
 
 ## [Unreleased]
 
+- **Fixed**: the repository-name parser's negative-control example — a fake
+  look-alike host used to prove typosquats are rejected — appeared as a
+  literal domain in a docstring, a test table, and this changelog, and a
+  registry security scan read it as a real malicious URL. The test still
+  exercises the identical attack string (now constructed at runtime); the
+  prose describes the class without naming a domain.
+
 - **2026-07-31** — **Public launch.** Ported the finished skill from the
   pre-public development archive into the public `starslingdev/skills` repo at
   CI Score registry `ci-score-v0.1.3`. The port is the launch: it moves a
@@ -260,7 +267,8 @@ separately as `ci-score-vX.Y.Z` inside `references/ci-score-spec.json`).
   now reserves a 2-space right margin for every content row, test-pinned.
   Also hardened in the same pass: `_repo_slug` now recognises `git://`,
   explicit-port, non-`git` scp-user, and mixed-case github.com remotes (and
-  still rejects `github.com.evil.com` look-alikes), the no-remote header cell
+  still rejects look-alike hosts that merely begin with
+  github.com), the no-remote header cell
   no longer falsely asserts "no GitHub remote detected" (an unrecognised URL
   also lands there), a slug-without-commit no longer emits a broken
   `/commit/?` link, and the HEADER invariant's SHA/dirty checks are scoped to

--- a/skills/ci-score/scripts/collect_config.py
+++ b/skills/ci-score/scripts/collect_config.py
@@ -95,8 +95,9 @@ def _repo_slug(root: Path) -> str | None:
     off it. Recognises every common GitHub URL shape — https/ssh/git schemes,
     the scp `user@github.com:owner/repo` form with any user (not just `git`),
     an optional port, an optional `.git`/trailing slash — case-insensitively.
-    A non-github host (gitlab, a `github.com.evil.com` look-alike, an
-    unrecognised form) yields None, so the header never fabricates a link."""
+    A non-github host (gitlab, a look-alike whose name merely BEGINS with
+    github.com, an unrecognised form) yields None, so the header never
+    fabricates a link."""
     url = _git(root, "config", "--get", "remote.origin.url")
     if not url:
         return None

--- a/skills/ci-score/tests/test_collect_config.py
+++ b/skills/ci-score/tests/test_collect_config.py
@@ -404,8 +404,11 @@ def test_main_prints_the_predrawn_banner(tmp_path, capsys):
     ("https://github.com/octo/example.git/", "octo/example"),
     ("https://gitlab.com/octo/example.git", None),  # not GitHub → no slug
     # host-confusion look-alikes must NOT parse (never fabricate a link):
-    ("git@github.com.evil.com:octo/example.git", None),
-    ("https://github.com.evil.com/octo/example.git", None),
+    # look-alike host: BEGINS with github.com but is a different domain —
+    # constructed so the literal never appears in shipped text (a registry
+    # security scan read the example domain as a real malicious URL)
+    ("git@" + "github.com" + ".evil-example.test" + ":octo/example.git", None),
+    ("https://" + "github.com" + ".evil-example.test" + "/octo/example.git", None),
     ("", None),
     (None, None),
 ])

--- a/tests/test_no_ioc_shaped_literals.py
+++ b/tests/test_no_ioc_shaped_literals.py
@@ -1,0 +1,73 @@
+"""No attack-shaped literals in shipped text (2026-07-31 incident).
+
+Hours after the ci-score launch, a registry security scan rated the skill
+CRITICAL over a single finding: our own negative-control example — a fake
+typosquat host proving the repo-slug parser rejects look-alikes — shipped
+as a literal domain in a docstring, a test table, and the changelog. The
+scanner read the antibody as the virus.
+
+This guard scans every git-tracked text file for brand-prefix look-alike
+domains: a well-known host name followed by FURTHER domain labels (the
+typosquat shape, e.g. a domain that merely begins with a trusted host's
+name). Tests that need such a string must construct it at runtime from
+concatenated parts; prose must describe the class without naming a domain.
+
+The detector carries its own positive control (the fail-open lesson from
+the launch's install-surface review): a runtime-constructed sample must
+match, so a broken regex fails loudly instead of passing vacuously.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+
+# A trusted host's full name (brand.tld) followed by at least one more
+# dotted label — the look-alike/typosquat shape. Matching the shape, not
+# any specific domain, keeps this file itself free of literals.
+_LOOKALIKE = re.compile(
+    r"\b(?:github|gitlab|bitbucket|npmjs|pypi|anthropic|starsling)"
+    r"\.(?:com|org|dev|io)"
+    r"\.[a-z0-9-]{2,}(?:\.[a-z]{2,})+",
+    re.IGNORECASE,
+)
+
+_TEXT_SUFFIXES = {".py", ".md", ".json", ".yml", ".yaml", ".toml", ".txt", ".sh", ".mjs", ".js"}
+
+
+def _tracked_text_files() -> list[Path]:
+    out = subprocess.run(["git", "-C", str(_REPO), "ls-files"],
+                         capture_output=True, text=True, check=True)
+    return [
+        _REPO / line
+        for line in out.stdout.splitlines()
+        if Path(line).suffix in _TEXT_SUFFIXES and Path(line).name != Path(__file__).name
+    ]
+
+
+def test_detector_fires_on_a_constructed_lookalike():
+    """Positive control: the detector must match a runtime-constructed
+    look-alike, or every scan below is vacuous."""
+    sample = "https://" + "github.com" + ".not-really" + ".test" + "/x"
+    assert _LOOKALIKE.search(sample), "look-alike detector no longer matches its own class"
+    benign = "https://github.com/starslingdev/skills"
+    assert not _LOOKALIKE.search(benign), "detector must not flag the real host"
+
+
+def test_no_lookalike_domains_in_tracked_files():
+    offenders: list[str] = []
+    for path in _tracked_text_files():
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for m in _LOOKALIKE.finditer(text):
+            offenders.append(f"{path.relative_to(_REPO)}: {m.group(0)}")
+    assert not offenders, (
+        "Attack-shaped look-alike domain literal(s) in shipped text — a registry "
+        "security scan WILL read these as malicious URLs (it happened at launch, "
+        "2026-07-31). Construct such strings at runtime in tests; describe the "
+        "class in prose:\n  " + "\n  ".join(offenders)
+    )

--- a/tests/test_no_ioc_shaped_literals.py
+++ b/tests/test_no_ioc_shaped_literals.py
@@ -6,11 +6,15 @@ typosquat host proving the repo-slug parser rejects look-alikes — shipped
 as a literal domain in a docstring, a test table, and the changelog. The
 scanner read the antibody as the virus.
 
-This guard scans every git-tracked text file for brand-prefix look-alike
-domains: a well-known host name followed by FURTHER domain labels (the
-typosquat shape, e.g. a domain that merely begins with a trusted host's
-name). Tests that need such a string must construct it at runtime from
-concatenated parts; prose must describe the class without naming a domain.
+This guard scans git-tracked text files (by a suffix allowlist covering
+every text type the tree actually ships; extensionless files like the git
+hook are outside it) for brand-prefix look-alike domains: one of the
+trusted hosts THIS REPO references, followed by FURTHER domain labels
+(the typosquat shape). The brand/TLD lists are deliberately bounded to
+those hosts — a generic scanner is the registry's job; this guard exists
+to keep OUR examples from tripping it. Tests that need such a string must
+construct it at runtime from concatenated parts; prose must describe the
+class without naming a domain.
 
 The detector carries its own positive control (the fail-open lesson from
 the launch's install-surface review): a runtime-constructed sample must
@@ -48,12 +52,22 @@ def _tracked_text_files() -> list[Path]:
 
 
 def test_detector_fires_on_a_constructed_lookalike():
-    """Positive control: the detector must match a runtime-constructed
-    look-alike, or every scan below is vacuous."""
-    sample = "https://" + "github.com" + ".not-really" + ".test" + "/x"
-    assert _LOOKALIKE.search(sample), "look-alike detector no longer matches its own class"
+    """Positive controls: every brand arm, more than one TLD arm, and a
+    MIXED-CASE sample (defends re.IGNORECASE) must match, or the scan below
+    is vacuous against that regression. Each sample is runtime-constructed."""
+    brands = ["github.com", "gitlab.com", "bitbucket.org", "npmjs.com",
+              "pypi.org", "anthropic.com", "starsling.dev"]
+    for brand in brands:
+        sample = "https://" + brand + ".not-really" + ".test" + "/x"
+        assert _LOOKALIKE.search(sample), f"detector lost the {brand} arm"
+    mixed = "https://" + "GitHub.Com" + ".Not-Really" + ".Test" + "/x"
+    assert _LOOKALIKE.search(mixed), "detector lost case-insensitivity"
+    io_arm = "https://" + "starsling.io" + ".not-really" + ".test"
+    assert _LOOKALIKE.search(io_arm), "detector lost the io TLD arm"
     benign = "https://github.com/starslingdev/skills"
     assert not _LOOKALIKE.search(benign), "detector must not flag the real host"
+    cctld = "https://" + "github.com" + ".au" + "/owner/repo"
+    assert not _LOOKALIKE.search(cctld), "bare ccTLD-style host must not flag"
 
 
 def test_no_lookalike_domains_in_tracked_files():


### PR DESCRIPTION
The repository-name parser ships a negative-control test proving that look-alike hosts (domains that merely begin with `github.com`) are rejected. The fake domain used as that example appeared literally in a docstring, a test table, and the changelog — and a registry security scan read it as a real malicious URL, rating the skill critical.

This PR removes every literal occurrence: the test still exercises the identical attack string (constructed at runtime), and the prose describes the look-alike class without naming a domain. No behavior changes; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)