### PR TITLE
ci-secure: credentials-scoped fact no longer fails on fork/watch triggers

### DIFF
--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -11,6 +11,20 @@ entries are dated (UTC). Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **2026-08-12** — **The `sec.checkout.credentials-scoped` fact no longer fails
+  workflows triggered only by `fork`/`watch`.** Those events fire when someone
+  forks or stars the repo; the workflow runs base code in the base context with
+  no attacker text, ref, or artifact entering the job, so a persisted checkout
+  token cannot be read by any attacker-influenced execution and
+  `persist-credentials: false` is not a defense there. Failing such a workflow
+  was a false positive on a config that is not actually exposed. The fact now
+  excludes `fork`/`watch` from its own applicability; a workflow that also
+  carries a real untrusted trigger (a PR head, comment/issue/discussion text, a
+  `workflow_run` artifact, a dispatch payload) still fails. The trigger set the
+  other checks use is unchanged.
+
 ### Added
 
 - **2026-08-10** — **A repo guard for installer-shaped literals.** Two shapes

--- a/skills/ci-secure/references/security-facts.md
+++ b/skills/ci-secure/references/security-facts.md
@@ -40,7 +40,7 @@ instead of shipping.
 | `sec.codeowners.workflows` | — none | CODEOWNERS is not workflow YAML; no ci-score check reads it. |
 | `sec.trigger.fork-code-uncleared` | `ci.trigger.*` (concurrency, cancel, path-filter) | Those checks read `concurrency:` and `paths:` blocks; this fact reads the trigger list plus checkout `ref:`/`repository:` values. No shared YAML key. Also tiered against ci-secure's own P14.9 finding: a bare untrusted trigger passes (the true-of-84% defect, deliberately removed), trigger + attacker-head checkout fails this FACT, and only the full trigger + checkout + execution chain is the P14.9 finding — so the fact and the finding cannot fire on the same edit either. |
 | `sec.secrets.no-blanket-inherit` | — none | No ci-score check reads `secrets:` on reusable-workflow calls. |
-| `sec.checkout.credentials-scoped` | `ci.checkout.shallow-clone` | Both read checkout steps, but different keys: `fetch-depth` there, `persist-credentials` here — two `with:` entries, two edits. This fact also applies only on untrusted-trigger workflows; shallow-clone applies on PR-gating ones. |
+| `sec.checkout.credentials-scoped` | `ci.checkout.shallow-clone` | Both read checkout steps, but different keys: `fetch-depth` there, `persist-credentials` here — two `with:` entries, two edits. This fact also applies only on untrusted-trigger workflows (excluding the payload-less `fork`/`watch` notification events); shallow-clone applies on PR-gating ones. |
 
 **Residual correlation, disclosed:** a repo with careless
 workflow hygiene will tend to fail checks in both tools — that is the
@@ -71,4 +71,6 @@ two moved numbers.
 - **`sec.checkout.credentials-scoped`** — on untrusted-trigger workflows,
   every `actions/checkout` sets `persist-credentials: false`. GitHub's default
   persists the token into `.git/config`, where attacker-influenced later steps
-  can read it. Trusted-trigger workflows are not this fact's business.
+  can read it. Trusted-trigger workflows are not this fact's business — nor are
+  the payload-less `fork`/`watch` notification events, which carry no
+  attacker-influenced execution that could read a persisted token.

--- a/skills/ci-secure/scripts/config_facts.py
+++ b/skills/ci-secure/scripts/config_facts.py
@@ -451,6 +451,23 @@ def _jobs_checking_out_attacker_head(scan: ModuleType, doc: dict) -> list[str]:
     return out
 
 
+# Untrusted triggers that carry NO attacker-controllable payload — pure activity
+# notifications. `fork`/`watch` fire when someone forks or stars the repo; the
+# workflow runs base code in the base context with no attacker text, ref, or
+# artifact entering the job. A persisted checkout token therefore cannot be read
+# by any attacker-influenced execution (there is none), so persist-credentials is
+# not a defense on these events and the credentials-scoped fact must not FAIL on
+# them (doing so penalised a config that is not actually exposed, and the reduced
+# score propagated into ci-advisor's blend). These stay in the GLOBAL
+# `_UNTRUSTED_TRIGGERS` — other checks (e.g. a write-token grant on an untrusted
+# trigger) still legitimately care about a fork/watch workflow — so the narrowing
+# is local to this one fact. Every other untrusted trigger carries attacker
+# content (a PR head, comment/issue/discussion text, a workflow_run artifact, a
+# dispatch payload) that, directly or via injection, can reach a persisted token,
+# so it stays in scope.
+_CREDS_SCOPED_INERT_TRIGGERS = frozenset({"fork", "watch"})
+
+
 def _unpersisted_checkout_violations(doc: dict) -> list[str]:
     """On an untrusted-trigger workflow, every checkout must set
     persist-credentials: false — GitHub's DEFAULT is to persist the token into
@@ -578,7 +595,11 @@ def compute_config_facts(
 
     persist = []
     for rel, doc in docs:
-        if not _untrusted_triggers_of(scan, doc):
+        # Scope to triggers that can actually expose a persisted token: exclude
+        # the payload-less notification events (`fork`/`watch`) that carry no
+        # attacker-influenced execution. A workflow with a real untrusted trigger
+        # AND fork/watch still applies (the subtraction leaves the real one).
+        if not (_untrusted_triggers_of(scan, doc) - _CREDS_SCOPED_INERT_TRIGGERS):
             continue
         jobs = _unpersisted_checkout_violations(doc)
         if jobs:

--- a/skills/ci-secure/tests/test_config_facts.py
+++ b/skills/ci-secure/tests/test_config_facts.py
@@ -613,6 +613,30 @@ def test_persisted_credentials_fail_only_on_untrusted_triggers(tmp_path):
                     "sec.checkout.credentials-scoped")["outcome"] == "fail"
 
 
+def test_persisted_credentials_pass_on_payloadless_notification_triggers(tmp_path):
+    """`fork`/`watch` fire on a fork/star with no attacker text, ref, or
+    artifact entering the job, so a persisted checkout token is unreadable by any
+    attacker-influenced execution — persist-credentials is not a defense there
+    and the fact must PASS, not FAIL (a false positive that dragged the security
+    score, and the blend, down). But a workflow that ALSO carries a real
+    untrusted trigger still FAILs — the notification event must not launder it."""
+    persisting = ("jobs:\n  t:\n    runs-on: ubuntu-latest\n"
+                  "    steps: [{uses: actions/checkout@v4}, {run: make}]\n")
+    for trig in ("[fork]", "[watch]", "[fork, watch]"):
+        wf = f"on: {trig}\npermissions: {{contents: read}}\n" + persisting
+        root, files = _repo(tmp_path / trig.strip("[]"), {"ci.yml": wf})
+        assert _outcome(cf.compute_config_facts(root, files, []),
+                        "sec.checkout.credentials-scoped")["outcome"] == "pass", \
+            f"{trig}: a payload-less notification trigger was wrongly failed"
+
+    # fork PLUS a real untrusted trigger: still exposed, still fails.
+    combo = "on: [fork, pull_request_target]\npermissions: {contents: read}\n" + persisting
+    rootc, filesc = _repo(tmp_path / "combo", {"ci.yml": combo})
+    assert _outcome(cf.compute_config_facts(rootc, filesc, []),
+                    "sec.checkout.credentials-scoped")["outcome"] == "fail", \
+        "fork laundered a real untrusted trigger (pull_request_target)"
+
+
 # --- coverage gaps: never a silent pass --------------------------------------
 
 def test_unscannable_workflow_forces_workflow_facts_to_unmeasured(tmp_path):


### PR DESCRIPTION
## What was wrong

`sec.checkout.credentials-scoped` failed any workflow with an untrusted trigger whose checkout did not set `persist-credentials: false` — and the untrusted-trigger set includes `fork` and `watch`. Those events fire when someone forks or stars the repo: the workflow runs base code in the base context, with no attacker text, ref, or artifact entering the job. A persisted checkout token can't be read by attacker-influenced execution there, so `persist-credentials: false` is not a defense — and failing such a workflow is a false positive on a configuration that is not actually exposed.

## The fix

The fact now excludes `fork`/`watch` from its own applicability (a local inert-trigger set subtracted from the untrusted triggers it scores). A workflow that *also* carries a real untrusted trigger — a PR head, comment/issue/discussion text, a `workflow_run` artifact, a dispatch payload — still fails; the notification event can't launder it. The trigger set every other check uses is unchanged.

## Tests

- New case: `fork`/`watch`/`[fork, watch]`-only workflows with a persisting checkout now PASS; `fork + pull_request_target` still FAILS.
- Full ci-secure suite green (535 passed); full repo suite green (3364 passed).