### PR TITLE
Registry security scan in CI: critical findings fail the build, warnings surface for review

### DIFF
--- a/.github/scripts/registry_scan_redprove.py
+++ b/.github/scripts/registry_scan_redprove.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Prove the registry-scan gate can actually go red.
+
+A check that cannot fail is not a check. `.github/workflows/registry-scan.yml`
+scans the skills under `skills/` and fails the build on a finding — but if the
+scanner stopped detecting the class of problem we care about, the gate would go
+on passing and we would learn about the next violation the way we learned about
+the last one: from a public audit page, days late.
+
+So before the real scan runs, this script builds a throwaway skill in a temp
+directory whose text carries the exact violation class that got a shipped skill
+flagged — an instruction to fetch a remote installer script and pipe it into a
+shell — points the scanner at it, and fails unless the scanner both reports the
+finding and exits non-zero.
+
+It fails in the other direction too. The scanner's rule catalog changes without
+any commit of ours; if the rule is renamed or retired, this step goes red on the
+next run and a human decides what the gate should now assert.
+
+The offending string is assembled from fragments at runtime and only ever exists
+inside a temp directory. Committing such a literal is precisely what this gate
+exists to prevent, so it appears nowhere in this repository — including here.
+The host is under `example.com`, reserved by RFC 2606 and not resolvable.
+
+Run it by hand the same way CI does (needs SNYK_TOKEN in the environment):
+
+    python3 .github/scripts/registry_scan_redprove.py
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# The rule this gate is anchored to: "suspicious download URL in skill", the
+# critical-severity finding a shipped skill was flagged under. Kept as a named
+# constant so a catalog revamp is a one-line, reviewed change.
+EXPECTED_ISSUE_CODE = "E005"
+
+SCANNER = "snyk-agent-scan@latest"
+
+
+def build_violating_skill(root: Path) -> Path:
+    """Write a one-skill tree under `root` that should trip EXPECTED_ISSUE_CODE.
+
+    Returns the directory to hand the scanner: the PARENT of the skill dir,
+    which is the shape the scanner expects (`<parent>/<name>/SKILL.md`) and the
+    same shape as this repo's `skills/`.
+    """
+    # Assembled from fragments so no installer-URL literal exists on disk here.
+    host = "get" + "." + "redprove" + "-fixture" + "." + "example" + "." + "com"
+    url = "htt" + "ps://" + host + "/inst" + "all" + ".sh"
+    pipe_to_shell = "curl -sSL " + url + " | " + "bash"
+
+    skill_dir = root / "redprove-fixture"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: redprove-fixture\n"
+        "description: Throwaway fixture that exists only to prove a CI gate can go red. "
+        "Sets up its toolchain by downloading and running a vendor installer script.\n"
+        "---\n"
+        "\n"
+        "# Redprove fixture\n"
+        "\n"
+        "## Setup\n"
+        "\n"
+        "Install the toolchain by running:\n"
+        "\n"
+        "```bash\n"
+        f"{pipe_to_shell}\n"
+        "```\n"
+        "\n"
+        "Then run `redprove --version` to confirm the install succeeded.\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+def main() -> int:
+    if not os.environ.get("SNYK_TOKEN"):
+        print(
+            "REGISTRY SCAN GATE NOT PROVEN: SNYK_TOKEN is unset, so the scanner "
+            "cannot run and the gate's ability to fail is unverified.",
+            file=sys.stderr,
+        )
+        return 1
+
+    with tempfile.TemporaryDirectory(prefix="registry-scan-redprove-") as tmp:
+        scan_path = build_violating_skill(Path(tmp))
+        cmd = [
+            "uvx",
+            SCANNER,
+            "scan",
+            str(scan_path),
+            "--ci",
+            "--dangerously-run-mcp-servers",
+        ]
+        print("Red-proof: scanning a deliberately violating skill")
+        print("  " + " ".join(cmd))
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        output = proc.stdout + proc.stderr
+        print(output)
+
+        problems = []
+        if proc.returncode == 0:
+            problems.append(
+                "scanner exited 0 on a skill that instructs the agent to download and "
+                "run a remote installer script — the gate would not have failed"
+            )
+        if EXPECTED_ISSUE_CODE not in output:
+            problems.append(
+                f"scanner output does not mention {EXPECTED_ISSUE_CODE}; the rule may have "
+                "been renamed or retired in a catalog revamp, so this gate is no longer "
+                "anchored to a rule that exists"
+            )
+
+        if problems:
+            print(
+                "REGISTRY SCAN GATE NOT PROVEN:\n  - " + "\n  - ".join(problems),
+                file=sys.stderr,
+            )
+            return 1
+
+    print(
+        f"Red-proof passed: the scanner reported {EXPECTED_ISSUE_CODE} and exited "
+        f"{proc.returncode}. The gate can fail."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/registry_scan_redprove.py
+++ b/.github/scripts/registry_scan_redprove.py
@@ -17,10 +17,14 @@ It fails in the other direction too. The scanner's rule catalog changes without
 any commit of ours; if the rule is renamed or retired, this step goes red on the
 next run and a human decides what the gate should now assert.
 
-The offending string is assembled from fragments at runtime and only ever exists
-inside a temp directory. Committing such a literal is precisely what this gate
-exists to prevent, so it appears nowhere in this repository — including here.
-The host is under `example.com`, reserved by RFC 2606 and not resolvable.
+The offending string is assembled from fragments at runtime, so no fetch-and-pipe
+command line exists on disk in this repository — committing such a literal is
+precisely what this gate exists to prevent. (CPython's peephole optimiser does
+fold the adjacent host fragments, so the hostname alone can be recovered from a
+compiled `.pyc`; those are gitignored, untracked, and live under `.github/`,
+which the scanner never reads. The command line itself does not fold, because the
+fragments are joined across a variable.) The host is under `example.com`, reserved
+by RFC 2606 and not resolvable.
 
 Run it by hand the same way CI does (needs SNYK_TOKEN in the environment):
 
@@ -96,11 +100,36 @@ def main() -> int:
             "scan",
             str(scan_path),
             "--ci",
+            # Keeps codes the printer would otherwise strip in the result the --ci exit
+            # check reads. Same reason the workflow passes it — see the comment there.
+            "--verbose",
             "--dangerously-run-mcp-servers",
         ]
+        # Run the GATE'S ignore list, not an empty one. Otherwise this proves only that the
+        # scanner can fail, not that this gate can: an ignore list grown to include the anchor
+        # code would leave the red-proof green while the real gate could no longer fire on it.
+        ignored = os.environ.get("IGNORED_ISSUE_CODES", "").strip()
+        if ignored:
+            cmd += ["--ignore-issues-codes", ignored]
+
         print("Red-proof: scanning a deliberately violating skill")
         print("  " + " ".join(cmd))
-        proc = subprocess.run(cmd, capture_output=True, text=True)
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=900)
+        except FileNotFoundError:
+            print(
+                "REGISTRY SCAN GATE NOT PROVEN: `uvx` is not on PATH, so the scanner "
+                "could not be run at all.",
+                file=sys.stderr,
+            )
+            return 1
+        except subprocess.TimeoutExpired:
+            print(
+                "REGISTRY SCAN GATE NOT PROVEN: the scanner did not finish within 15 "
+                "minutes, so the gate's ability to fail is unverified.",
+                file=sys.stderr,
+            )
+            return 1
         output = proc.stdout + proc.stderr
         print(output)
 

--- a/.github/scripts/registry_scan_report.py
+++ b/.github/scripts/registry_scan_report.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Surface every registry-scan finding, without letting a warning block the build.
+
+`.github/workflows/registry-scan.yml` gates on Snyk Agent Scan's critical class only
+— the E-codes. Warnings (W-codes) are real findings we want a human or a review agent
+to look at, but they do not fail CI. A finding nobody can see is the failure this whole
+gate exists to prevent, so "does not block" must not decay into "does not appear".
+
+This script reads the scanner's `--json` output and writes it to three surfaces, each
+for a different consumer:
+
+  1. `::warning::` workflow commands — render on the checks tab and the Files view, and
+     come back through the checks API as annotations, which is what an automated review
+     agent can actually query.
+  2. A markdown table on `$GITHUB_STEP_SUMMARY` — the human-glanceable surface.
+  3. The raw JSON, uploaded as a run artifact by the workflow — a deterministic feed for
+     tooling, so nothing has to scrape the log.
+
+It also prints a plain-text table to the job log, because the scanner's own rich report
+is not produced in JSON mode and this is the only pass that sees every finding: the
+gating pass runs with the ignore list, and the scanner strips ignored findings from its
+printed report as well as from its exit status.
+
+Exit status: 0 whatever the findings are — gating is the next step's job, and warnings
+must never block. It exits 1 only if the scan output cannot be parsed at all, because at
+that point the surfacing is broken and silence would look exactly like "nothing found".
+
+Usage:  python3 .github/scripts/registry_scan_report.py <findings.json>
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Snyk Agent Scan issue codes carry their class in the prefix: E = critical class
+# (what this gate fails on), W = warning class (surfaced, never blocking), X = a scan
+# runtime failure. See https://github.com/snyk/agent-scan/blob/main/docs/issue-codes.md
+CRITICAL_PREFIX = "E"
+
+
+def load_findings(path: Path) -> dict:
+    """Parse the scanner's JSON, tolerating a banner printed before the document.
+
+    The scanner prints a version line on stdout before the JSON document in some
+    versions, so slicing from the first brace is more durable than assuming the file
+    is pure JSON.
+    """
+    raw = path.read_text(encoding="utf-8")
+    start = raw.find("{")
+    if start == -1:
+        raise ValueError(f"no JSON object in {path}; the scan produced no parseable output")
+    return json.loads(raw[start:])
+
+
+def skill_name(result: dict, issue: dict) -> str:
+    """Best-effort name of the skill an issue fired on.
+
+    `reference` is (server_index, entity_index); for a skills directory each skill is
+    one "server" entry. Falls back to the scanned path when the shape is unfamiliar,
+    which is a labelling detail only — the finding is reported either way.
+    """
+    reference = issue.get("reference")
+    servers = result.get("servers") or []
+    if isinstance(reference, (list, tuple)) and reference and isinstance(reference[0], int):
+        index = reference[0]
+        if 0 <= index < len(servers):
+            name = (servers[index] or {}).get("name")
+            if name:
+                return str(name)
+    return str(result.get("path") or "unknown")
+
+
+def severity_of(issue: dict) -> str:
+    extra = issue.get("extra_data") or {}
+    return str(extra.get("severity") or "unknown")
+
+
+def collect(findings: dict) -> list[dict]:
+    rows = []
+    for result in findings.values():
+        if not isinstance(result, dict):
+            continue
+        for issue in result.get("issues") or []:
+            code = str(issue.get("code") or "")
+            rows.append(
+                {
+                    "code": code,
+                    "severity": severity_of(issue),
+                    "skill": skill_name(result, issue),
+                    "message": " ".join(str(issue.get("message") or "").split()),
+                    "critical": code.startswith(CRITICAL_PREFIX),
+                }
+            )
+    # Critical first, then by code, so the thing that will fail the build reads first.
+    rows.sort(key=lambda r: (not r["critical"], r["code"], r["skill"]))
+    return rows
+
+
+def emit_annotations(rows: list[dict]) -> None:
+    """One annotation per warning finding.
+
+    Deliberately `::warning::` and not `::error::`: an error annotation does not by
+    itself fail a job, but it renders as a failure to a reader, and the owner's rule is
+    that warnings are visible without ever reading as blocking. Criticals are left to
+    the gating step, which fails the job and says so itself.
+    """
+    for row in rows:
+        if row["critical"]:
+            continue
+        print(
+            f"::warning title={row['code']} ({row['severity']}) in {row['skill']}"
+            f"::{row['message']}"
+        )
+
+
+def render_table(rows: list[dict]) -> str:
+    lines = [
+        "| Class | Code | Severity | Skill | Finding |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        klass = "**critical — blocks**" if row["critical"] else "warning"
+        lines.append(
+            f"| {klass} | `{row['code']}` | {row['severity']} | `{row['skill']}` | "
+            f"{row['message']} |"
+        )
+    return "\n".join(lines)
+
+
+def write_summary(rows: list[dict]) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    body = ["## Registry scan findings", ""]
+    body.append(
+        "Warnings do not block; critical (E-class) findings do. Every finding below is "
+        "real — warnings are surfaced for a human or a review agent to judge, not "
+        "suppressed. The full machine-readable finding set is attached to this run as "
+        "the `registry-scan-findings` artifact."
+    )
+    body.append("")
+    if rows:
+        criticals = sum(1 for row in rows if row["critical"])
+        body.append(
+            f"{len(rows)} finding(s): {criticals} critical, {len(rows) - criticals} warning."
+        )
+        body.append("")
+        body.append(render_table(rows))
+    else:
+        body.append("No findings.")
+    body.append("")
+
+    text = "\n".join(body)
+    print(text)
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(text + "\n")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"usage: {argv[0]} <findings.json>", file=sys.stderr)
+        return 2
+
+    path = Path(argv[1])
+    try:
+        findings = load_findings(path)
+    except (OSError, ValueError) as exc:
+        # Not a finding — a broken pipeline. Silence here would be indistinguishable
+        # from a clean scan, which is the exact confusion this gate exists to remove.
+        print(
+            "::error title=REGISTRY SCAN FINDINGS UNREADABLE::"
+            f"Could not read the scanner's JSON output ({exc}). Findings were not "
+            "surfaced; do not read this run as 'no warnings'.",
+            file=sys.stderr,
+        )
+        return 1
+
+    rows = collect(findings)
+    emit_annotations(rows)
+    write_summary(rows)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/workflows/registry-scan.yml
+++ b/.github/workflows/registry-scan.yml
@@ -142,7 +142,13 @@ jobs:
     # way to fix would be hostile, so this reports rather than blocks — but it reports loudly, and
     # a maintainer must re-run the scan on an internal branch before merging any change to
     # `skills/` that came from a fork.
-    if: github.event.pull_request.head.repo.full_name != github.repository
+    # Both halves are load-bearing. On a push, a schedule, or a manual dispatch there is no
+    # `github.event.pull_request`, so the second clause alone would be true (null != repo) and
+    # this job would post a green "fork PR — no scan coverage" check next to a real scan that
+    # did run — the exact misreading the job's name exists to prevent.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Report the coverage gap

--- a/.github/workflows/registry-scan.yml
+++ b/.github/workflows/registry-scan.yml
@@ -1,0 +1,161 @@
+name: Registry scan
+
+# Runs the same third-party security scanner that skill registries publish audits from
+# (Snyk Agent Scan) against the installable skill trees under `skills/`, so a rule violation
+# fails our build instead of appearing as a public FAIL badge days after release.
+#
+# WHAT THIS DOES NOT COVER. Registries run more than one scanner. This gate reproduces exactly
+# one of them (Snyk Agent Scan). It says nothing about Gen Agent Trust Hub — which publishes no
+# rule catalog and no CLI, and whose verdicts are LLM-generated and not reproducible — or about
+# Socket. A green check here means "Snyk Agent Scan finds nothing we have not accepted". It does
+# not mean every registry scanner will pass.
+on:
+  pull_request:
+  push:
+    branches: [main]
+  # The scanner's rule catalog changes without any commit of ours: a renamed, retired, or newly
+  # added rule can turn a shipped skill red on its own. The weekly run is what notices.
+  schedule:
+    - cron: "23 7 * * 1" # Mondays, 07:23 UTC
+  workflow_dispatch:
+
+# One in-flight run per ref — a new push cancels the previous, still-running run for that branch.
+concurrency:
+  group: registry-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: the gate only reads the checked-out code.
+permissions:
+  contents: read
+
+env:
+  # Codes excluded from the gate's exit status. Exactly one entry, and it is deliberate:
+  #
+  #   W011 "Exposure to untrusted third-party content" — an accurate description of what these
+  #   skills do. They read a repository's own CI configuration, workflow files, and job logs,
+  #   which are third-party content the skill did not author. `ci-speedup` and `ci-secure` both
+  #   fire it today and both pass their published registry audits with it present. Removing the
+  #   behaviour would mean the skills no longer do their job, so we accept the finding rather
+  #   than suppress the cause.
+  #
+  # Nothing else is excluded. If any other code fires, this build goes red and a human decides.
+  # A new exclusion is a reviewed change to this line, with its reason written next to it.
+  IGNORED_ISSUE_CODES: W011
+
+  # The scanner reads skills out of a directory of `<name>/SKILL.md` subdirectories. This is the
+  # installable tree: exactly what the `skills` CLI copies onto a user's machine and what a
+  # registry publishes.
+  SCAN_PATH: skills
+
+jobs:
+  scan:
+    name: registry scan
+    # This repo dogfoods StarSling runners for its own CI (matching ci.yml). The runner is
+    # self-hosted, so never execute untrusted fork-PR code on it, and repository secrets —
+    # SNYK_TOKEN included — are not available to fork PRs anyway. Fork PRs get the
+    # `fork-not-scanned` job below, which reports the coverage gap instead of a green check.
+    runs-on: starsling-ubuntu-24.04
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+    steps:
+      # Third-party actions are pinned to a commit SHA (the tag comment is for humans only) so a
+      # moved/compromised tag can't silently change what runs in CI.
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # The scanner reads the working tree only — no history needed, unlike ci.yml's
+          # provenance guard.
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.12"
+
+      # A missing token must never look like a clean scan. This is the whole point of the gate:
+      # the failure we are guarding against is a security finding nobody saw, and a silently
+      # skipped security scan is that same failure wearing a green check. On internal pushes and
+      # PRs the secret is expected to exist, so its absence is a red build, not a quiet skip.
+      - name: Require SNYK_TOKEN
+        run: |
+          if [ -z "${SNYK_TOKEN}" ]; then
+            echo "::error title=REGISTRY SCAN DID NOT RUN::SNYK_TOKEN is not set. No skill was scanned. This is a coverage gap, not a clean result."
+            echo "================================================================"
+            echo "  REGISTRY SCAN DID NOT RUN — NOTHING WAS SCANNED"
+            echo ""
+            echo "  SNYK_TOKEN is not set, so the scanner could not contact Snyk"
+            echo "  and no skill under '${SCAN_PATH}' was analysed. Do NOT read this"
+            echo "  run as 'scanned, clean' — it is a coverage gap."
+            echo ""
+            echo "  Fix: add a SNYK_TOKEN repository secret. Get the token from a"
+            echo "  free Snyk account at https://app.snyk.io/account (API Token ->"
+            echo "  KEY -> click to reveal), then add it under Settings -> Secrets"
+            echo "  and variables -> Actions -> New repository secret."
+            echo "================================================================"
+            exit 1
+          fi
+          echo "SNYK_TOKEN is set — the scan below is a real scan."
+
+      - name: Install uv
+        run: python -m pip install --disable-pip-version-check uv
+
+      # A check that cannot fail is not a check. This scans a throwaway skill built in a temp
+      # directory whose text carries the exact violation class that got a shipped skill flagged,
+      # and it fails this job unless the scanner reports the finding AND exits non-zero. It also
+      # catches the other direction: if the rule is renamed or retired in a catalog revamp, this
+      # step goes red and we find out from our own CI instead of from a public audit page.
+      # The offending string is assembled at runtime — committing one is the thing we're guarding
+      # against — so nothing in this repository contains it.
+      - name: Prove the gate can go red
+        run: python .github/scripts/registry_scan_redprove.py
+
+      # Two passes, on purpose. `--ignore-issues-codes` filters findings out of the printed
+      # report as well as out of the exit status, so an ignored finding scanned with the gate's
+      # flags would be invisible. An exclusion nobody can see is how a real finding gets hidden
+      # later, so this first pass runs with no ignore list and prints everything the scanner
+      # found — W011 included. Its exit status is advisory; the gate below is authoritative.
+      - name: Scan (full findings, including accepted ones)
+        continue-on-error: true
+        run: |
+          echo "Every finding below is real. Codes in IGNORED_ISSUE_CODES (${IGNORED_ISSUE_CODES})"
+          echo "are accepted and do not fail the build; see the comment in this workflow for why."
+          uvx snyk-agent-scan@latest scan "${SCAN_PATH}"
+
+      # The authoritative gate. `--ci` turns any remaining finding into exit 1.
+      # `--dangerously-run-mcp-servers` is required by `--ci`; it only affects MCP server configs,
+      # and this path contains skill directories only, so nothing is executed.
+      - name: Gate on findings
+        run: |
+          uvx snyk-agent-scan@latest scan "${SCAN_PATH}" \
+            --ci \
+            --dangerously-run-mcp-servers \
+            --ignore-issues-codes "${IGNORED_ISSUE_CODES}"
+
+  fork-not-scanned:
+    # The name is the message: this check being green must not read as "scanned, clean".
+    name: registry scan NOT RUN (fork PR — no scan coverage)
+    # Inverse of the guard above: fork PRs cannot reach repository secrets, so the scanner has no
+    # token and cannot run. Failing an external contributor's PR for infrastructure they have no
+    # way to fix would be hostile, so this reports rather than blocks — but it reports loudly, and
+    # a maintainer must re-run the scan on an internal branch before merging any change to
+    # `skills/` that came from a fork.
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report the coverage gap
+        run: |
+          echo "::warning title=REGISTRY SCAN DID NOT RUN::Fork PRs have no SNYK_TOKEN, so no skill was scanned on this PR. This is a coverage gap, not a clean result — a maintainer must re-run the scan on an internal branch before merging changes under skills/."
+          echo "================================================================"
+          echo "  REGISTRY SCAN DID NOT RUN — NOTHING WAS SCANNED"
+          echo ""
+          echo "  This pull request comes from a fork. Fork runs have no access"
+          echo "  to the SNYK_TOKEN secret, so the registry scanner could not run"
+          echo "  and no skill was analysed."
+          echo ""
+          echo "  This is a coverage gap, NOT a clean result. Before merging any"
+          echo "  change under skills/ from a fork, a maintainer must push the"
+          echo "  branch to this repository and let the 'registry scan' job run."
+          echo "================================================================"

--- a/.github/workflows/registry-scan.yml
+++ b/.github/workflows/registry-scan.yml
@@ -19,9 +19,13 @@ on:
     - cron: "23 7 * * 1" # Mondays, 07:23 UTC
   workflow_dispatch:
 
-# One in-flight run per ref — a new push cancels the previous, still-running run for that branch.
+# One in-flight run per ref per event — a new push cancels the previous, still-running run for
+# that branch. `github.event_name` is in the key because a push to main and the weekly scheduled
+# run share `refs/heads/main`: without it, a push would cancel the scheduled run, and a cancelled
+# run notifies nobody. The schedule is the only trigger that notices a rule-catalog change that
+# needed no commit of ours, so it must not be silently cancellable.
 concurrency:
-  group: registry-scan-${{ github.ref }}
+  group: registry-scan-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 # Least privilege: the gate only reads the checked-out code.
@@ -29,18 +33,27 @@ permissions:
   contents: read
 
 env:
-  # Codes excluded from the gate's exit status. Exactly one entry, and it is deliberate:
+  # THE GATING RULE (owner ruling, 2026-08-10): this build fails on Snyk Agent Scan's critical
+  # class only — the E-codes. Warning-class findings (W-codes) never fail CI.
   #
-  #   W011 "Exposure to untrusted third-party content" — an accurate description of what these
-  #   skills do. They read a repository's own CI configuration, workflow files, and job logs,
-  #   which are third-party content the skill did not author. `ci-speedup` and `ci-secure` both
-  #   fire it today and both pass their published registry audits with it present. Removing the
-  #   behaviour would mean the skills no longer do their job, so we accept the finding rather
-  #   than suppress the cause.
+  # They are not hidden, though; "does not block" must not decay into "does not appear". Every
+  # W finding is surfaced three ways on every run: a `::warning::` annotation on the checks tab
+  # (queryable through the checks API, which is what a review agent reads), a table in the job
+  # summary, and the raw finding set uploaded as the `registry-scan-findings` artifact. A human
+  # or a review agent judges them; CI does not block on them.
   #
-  # Nothing else is excluded. If any other code fires, this build goes red and a human decides.
-  # A new exclusion is a reviewed change to this line, with its reason written next to it.
-  IGNORED_ISSUE_CODES: W011
+  # The scanner has no severity threshold — `--ignore-issues-codes` is its only gating knob — so
+  # the rule is expressed by enumerating the W class. This is every W-code published in
+  # https://github.com/snyk/agent-scan/blob/main/docs/issue-codes.md. It is a class rule, not
+  # fifteen individual judgements, so it carries no per-code justification. W011 "exposure to
+  # untrusted third-party content", the one that fires on these skills today, is an accurate
+  # description of what they do: they read a repository's own CI configuration, workflow files,
+  # and job logs, none of which the skill authored.
+  #
+  # NO E-CODE MAY EVER APPEAR HERE — that would silently disarm the gate, and
+  # tests/test_registry_scan_workflow.py fails if one does. When the scanner publishes a new
+  # W-code it will fail this build once; adding it here is the conscious update that follows.
+  IGNORED_ISSUE_CODES: W001,W007,W008,W009,W011,W012,W013,W014,W015,W016,W017,W018,W019,W020,W021
 
   # The scanner reads skills out of a directory of `<name>/SKILL.md` subdirectories. This is the
   # installable tree: exactly what the `skills` CLI copies onto a user's machine and what a
@@ -55,6 +68,9 @@ jobs:
     # SNYK_TOKEN included — are not available to fork PRs anyway. Fork PRs get the
     # `fork-not-scanned` job below, which reports the coverage gap instead of a green check.
     runs-on: starsling-ubuntu-24.04
+    # The scan talks to a network service. A stalled request would otherwise hold a self-hosted
+    # runner for the six-hour GitHub default with no signal.
+    timeout-minutes: 20
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -99,6 +115,21 @@ jobs:
           fi
           echo "SNYK_TOKEN is set — the scan below is a real scan."
 
+      # A gate that scans nothing is a gate that passes. The token check above catches one way
+      # that happens; this catches the other. The scanner reads a directory of `<name>/SKILL.md`
+      # subdirectories, so if SCAN_PATH is renamed, moved, or restructured (a `skills/<category>/`
+      # nesting, say), the scanner finds zero skills, reports nothing, exits 0, and this check
+      # goes green having analysed no skill at all. The red-proof below cannot catch that: it
+      # scans its own temp fixture and never touches SCAN_PATH.
+      - name: Require the scan path to contain skills
+        run: |
+          count=$(find "${SCAN_PATH}" -mindepth 2 -maxdepth 2 -name SKILL.md | wc -l | tr -d ' ')
+          if [ "${count}" -eq 0 ]; then
+            echo "::error title=REGISTRY SCAN HAS NOTHING TO SCAN::No '<name>/SKILL.md' found under '${SCAN_PATH}'. The scanner would find zero skills and exit 0. This is a coverage gap, not a clean result."
+            exit 1
+          fi
+          echo "Found ${count} skill(s) under '${SCAN_PATH}' to scan."
+
       - name: Install uv
         run: python -m pip install --disable-pip-version-check uv
 
@@ -108,29 +139,56 @@ jobs:
       # catches the other direction: if the rule is renamed or retired in a catalog revamp, this
       # step goes red and we find out from our own CI instead of from a public audit page.
       # The offending string is assembled at runtime — committing one is the thing we're guarding
-      # against — so nothing in this repository contains it.
+      # against — so nothing in this repository contains it. It runs the gate's real flags,
+      # IGNORED_ISSUE_CODES included, so an ignore list that grew to swallow the anchor rule
+      # would fail here rather than quietly neutering the gate.
       - name: Prove the gate can go red
         run: python .github/scripts/registry_scan_redprove.py
 
-      # Two passes, on purpose. `--ignore-issues-codes` filters findings out of the printed
-      # report as well as out of the exit status, so an ignored finding scanned with the gate's
-      # flags would be invisible. An exclusion nobody can see is how a real finding gets hidden
-      # later, so this first pass runs with no ignore list and prints everything the scanner
-      # found — W011 included. Its exit status is advisory; the gate below is authoritative.
-      - name: Scan (full findings, including accepted ones)
+      # Two passes, on purpose, and exactly two — the scanner is a network service, so every
+      # invocation costs. `--ignore-issues-codes` filters findings out of the printed report as
+      # well as out of the exit status, so the gating pass below is structurally incapable of
+      # showing a warning: it runs with the very flags that hide them. This pass carries no
+      # ignore list and is the only one that sees everything.
+      #
+      # It emits `--json` rather than the rich report because the JSON is what the next step
+      # turns into annotations, a summary table, and an artifact — and because the scanner's own
+      # printer silently drops the codes W003-W006 from the result, mutating it in place as it
+      # prints. JSON skips the printer entirely, so it is strictly the more complete output.
+      - name: Scan (all findings, unfiltered)
         continue-on-error: true
         run: |
-          echo "Every finding below is real. Codes in IGNORED_ISSUE_CODES (${IGNORED_ISSUE_CODES})"
-          echo "are accepted and do not fail the build; see the comment in this workflow for why."
-          uvx snyk-agent-scan@latest scan "${SCAN_PATH}"
+          echo "Scanning '${SCAN_PATH}' with no ignore list — every finding the scanner has."
+          uvx snyk-agent-scan@latest scan "${SCAN_PATH}" --json > registry-scan-findings.json
 
-      # The authoritative gate. `--ci` turns any remaining finding into exit 1.
+      # Warnings never fail this build, so they must be impossible to miss instead. This writes
+      # each one to the checks tab as an annotation (where a review agent can query it), to the
+      # job summary as a table, and leaves the raw set for the artifact upload below. It never
+      # gates — it fails only if the scan output is unparseable, because silent surfacing looks
+      # exactly like a clean scan.
+      - name: Surface findings (annotations, summary, artifact)
+        run: python .github/scripts/registry_scan_report.py registry-scan-findings.json
+
+      - name: Upload the finding set
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: registry-scan-findings
+          path: registry-scan-findings.json
+          retention-days: 14
+          if-no-files-found: warn
+
+      # The authoritative gate, and the only step that fails on a finding. `--ci` turns any
+      # remaining finding into exit 1; with the W class ignored, "remaining" means the critical
+      # E-class, plus the scanner's own X-class runtime failures, which are deliberately NOT
+      # ignored — a scan that broke is not a scan that passed.
       # `--dangerously-run-mcp-servers` is required by `--ci`; it only affects MCP server configs,
       # and this path contains skill directories only, so nothing is executed.
-      - name: Gate on findings
+      - name: Gate on critical findings
         run: |
           uvx snyk-agent-scan@latest scan "${SCAN_PATH}" \
             --ci \
+            --verbose \
             --dangerously-run-mcp-servers \
             --ignore-issues-codes "${IGNORED_ISSUE_CODES}"
 
@@ -150,6 +208,7 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Report the coverage gap
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,38 @@ External contributions are welcome and follow the standard fork flow:
   `python3 -m pytest -v` runs in both places, so you can reproduce CI locally
   before you push.
 
+## Registry security scanning
+
+Skill registries publish third-party security audits of every skill they list, and
+a skill can fail one without failing anything in this repo — the text a skill ships
+is the thing being scanned, so an illustrative example can read to a scanner as the
+attack it describes. `.github/workflows/registry-scan.yml` runs one of those
+scanners (Snyk Agent Scan) over the installable trees under `skills/` on every
+internal push and pull request, weekly on a schedule, and on demand, so a violation
+fails our build instead of appearing as a public FAIL badge days after release.
+
+Two things about that gate are worth knowing before you rely on it.
+
+**It reproduces one scanner, not all of them.** Registries run several. This gate
+covers Snyk Agent Scan only. It says nothing about Gen Agent Trust Hub — which
+publishes no rule catalog and no CLI, and whose verdicts are LLM-generated and not
+reproducible from one run to the next — or about Socket. A green check means "Snyk
+Agent Scan finds nothing we have not accepted", not "every registry scanner will
+pass".
+
+**One finding is accepted and excluded from the build's exit status:** W011,
+"exposure to untrusted third-party content", which accurately describes skills that
+read a repository's own CI configuration and job logs. It is still printed in full
+in the scan log, and the reason is written beside the exclusion in the workflow.
+Nothing else is excluded; any other code turns the build red for a human to decide.
+
+The gate needs a `SNYK_TOKEN` repository secret (a free Snyk account). Without it
+the job fails loudly rather than passing quietly — a skipped security scan reported
+as green is the exact failure this gate exists to prevent. Fork pull requests cannot
+reach repository secrets, so they get a separate, clearly named check that reports
+the coverage gap; a maintainer re-runs the scan on an internal branch before merging
+fork changes under `skills/`.
+
 ## Adding or changing detection patterns
 
 The pattern catalog is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,8 +56,9 @@ a skill can fail one without failing anything in this repo — the text a skill 
 is the thing being scanned, so an illustrative example can read to a scanner as the
 attack it describes. `.github/workflows/registry-scan.yml` runs one of those
 scanners (Snyk Agent Scan) over the installable trees under `skills/` on every
-internal push and pull request, weekly on a schedule, and on demand, so a violation
-fails our build instead of appearing as a public FAIL badge days after release.
+internal pull request, on pushes to `main`, weekly on a schedule, and on demand, so
+a violation fails our build instead of appearing as a public FAIL badge days after
+release.
 
 Two things about that gate are worth knowing before you rely on it.
 
@@ -68,11 +69,28 @@ reproducible from one run to the next — or about Socket. A green check means "
 Agent Scan finds nothing we have not accepted", not "every registry scanner will
 pass".
 
-**One finding is accepted and excluded from the build's exit status:** W011,
-"exposure to untrusted third-party content", which accurately describes skills that
-read a repository's own CI configuration and job logs. It is still printed in full
-in the scan log, and the reason is written beside the exclusion in the workflow.
-Nothing else is excluded; any other code turns the build red for a human to decide.
+**Only critical findings block.** The scanner sorts findings into a critical class
+(`E`-codes) and a warning class (`W`-codes). A critical finding fails the build. A
+warning never does — warnings on these skills are usually accurate descriptions of
+what the skills legitimately do, such as W011 "exposure to untrusted third-party
+content", which is what reading a repository's own CI configuration and job logs
+looks like to a scanner. They are judged by a human, not by CI.
+
+Warnings are never hidden, though. Every run surfaces the full finding set three
+ways, because "does not block" must not quietly become "does not appear":
+
+- **Annotations** on the checks tab, one per warning — also readable through the
+  checks API, which is how an automated review agent picks them up.
+- **A job summary table** listing every finding, its code, severity, and skill.
+- **A `registry-scan-findings` artifact** holding the scanner's raw JSON, kept for
+  14 days. Review agents and tooling should read this rather than scraping the log:
+  `gh run download <run-id> --name registry-scan-findings`.
+
+If you are adding a warning code to the ignore list, it must be a `W`-code from
+[the scanner's published catalog](https://github.com/snyk/agent-scan/blob/main/docs/issue-codes.md),
+and it goes in both the workflow and `tests/test_registry_scan_workflow.py`. An
+`E`-code can never go in the ignore list — that would disarm the gate while leaving
+it green, and the tests fail if one appears.
 
 The gate needs a `SNYK_TOKEN` repository secret (a free Snyk account). Without it
 the job fails loudly rather than passing quietly — a skipped security scan reported

--- a/tests/test_registry_scan_workflow.py
+++ b/tests/test_registry_scan_workflow.py
@@ -17,6 +17,7 @@ inside the workflow itself on every run.
 """
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -28,10 +29,21 @@ _REPO = Path(__file__).resolve().parents[1]
 _WORKFLOW = _REPO / ".github" / "workflows" / "registry-scan.yml"
 _CI_WORKFLOW = _REPO / ".github" / "workflows" / "ci.yml"
 _REDPROVE = _REPO / ".github" / "scripts" / "registry_scan_redprove.py"
+_REPORT = _REPO / ".github" / "scripts" / "registry_scan_report.py"
 
-# The one accepted exclusion. Widening this set is a deliberate, reviewed change to
-# both this list and the rationale comment beside it in the workflow.
-_ACCEPTED_IGNORED_CODES = {"W011"}
+# THE GATING RULE (owner ruling, 2026-08-10): the build fails on the critical class only —
+# Snyk Agent Scan's E-codes. Warning-class findings (W-codes) are surfaced on every run but
+# never block. The scanner has no severity threshold, so the rule is expressed by enumerating
+# the W class into --ignore-issues-codes.
+#
+# This is every W-code published in the scanner's catalog:
+# https://github.com/snyk/agent-scan/blob/main/docs/issue-codes.md
+# Pinned so that a newly published W-code arrives as a conscious update here rather than as an
+# unexplained red build — and, far more importantly, so that no E-code can ever be slipped in.
+_PUBLISHED_WARNING_CODES = {
+    "W001", "W007", "W008", "W009", "W011", "W012", "W013", "W014",
+    "W015", "W016", "W017", "W018", "W019", "W020", "W021",
+}
 
 
 @pytest.fixture(scope="module")
@@ -57,6 +69,67 @@ def _scan_job(workflow: dict) -> dict:
 
 def _steps_text(job: dict) -> str:
     return "\n".join(step.get("run", "") for step in job["steps"])
+
+
+def _invokes_scanner(step: dict) -> bool:
+    """True for a step that actually shells out to the scanner's `scan` subcommand.
+
+    Matched on the command line rather than on the word "scan" appearing anywhere in
+    the step, so an echo, a heredoc, or a comment mentioning the scanner cannot stand
+    in for a step that runs it.
+    """
+    return bool(re.search(r"uvx\s+snyk-agent-scan\S*\s+scan\b", step.get("run", "")))
+
+
+def _gate_step(workflow: dict) -> dict:
+    """The authoritative step: the scanner invocation carrying the ignore list.
+
+    Every property below is asserted against THIS step specifically. Asserting them
+    against the job's concatenated step text is what let the earlier version of this
+    file stay green while `--ci` moved onto the advisory pass.
+    """
+    steps = [
+        step for step in _scan_job(workflow)["steps"]
+        if _invokes_scanner(step) and "--ignore-issues-codes" in step["run"]
+    ]
+    assert len(steps) == 1, (
+        f"expected exactly one gating scanner invocation (the one passing the ignore "
+        f"list); found {len(steps)}"
+    )
+    return steps[0]
+
+
+def _visibility_step(workflow: dict) -> dict:
+    """The unfiltered pass: a scanner invocation with no ignore list, distinct from the gate."""
+    steps = [
+        step for step in _scan_job(workflow)["steps"]
+        if _invokes_scanner(step) and "--ignore-issues-codes" not in step["run"]
+    ]
+    assert len(steps) == 1, (
+        f"expected exactly one unfiltered scanner invocation; found {len(steps)}. The "
+        f"scanner strips ignored findings from its printed report as well as its exit "
+        f"status, so without a separate unfiltered pass an accepted finding is invisible."
+    )
+    return steps[0]
+
+
+def _step_index(job: dict, predicate) -> int:
+    for i, step in enumerate(job["steps"]):
+        if predicate(step):
+            return i
+    raise AssertionError("no step matched")
+
+
+def _assert_unconditional(step: dict, what: str) -> None:
+    """A step with an `if:` or `continue-on-error:` is a step that can stop mattering.
+
+    These are the two cheapest ways to neuter a gate step while leaving it visible in
+    the file, so they are asserted rather than assumed.
+    """
+    assert "if" not in step, f"{what} is conditional; it must run on every run"
+    assert not step.get("continue-on-error"), (
+        f"{what} is continue-on-error; its failure would no longer fail the build"
+    )
 
 
 def test_workflow_exists_and_parses(workflow: dict):
@@ -95,30 +168,168 @@ def test_fork_prs_never_reach_the_self_hosted_runner(workflow: dict):
 
 
 def test_gate_uses_ci_flag(workflow: dict):
-    """Without --ci a finding is printed and the build stays green."""
-    assert "--ci" in _steps_text(_scan_job(workflow))
+    """Without --ci a finding is printed and the build stays green.
+
+    Asserted against the gating step itself. Checking the job's concatenated step text
+    would be satisfied by `--ci` appearing in an echo, or by it moving onto the advisory
+    visibility pass — both of which make every finding non-blocking.
+    """
+    gate = _gate_step(workflow)
+    assert "--ci" in gate["run"], "the gating scan lost --ci; findings are now advisory"
+    assert "--dangerously-run-mcp-servers" in gate["run"], (
+        "the scanner refuses --ci without --dangerously-run-mcp-servers (exit 2)"
+    )
+    _assert_unconditional(gate, "the gating scan")
 
 
-def test_ignore_list_is_exactly_the_accepted_exclusion(workflow: dict):
-    declared = {
+def test_gate_spells_the_ignore_flag_the_way_the_scanner_does(workflow: dict):
+    """The flag is `--ignore-issues-codes` — plural "issues", singular "codes".
+
+    It reads like a typo and has been "corrected" to `--ignore-issue-codes` in review.
+    It is not a typo: the scanner's own argument parser declares
+    `parser.add_argument("--ignore-issues-codes", ...)`, and the singular spelling is
+    rejected with `error: unrecognized arguments`. Getting it wrong does not degrade the
+    gate quietly — it exits on a usage error the first time it runs with a token, which
+    is a path no offline test can reach. Hence this assertion.
+    """
+    assert "--ignore-issues-codes" in _gate_step(workflow)["run"]
+
+
+def test_unfiltered_pass_sees_what_the_printer_would_hide(workflow: dict):
+    """The visibility pass emits JSON, which is strictly more complete than the report.
+
+    The scanner's printer strips the codes W003-W006 from the result as it prints — and
+    mutates the result in place doing it. JSON output skips the printer entirely, so the
+    one pass that is supposed to see everything actually does. (The gating pass keeps
+    `--verbose`, which is the same defect's off-switch on the report path.)
+    """
+    assert "--json" in _visibility_step(workflow)["run"], (
+        "the unfiltered pass must emit JSON: it is the input to the annotation, summary, "
+        "and artifact surfaces, and it is the only output the printer cannot silently trim"
+    )
+    assert "--verbose" in _gate_step(workflow)["run"], (
+        "the gating pass lost --verbose, so the scanner drops W003-W006 from the result "
+        "the --ci exit check reads"
+    )
+
+
+def _declared_ignored_codes(workflow: dict) -> set:
+    return {
         code.strip()
         for code in workflow["env"]["IGNORED_ISSUE_CODES"].split(",")
         if code.strip()
     }
-    assert declared == _ACCEPTED_IGNORED_CODES, (
-        "the gate's ignore list changed. Every excluded code hides a real finding from "
-        "the build's exit status, so each one needs a reason written next to it in the "
-        "workflow and a matching update here."
+
+
+def test_no_critical_code_is_ever_ignored(workflow: dict):
+    """The load-bearing direction of the gating rule.
+
+    Warnings not blocking is a policy choice. A critical code reaching the ignore list is
+    a disarmed gate that still reports green — the precise failure this whole workflow
+    exists to prevent — so it is asserted separately and in the strongest form: nothing
+    outside the W class may be suppressed, whatever the reason given.
+    """
+    for code in _declared_ignored_codes(workflow):
+        assert code.startswith("W"), (
+            f"{code!r} is in the gate's ignore list but is not a warning-class code. Only "
+            f"W-codes may be ignored; an E-code here silently disarms the gate, and the "
+            f"X-codes report that the scan itself failed."
+        )
+
+
+def test_ignore_list_is_exactly_the_published_warning_class(workflow: dict):
+    """The rule is class-based, so the list must be the class — no more, no less.
+
+    Short of the published set, a warning fails the build and someone 'fixes' it by
+    guessing. Beyond it, a code nobody has read is being suppressed.
+    """
+    assert _declared_ignored_codes(workflow) == _PUBLISHED_WARNING_CODES, (
+        "the gate's ignore list no longer matches the published W-class. If the scanner "
+        "published a new warning code, add it here and to the workflow in the same change; "
+        "if a code was removed, drop it. Never add a code that is not a W-code."
+    )
+
+    # The env var is only the declared list; what the gate actually suppresses is what it
+    # passes on the command line. An inline `--ignore-issues-codes "${IGNORED_ISSUE_CODES},E005"`
+    # would suppress the very rule the red-proof is anchored to while the check above stays
+    # green, so pin that the flag's argument is the variable and nothing else.
+    argument = re.search(
+        r'--ignore-issues-codes\s+"?([^"\n\\]*)"?', _gate_step(workflow)["run"]
+    )
+    assert argument, "the gating scan no longer passes an ignore list"
+    assert argument.group(1).strip() == "${IGNORED_ISSUE_CODES}", (
+        "the gating scan suppresses codes inline rather than through IGNORED_ISSUE_CODES. "
+        "Every exclusion must go through the reviewed list above, where its reason is "
+        f"written beside it; found {argument.group(1).strip()!r}."
     )
 
 
-def test_exclusion_carries_its_reason(workflow_text: str):
-    """An exclusion nobody can see is how a real finding gets hidden later."""
-    for code in _ACCEPTED_IGNORED_CODES:
-        assert code in workflow_text
+def test_gating_rule_is_written_down_where_it_is_configured(workflow_text: str):
+    """A rule nobody can see is how a real finding gets hidden later.
+
+    The ignore list is now fifteen codes long; without the rule stated beside it, the next
+    reader sees a pile of suppressions rather than one deliberate class decision.
+    """
+    assert "issue-codes.md" in workflow_text, (
+        "the workflow must cite the published catalog the W class is enumerated from"
+    )
     assert "untrusted third-party content" in workflow_text, (
-        "the W011 exclusion must state, in the workflow, what the finding is and why "
-        "it is accepted"
+        "the workflow must say what W011 — the code that actually fires on these skills "
+        "— is, so the list is not fifteen opaque strings"
+    )
+    lowered = workflow_text.lower()
+    assert "never fail" in lowered or "never block" in lowered, (
+        "the workflow must state the gating rule in words, not only in a variable"
+    )
+
+
+def test_warnings_are_surfaced_on_all_three_channels(workflow: dict):
+    """Warnings do not block, so they have to be impossible to miss instead.
+
+    Each channel serves a different consumer and none substitutes for the others: the
+    annotations are what an automated review agent queries through the checks API, the job
+    summary is what a human glances at, and the artifact is the deterministic full set that
+    tooling can fetch without scraping a log. If "does not block" quietly became "does not
+    appear", the gate would be back to the failure it was built to prevent.
+    """
+    job = _scan_job(workflow)
+    steps_text = _steps_text(job)
+
+    assert _REPORT.exists(), "the finding-surfacing script is missing"
+    assert "registry_scan_report.py" in steps_text, (
+        "nothing surfaces the findings; warnings would be invisible as well as non-blocking"
+    )
+
+    report_step = next(s for s in job["steps"] if "registry_scan_report.py" in s.get("run", ""))
+    _assert_unconditional(report_step, "the finding-surfacing step")
+
+    uploads = [
+        step for step in job["steps"]
+        if "upload-artifact" in str(step.get("uses", ""))
+    ]
+    assert uploads, "the finding set is never uploaded as an artifact"
+    assert uploads[0]["with"]["name"] == "registry-scan-findings", (
+        "the artifact name is the documented handle tooling fetches by; changing it breaks "
+        "every consumer that reads it"
+    )
+
+    source = _REPORT.read_text(encoding="utf-8")
+    assert "::warning" in source, "no warning annotations are emitted"
+    assert "GITHUB_STEP_SUMMARY" in source, "nothing is written to the job summary"
+
+
+def test_surfacing_findings_never_fails_the_build(workflow: dict):
+    """Warnings must not block — including through the back door of the reporter.
+
+    The reporter's only non-zero exit is unparseable scanner output, which is a broken
+    pipeline rather than a finding. Any other non-zero path would turn a warning into a
+    red build and quietly reverse the gating rule.
+    """
+    source = _REPORT.read_text(encoding="utf-8")
+    returns = set(re.findall(r"^\s+return (\d+)$", source, re.M))
+    assert returns <= {"0", "1", "2"}, f"unexpected exit codes in the reporter: {returns}"
+    assert "unparseable" in source.lower() or "UNREADABLE" in source, (
+        "the reporter's failure path must be about unreadable output, not about findings"
     )
 
 
@@ -126,21 +337,68 @@ def test_full_findings_are_printed_unfiltered(workflow: dict):
     """The scanner strips ignored findings from its printed report as well as from
     its exit status, so the gate runs an unfiltered pass first. If that pass ever
     grows an ignore list, accepted findings stop appearing in the log entirely."""
-    steps = _scan_job(workflow)["steps"]
-    visibility = [
-        step for step in steps
-        if "scan" in step.get("run", "") and "--ignore-issues-codes" not in step.get("run", "")
-        and "snyk-agent-scan" in step.get("run", "")
-    ]
-    assert visibility, (
-        "no unfiltered scan pass found — accepted findings would never be printed"
+    visibility = _visibility_step(workflow)
+    gate = _gate_step(workflow)
+    assert visibility is not gate, (
+        "the unfiltered pass and the gating pass are the same step; accepted findings "
+        "would never be printed anywhere"
+    )
+    # The visibility pass is advisory on purpose — the gate below is what fails the build —
+    # but only the visibility pass may be advisory.
+    assert visibility.get("continue-on-error") is True, (
+        "the unfiltered pass must be advisory; its job is to print, not to gate"
+    )
+
+
+def test_scan_path_points_at_a_tree_that_actually_holds_skills(workflow: dict):
+    """A gate that scans nothing passes.
+
+    The scanner reads a directory of `<name>/SKILL.md` subdirectories. Point it at a
+    renamed, moved, or restructured tree and it finds zero skills, reports nothing, and
+    exits 0 — a green check over an empty scan. The red-proof cannot catch this: it scans
+    its own temp fixture and never touches SCAN_PATH. So the path is pinned here, and the
+    workflow re-checks it at runtime against the tree it actually checked out.
+    """
+    scan_path = _REPO / workflow["env"]["SCAN_PATH"]
+    assert scan_path.is_dir(), f"SCAN_PATH {scan_path} is not a directory in this repo"
+    skills = sorted(p.parent.name for p in scan_path.glob("*/SKILL.md"))
+    assert skills, (
+        f"SCAN_PATH {workflow['env']['SCAN_PATH']!r} contains no '<name>/SKILL.md' — the "
+        f"scanner would find nothing to scan and the gate would pass over an empty tree"
+    )
+
+    text = _steps_text(_scan_job(workflow))
+    assert "SKILL.md" in text and "HAS NOTHING TO SCAN" in text, (
+        "the workflow must fail at runtime if SCAN_PATH holds no skills; this test only "
+        "pins the tree as it stands in the repo, not as it is checked out in CI"
     )
 
 
 def test_red_proof_runs_on_every_run(workflow: dict):
-    """A check that cannot fail is not a check."""
+    """A check that cannot fail is not a check.
+
+    Adding `if:` or `continue-on-error:` to this step disables the one guarantee the whole
+    gate rests on while leaving it plainly visible in the file, so both are asserted — and
+    it must run before the gating scan, so a broken anchor is reported as such rather than
+    as a scan result.
+    """
     assert _REDPROVE.exists(), "the red-proof script is missing"
-    assert "registry_scan_redprove.py" in _steps_text(_scan_job(workflow))
+    job = _scan_job(workflow)
+    redprove = [
+        step for step in job["steps"]
+        if "registry_scan_redprove.py" in step.get("run", "")
+    ]
+    assert len(redprove) == 1, "expected exactly one red-proof step"
+    _assert_unconditional(redprove[0], "the red-proof step")
+
+    gate_index = _step_index(job, lambda s: s is _gate_step(workflow))
+    redprove_index = _step_index(
+        job, lambda s: "registry_scan_redprove.py" in s.get("run", "")
+    )
+    assert redprove_index < gate_index, (
+        "the red-proof must run before the gating scan, so 'the gate cannot fail' is "
+        "reported as its own failure rather than hidden behind a scan result"
+    )
 
 
 def test_missing_token_fails_rather_than_passing_quietly(workflow: dict):
@@ -180,6 +438,108 @@ def test_scanner_coverage_limits_are_documented(workflow_text: str):
         assert scanner in workflow_text, (
             f"the workflow must say that {scanner} is not covered by this gate"
         )
+
+
+def _load_report_module():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("registry_scan_report", _REPORT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_SAMPLE_SCAN = {
+    "skills": {
+        "path": "skills",
+        "servers": [{"name": "ci-speedup"}, {"name": "ci-secure"}],
+        "issues": [
+            {
+                "code": "W011",
+                "message": "Exposure to untrusted third-party content",
+                "reference": [0, None],
+                "extra_data": {"severity": "medium"},
+            },
+            {
+                "code": "E005",
+                "message": "Suspicious download URL in skill",
+                "reference": [1, None],
+                "extra_data": {"severity": "critical"},
+            },
+        ],
+    }
+}
+
+
+def test_reporter_annotates_warnings_and_leaves_criticals_to_the_gate(tmp_path, capsys):
+    """Warnings become annotations; criticals do not.
+
+    A critical already fails the build loudly in the gating step. Annotating it here too
+    would double-report it, and an `::error::` annotation from a step that does not gate
+    is how a reader learns to distrust the annotations.
+    """
+    module = _load_report_module()
+    findings = tmp_path / "findings.json"
+    findings.write_text(json.dumps(_SAMPLE_SCAN), encoding="utf-8")
+
+    assert module.main(["report", str(findings)]) == 0
+    out = capsys.readouterr().out
+
+    assert "::warning title=W011 (medium) in ci-speedup::" in out
+    assert "::warning title=E005" not in out, "a critical must not be reported as a warning"
+    assert "::error" not in out, "the reporter does not gate, so it must not emit errors"
+
+    # Both findings still appear in the human table — "does not annotate" is not "does not show".
+    assert "W011" in out and "E005" in out
+    assert "ci-secure" in out
+
+
+def test_reporter_states_the_rule_in_the_job_summary(tmp_path, monkeypatch, capsys):
+    """The summary has to say what a green check means, or a reader infers 'clean'."""
+    module = _load_report_module()
+    findings = tmp_path / "findings.json"
+    findings.write_text(json.dumps(_SAMPLE_SCAN), encoding="utf-8")
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+
+    assert module.main(["report", str(findings)]) == 0
+    capsys.readouterr()
+
+    body = summary.read_text(encoding="utf-8")
+    assert "Warnings do not block" in body
+    assert "registry-scan-findings" in body, "the summary must point at the artifact"
+    assert "`W011`" in body and "`E005`" in body
+
+
+def test_reporter_fails_loudly_on_unreadable_scan_output(tmp_path, capsys):
+    """A reporter that silently produced nothing is indistinguishable from a clean scan."""
+    module = _load_report_module()
+    broken = tmp_path / "findings.json"
+    broken.write_text("the scanner crashed before writing anything\n", encoding="utf-8")
+
+    assert module.main(["report", str(broken)]) == 1
+    assert "UNREADABLE" in capsys.readouterr().err
+
+
+def test_reporter_survives_a_banner_before_the_json(tmp_path, capsys):
+    """The scanner prints a version line before the document in some versions."""
+    module = _load_report_module()
+    findings = tmp_path / "findings.json"
+    findings.write_text(
+        "Snyk Agent Scan v0.5.16\n" + json.dumps(_SAMPLE_SCAN), encoding="utf-8"
+    )
+
+    assert module.main(["report", str(findings)]) == 0
+    assert "::warning title=W011" in capsys.readouterr().out
+
+
+def test_reporter_reports_nothing_as_nothing(tmp_path, capsys):
+    module = _load_report_module()
+    findings = tmp_path / "findings.json"
+    findings.write_text(json.dumps({"skills": {"path": "skills", "issues": []}}), encoding="utf-8")
+
+    assert module.main(["report", str(findings)]) == 0
+    assert "No findings." in capsys.readouterr().out
 
 
 def test_redprove_builds_a_violating_skill_without_committing_one(tmp_path):

--- a/tests/test_registry_scan_workflow.py
+++ b/tests/test_registry_scan_workflow.py
@@ -160,6 +160,19 @@ def test_fork_prs_report_the_coverage_gap(workflow: dict):
     assert "DID NOT RUN" in _steps_text(fork_job)
 
 
+def test_fork_report_is_confined_to_pull_requests(workflow: dict):
+    """`github.event.pull_request` is null on pushes, schedules, and dispatches, so a
+    bare `head.repo.full_name != github.repository` is TRUE on every one of them. Without
+    the event-name clause this job posts a green 'fork PR — no scan coverage' check
+    beside a scan that actually ran — the misreading its name exists to prevent."""
+    guard = workflow["jobs"]["fork-not-scanned"]["if"]
+    assert "github.event_name == 'pull_request'" in guard, (
+        "the fork coverage-gap report must be gated on the pull_request event, or it "
+        "fires on pushes and scheduled runs too"
+    )
+    assert "github.event.pull_request.head.repo.full_name != github.repository" in guard
+
+
 def test_scanner_coverage_limits_are_documented(workflow_text: str):
     """Registries run more than one scanner; a green check here is not a clean bill
     of health from all of them."""

--- a/tests/test_registry_scan_workflow.py
+++ b/tests/test_registry_scan_workflow.py
@@ -17,6 +17,7 @@ inside the workflow itself on every run.
 """
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -183,7 +184,19 @@ def test_redprove_builds_a_violating_skill_without_committing_one(tmp_path):
 
     body = skill.read_text(encoding="utf-8")
     assert "curl" in body and "| bash" in body, "fixture lost the violating shape"
-    assert ".example.com/" in body, "fixture host must stay under the reserved example.com"
+
+    # Parse the host out rather than substring-matching the URL: the fixture must
+    # stay under example.com, reserved by RFC 2606 and not resolvable, so the
+    # red-proof can never point a reader (or an agent) at a live host.
+    from urllib.parse import urlsplit
+
+    urls = re.findall(r"https?://\S+", body)
+    assert urls, "fixture no longer contains a download URL"
+    for url in urls:
+        host = urlsplit(url).hostname or ""
+        assert host == "example.com" or host.endswith(".example.com"), (
+            f"fixture URL host {host!r} is outside the reserved example.com domain"
+        )
 
     # The assembled string must not appear verbatim in the script that assembles it.
     marker = "curl -sSL http" + "s://get.redprove-fixture.example.com"

--- a/tests/test_registry_scan_workflow.py
+++ b/tests/test_registry_scan_workflow.py
@@ -1,0 +1,192 @@
+"""The registry-scan gate's own shape is enforced, so it cannot rot silently.
+
+`.github/workflows/registry-scan.yml` runs a third-party security scanner over the
+installable skill trees, so a rule violation fails our build instead of surfacing
+as a public FAIL badge days after release. Almost every way that gate can decay is
+invisible: a dropped `--ci` makes findings advisory, a widened ignore list hides a
+real finding, a deleted `schedule` stops catching rule-catalog changes that need no
+commit of ours, a drifted runner label quietly moves the job off the runners the
+rest of this repo's CI dogfoods. In every one of those cases the check still runs
+and still reports green.
+
+These tests pin the properties the gate's value depends on. They are pure YAML and
+text assertions — no network, no scanner, no token — so they run in the same
+offline `pytest -v` as everything else. They cannot prove the scanner still
+detects anything; that is `.github/scripts/registry_scan_redprove.py`, which runs
+inside the workflow itself on every run.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+_REPO = Path(__file__).resolve().parents[1]
+_WORKFLOW = _REPO / ".github" / "workflows" / "registry-scan.yml"
+_CI_WORKFLOW = _REPO / ".github" / "workflows" / "ci.yml"
+_REDPROVE = _REPO / ".github" / "scripts" / "registry_scan_redprove.py"
+
+# The one accepted exclusion. Widening this set is a deliberate, reviewed change to
+# both this list and the rationale comment beside it in the workflow.
+_ACCEPTED_IGNORED_CODES = {"W011"}
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:
+    # PyYAML parses the `on:` key as the boolean True (YAML 1.1); read it back the
+    # same way rather than fighting it.
+    return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def workflow_text() -> str:
+    return _WORKFLOW.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def triggers(workflow: dict) -> dict:
+    return workflow[True] if True in workflow else workflow["on"]
+
+
+def _scan_job(workflow: dict) -> dict:
+    return workflow["jobs"]["scan"]
+
+
+def _steps_text(job: dict) -> str:
+    return "\n".join(step.get("run", "") for step in job["steps"])
+
+
+def test_workflow_exists_and_parses(workflow: dict):
+    assert workflow["jobs"], "registry-scan.yml has no jobs"
+
+
+def test_runs_on_pull_requests_and_pushes(triggers: dict):
+    assert "pull_request" in triggers, "the gate must run on pull requests"
+    assert "push" in triggers, "the gate must run on pushes to main"
+
+
+def test_scheduled_run_exists(triggers: dict):
+    """The scanner's rules change with no commit of ours — only a scheduled run
+    notices a skill that went red on its own."""
+    schedule = triggers.get("schedule")
+    assert schedule, "the gate must run on a schedule; a rule revamp needs no commit of ours"
+    assert any(entry.get("cron") for entry in schedule), "schedule entry has no cron expression"
+
+
+def test_manually_dispatchable(triggers: dict):
+    """A maintainer investigating a registry audit must be able to run it on demand."""
+    assert "workflow_dispatch" in triggers
+
+
+def test_runner_matches_the_repo_ci_runner(workflow: dict):
+    """This repo dogfoods StarSling runners for its internal CI. If ci.yml's runner
+    moves, this gate moves with it rather than drifting onto different infrastructure."""
+    ci = yaml.safe_load(_CI_WORKFLOW.read_text(encoding="utf-8"))
+    assert _scan_job(workflow)["runs-on"] == ci["jobs"]["test"]["runs-on"]
+
+
+def test_fork_prs_never_reach_the_self_hosted_runner(workflow: dict):
+    """Fork code must not execute on self-hosted runners (the ci.yml contract)."""
+    guard = _scan_job(workflow)["if"]
+    assert "github.event.pull_request.head.repo.full_name == github.repository" in guard
+
+
+def test_gate_uses_ci_flag(workflow: dict):
+    """Without --ci a finding is printed and the build stays green."""
+    assert "--ci" in _steps_text(_scan_job(workflow))
+
+
+def test_ignore_list_is_exactly_the_accepted_exclusion(workflow: dict):
+    declared = {
+        code.strip()
+        for code in workflow["env"]["IGNORED_ISSUE_CODES"].split(",")
+        if code.strip()
+    }
+    assert declared == _ACCEPTED_IGNORED_CODES, (
+        "the gate's ignore list changed. Every excluded code hides a real finding from "
+        "the build's exit status, so each one needs a reason written next to it in the "
+        "workflow and a matching update here."
+    )
+
+
+def test_exclusion_carries_its_reason(workflow_text: str):
+    """An exclusion nobody can see is how a real finding gets hidden later."""
+    for code in _ACCEPTED_IGNORED_CODES:
+        assert code in workflow_text
+    assert "untrusted third-party content" in workflow_text, (
+        "the W011 exclusion must state, in the workflow, what the finding is and why "
+        "it is accepted"
+    )
+
+
+def test_full_findings_are_printed_unfiltered(workflow: dict):
+    """The scanner strips ignored findings from its printed report as well as from
+    its exit status, so the gate runs an unfiltered pass first. If that pass ever
+    grows an ignore list, accepted findings stop appearing in the log entirely."""
+    steps = _scan_job(workflow)["steps"]
+    visibility = [
+        step for step in steps
+        if "scan" in step.get("run", "") and "--ignore-issues-codes" not in step.get("run", "")
+        and "snyk-agent-scan" in step.get("run", "")
+    ]
+    assert visibility, (
+        "no unfiltered scan pass found — accepted findings would never be printed"
+    )
+
+
+def test_red_proof_runs_on_every_run(workflow: dict):
+    """A check that cannot fail is not a check."""
+    assert _REDPROVE.exists(), "the red-proof script is missing"
+    assert "registry_scan_redprove.py" in _steps_text(_scan_job(workflow))
+
+
+def test_missing_token_fails_rather_than_passing_quietly(workflow: dict):
+    """A skipped security scan is the failure we are guarding against, wearing a
+    green check."""
+    text = _steps_text(_scan_job(workflow))
+    assert "SNYK_TOKEN" in text
+    assert "DID NOT RUN" in text, "a missing token must say so unmistakably in the log"
+    assert "exit 1" in text, "on an internal run, a missing token must fail the build"
+
+
+def test_fork_prs_report_the_coverage_gap(workflow: dict):
+    """Fork PRs cannot reach the token. The check that remains must not read as
+    'scanned, clean' — its own name has to carry the gap."""
+    fork_job = workflow["jobs"]["fork-not-scanned"]
+    assert "NOT RUN" in fork_job["name"]
+    assert "DID NOT RUN" in _steps_text(fork_job)
+
+
+def test_scanner_coverage_limits_are_documented(workflow_text: str):
+    """Registries run more than one scanner; a green check here is not a clean bill
+    of health from all of them."""
+    for scanner in ("Gen Agent Trust Hub", "Socket"):
+        assert scanner in workflow_text, (
+            f"the workflow must say that {scanner} is not covered by this gate"
+        )
+
+
+def test_redprove_builds_a_violating_skill_without_committing_one(tmp_path):
+    """The fixture is assembled at runtime: the literal that got a shipped skill
+    flagged must not exist anywhere in this repository, this script included."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("registry_scan_redprove", _REDPROVE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    scan_root = module.build_violating_skill(tmp_path)
+    skill = scan_root / "redprove-fixture" / "SKILL.md"
+    assert skill.exists(), "the fixture must be a <parent>/<name>/SKILL.md tree"
+
+    body = skill.read_text(encoding="utf-8")
+    assert "curl" in body and "| bash" in body, "fixture lost the violating shape"
+    assert ".example.com/" in body, "fixture host must stay under the reserved example.com"
+
+    # The assembled string must not appear verbatim in the script that assembles it.
+    marker = "curl -sSL http" + "s://get.redprove-fixture.example.com"
+    assert marker not in _REDPROVE.read_text(encoding="utf-8"), (
+        "the red-proof script now contains the literal it is supposed to construct"
+    )


### PR DESCRIPTION
## The problem

Skill registries publish third-party security audits of every skill they list, and a skill can fail one of those audits without failing anything in this repository. The text a skill ships is the thing being scanned, so an illustrative example can read to a scanner as the attack it describes. That is what happened to `ci-secure`: its own teaching material for the "download an installer and pipe it into a shell" attack vector shipped literal installer URLs, and the scanner read the antibody as the virus and rated the skill CRITICAL. We found out days later by looking at the public page. There is no rescan button and no dispute channel — audits re-run only when someone freshly installs the skill — so a FAIL badge on a security product is expensive and slow to reverse. The specific literals were fixed in #39; this is the gate that catches the next one before it merges.

## What the gate does

`.github/workflows/registry-scan.yml` runs the same scanner the registry uses (Snyk Agent Scan, `uvx snyk-agent-scan@latest`) over `skills/` — the installable trees, exactly what the `skills` CLI copies onto a user's machine and what a registry publishes. It runs on every internal pull request, on pushes to `main`, weekly on a schedule, and on demand.

## What fails the build, and what does not

**Critical findings block; warnings never do.** The scanner sorts findings into a critical class (`E`-codes) and a warning class (`W`-codes). A critical finding fails the build. A warning does not, because the warnings these skills produce are mostly accurate descriptions of what they legitimately do — W011 "exposure to untrusted third-party content" is what reading a repository's own CI configuration and job logs looks like to a scanner. Those are judgements for a human, not a gate. The scanner has no severity threshold, so the rule is expressed by enumerating the published `W` class into `--ignore-issues-codes`; the workflow says so beside the list, and a test fails if an `E`-code ever appears there.

**Warnings are surfaced, not silenced.** "Does not block" must not decay into "does not appear" — that is the same failure this gate exists to prevent, wearing a different hat. Every run publishes the full finding set three ways, each for a different consumer:

- **Annotations** on the checks tab, one per warning, titled with the code, severity, and skill. These come back through the checks API, which is how an automated review agent reads them.
- **A job summary table** of every finding, headed by the rule itself, for a human glancing at the run.
- **A `registry-scan-findings` artifact** holding the scanner's raw JSON, kept 14 days, so tooling can fetch the exact finding set with `gh run download` instead of scraping a log.

This still costs exactly two scanner invocations. The unfiltered pass emits `--json` and `.github/scripts/registry_scan_report.py` renders all three surfaces from it; the second pass is the authoritative gate. Two passes are necessary because `--ignore-issues-codes` strips findings from the printed report as well as from the exit status, so the gating pass is structurally incapable of showing a warning.

## A missing token is never a pass

A skipped security scan reported as green is the failure we are fixing. On internal pushes and pull requests the secret is expected to exist, so **its absence is a red build, not a neutral skip** — the job prints a banner and a GitHub error annotation saying the scan did not run and that this is a coverage gap. The same reasoning covers the other door into a vacuous pass: if `skills/` ever stopped matching the `<name>/SKILL.md` shape the scanner reads, it would find zero skills and exit 0, so the job fails unless it can count at least one skill to scan.

Fork pull requests are different: they cannot reach repository secrets at all, and failing an external contributor's PR for infrastructure they have no way to fix would be hostile. They instead get a separate check named **"registry scan NOT RUN (fork PR — no scan coverage)"**, which passes but carries the gap in its own name and emits a warning annotation. A maintainer re-runs the scan on an internal branch before merging any fork change under `skills/`. Fork code also never touches the self-hosted runners, matching the existing `ci.yml` / `ci-fork.yml` contract.

## The gate is red-proved on every run, and the proof has now run

A check that cannot fail is not a check. Before the real scan, every run executes `.github/scripts/registry_scan_redprove.py`, which builds a throwaway skill in a temp directory whose text carries the exact violation class that got us flagged, scans it **with the gate's real ignore list**, and fails the job unless the scanner both reports `E005` and exits non-zero. The offending string is assembled from fragments at runtime and never exists on disk in this repository — committing such a literal is precisely what the gate exists to prevent.

That step also guards the direction nobody watches. The scanner's rule catalog changes with no commit of ours, and its maintainers have said the issue codes are being revamped. If the rule this gate is anchored to is renamed or retired, the red-proof goes red and we find out from our own CI rather than from a public audit page. The weekly scheduled run does the same job for our shipped skills.

**Both directions are now observed live, not asserted.** From this PR's own passing run:

```
Found 3 skill(s) under 'skills' to scan.

Red-proof: scanning a deliberately violating skill
● Scanning /tmp/registry-scan-redprove-x40o92p1 found 1 skill
└── redprove-fixture 2 findings (2 high)
    ● [E005 high]: Suspicious download URL detected (high risk: 1.00). This is a
    direct link to a shell installer hosted on a non-official/custom domain and
    the skill explicitly pipes it to bash ("curl ... | bash")
CI (--ci): exiting with code 1 (issue codes: E005, E006).
Red-proof passed: the scanner reported E005 and exited 1. The gate can fail.

6 finding(s): 0 critical, 6 warning.
Artifact registry-scan-findings has been successfully uploaded!
```

So the gate demonstrably goes red on a violation, and demonstrably goes green on `skills/` as it stands — with its six warnings visible as annotations rather than suppressed.

## What this does not cover

Registries run more than one scanner. This gate reproduces exactly one of them. It says nothing about Gen Agent Trust Hub, which publishes no rule catalog and no CLI and whose verdicts are LLM-generated and not reproducible from one run to the next, or about Socket. A green check here means "Snyk Agent Scan finds no critical finding" — it is not a clean bill of health from every registry scanner. That limit is written in three places a maintainer would actually look: the workflow's header comment, a "Registry security scanning" section in `CONTRIBUTING.md`, and a test that fails if the workflow stops saying it.

## Guarding the gate against itself

`tests/test_registry_scan_workflow.py` (27 tests, offline, no token) pins the properties that would otherwise decay invisibly. The assertions are per-step and identity-aware rather than text searches over the job, because the looser form let four real evasions through: moving `--ci` onto the advisory pass, adding `continue-on-error` or an `if:` to the red-proof step, and suppressing codes inline at the call site instead of through the reviewed list all kept the suite green. It also pins that no `E`-code is ever ignored, that the ignore list matches the published `W` class, that all three warning surfaces exist, and that the scan path really holds skills.

## Changelog

No skill changelog entry. `CLAUDE.md` scopes the changelog rule to changes that alter a skill's behaviour, and this changes none: it is repository CI infrastructure, adds no shipped file under `skills/`, and is invisible to anyone who installs a skill.

## Testing

`python3 -m pytest -q` — 3363 passed, 15 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
