### PR TITLE
registry-scan: run in the public repo only

### DIFF
--- a/.github/workflows/registry-scan.yml
+++ b/.github/workflows/registry-scan.yml
@@ -71,9 +71,15 @@ jobs:
     # The scan talks to a network service. A stalled request would otherwise hold a self-hosted
     # runner for the six-hour GitHub default with no signal.
     timeout-minutes: 20
+    # Public repo only. On any private staging copy of this tree (e.g. a pre-launch mirror),
+    # running the scan would send UNRELEASED skill text to a third-party scanner API — for a new
+    # skill, the verdict minted on that first contact is the one it wears, so the scan is held
+    # until launch. The guard also keeps a mirror's missing/foreign SNYK_TOKEN from painting
+    # every staged PR red with a scan that was never supposed to run there.
     if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.repository == 'starslingdev/skills' &&
+      (github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository)
     env:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
@@ -205,6 +211,7 @@ jobs:
     # this job would post a green "fork PR — no scan coverage" check next to a real scan that
     # did run — the exact misreading the job's name exists to prevent.
     if: >-
+      github.repository == 'starslingdev/skills' &&
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `github.repository == 'starslingdev/skills'` as the leading clause of both jobs' `if:` conditions in `.github/workflows/registry-scan.yml`.

**Why.** The workflow triggers on bare `pull_request`, so any private staging copy of this tree that opens or updates a PR fires the scan there too. On a staging copy that's actively harmful, twice over: the scan would send **unreleased skill text** to the third-party scanner API — and for a new skill, the verdict minted on that first contact is the one it wears, with no rescan or dispute channel — and a missing (or org-inherited) `SNYK_TOKEN` would otherwise paint every staged PR red with a scan that was never supposed to run there.

**In this repo the guard is a no-op**: `github.repository` always equals `starslingdev/skills`, so scan scheduling, PR gating, the weekly run, and the fork-coverage-gap job all behave exactly as before.

Both jobs get the clause — `scan` and `fork-not-scanned` — so a staging copy shows skipped checks rather than a misleading green "fork PR — no scan coverage" annotation.

Full suite green: 3360 passed, 18 skipped (includes the 27 workflow-pinning tests in `tests/test_registry_scan_workflow.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)