### PR TITLE
Declare license: MIT on ci-score and ci-speedup

### DIFF
--- a/skills/ci-score/SKILL.md
+++ b/skills/ci-score/SKILL.md
@@ -15,6 +15,7 @@ description: >-
   is not a security audit — exactly two rubric checks, action pinning
   and OIDC token scoping, happen to be security-related); writing new
   workflows from scratch; non-GitHub-Actions CI.
+license: MIT
 ---
 
 # ci-score

--- a/skills/ci-speedup/SKILL.md
+++ b/skills/ci-speedup/SKILL.md
@@ -12,6 +12,7 @@ description: >-
   CI changes. Do not trigger for: general CI setup help, writing new
   workflows from scratch, non-GitHub-Actions CI systems, or
   security/posture audits — use `ci-secure` for those.
+license: MIT
 ---
 
 # ci-speedup — CI Optimization Audit for GitHub Actions


### PR DESCRIPTION
All three skills ship under the repo's MIT `LICENSE`, but only `ci-secure` declared `license: MIT` in its frontmatter, so the skills registry renders one skill as licensed and the other two as unspecified. This adds the field to `ci-score` and `ci-speedup` for consistent presentation.

Frontmatter-only, two lines, no behavior change. The `license` value matches the repo's MIT LICENSE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtgWmCppdqYaeSqTnQEybz