### PR TITLE
Add skills-registry-security maintainer tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ docs/methodology.md                 # public front-door methodology (links into 
 examples/                           # sanitized sample report(s)
 maintainers/                        # maintainer-only loop infra, OUTSIDE the installable tree
   ci-score/                         #   (ci-score's maintainer-only material)
+  skills-registry-security/         # skill: triage a registry audit verdict (see its README.md)
   ci-speedup/                       #   (the `skills` CLI copies skills/<name>/ recursively, so
     MAINTAINERS.md                  #    keeping this here is the only way to keep it out of installs)
     loops/                          # loop prompts + summary schema (gap→catalog, transcript)
@@ -72,6 +73,18 @@ of a run. The debug lines record **endpoints, response sizes, and
 pattern/workflow names — never gh response bodies**, so secrets returned by gh
 API calls won't appear. Workflow file paths and pattern names DO appear; review a
 captured log before sharing it externally if your workflow names are sensitive.
+
+## Registry audit triage (maintainers-only)
+
+When a published skill shows a failing security audit on skills.sh, do NOT
+start reverse-engineering it by hand — that path has already been walked and it
+costs hours. Run `maintainers/skills-registry-security/` instead; it answers
+"is this finding real, or is the registry auditing stale content?" in seconds
+and prints the evidence either way. Overview:
+`maintainers/skills-registry-security/README.md`. The model behind it —
+including why a fresh audit timestamp proves nothing, and the precondition to
+check before concluding an install did nothing — is in that skill's
+`references/audit-pipeline.md`.
 
 ## Maintainer self-improvement loops (local, maintainers-only)
 

--- a/maintainers/skills-registry-security/CHANGELOG.md
+++ b/maintainers/skills-registry-security/CHANGELOG.md
@@ -4,6 +4,26 @@ Maintainer-only. Not part of any installable skill tree.
 
 ## Added
 
+- **2026-08-13** — **The skill moves from one-shot diagnostic to unattended
+  operator: it now emits a next-action verdict and checks whether an install can
+  even fire the re-index beacon.** `decide()` reduces a run to one of `RESOLVED`
+  / `ACTION_REQUIRED` (a cited literal is still in HEAD — a real finding) /
+  `MONITOR` (the finding is stale, nothing to fix, wait for the registry's own
+  re-audit) / `DISAGREEMENT` / `UNVERIFIED`, so a watch loop can act without a
+  human reading the report. `beacon_precondition()` checks the GitHub-repo probe
+  (must be 200) and the telemetry env vars up front, so a suppressed-beacon
+  environment (the 403 sandbox/CI case) is never mistaken for "installs don't
+  trigger a re-audit" — the false conclusion that turned a prior run into a
+  ~two-day manual drive. SKILL.md gains a "Drive it to green unattended" section:
+  a durable server-side Routine (never an in-session timer, which stalls when the
+  session suspends), surface-only-on-decision-change, the beacon-suppressed
+  branch (monitor the registry's own cadence rather than loop no-op installs),
+  escalation reframed as an optional long-shot draft (never auto-filed, never
+  "the fix"), and rails — read-only research subagents by default, no
+  rename/re-slug remediation, fetched-clock timing, and an evidence checklist
+  before concluding. Twelve tests pin `decide()`'s branches and
+  `beacon_precondition()`'s suppression paths.
+
 - **2026-08-11** — **The stored snapshot is now read directly, which turns the
   central claim from an inference into an artifact.** `GET
   /api/download/{owner}/{repo}/{skill}` returns the pre-built snapshot the

--- a/maintainers/skills-registry-security/CHANGELOG.md
+++ b/maintainers/skills-registry-security/CHANGELOG.md
@@ -4,6 +4,22 @@ Maintainer-only. Not part of any installable skill tree.
 
 ## Added
 
+- **2026-08-11** — **The stored snapshot is now read directly, which turns the
+  central claim from an inference into an artifact.** `GET
+  /api/download/{owner}/{repo}/{skill}` returns the pre-built snapshot the
+  registry keeps and the scanners read, as real file contents plus a
+  `skillsComputedHash`. Searching a finding's quoted literal in those bytes
+  answers "what was the scanner actually handed?" instead of inferring it from
+  what the repository no longer contains. Literals are now classified three
+  ways — `REAL` (still in current content, the finding stands), `STALE_INPUT`
+  (gone from the repository but still in the snapshot, so the input needs
+  refreshing), and `PHANTOM` (gone from both, so the scanner is likely serving
+  its own cached result) — because those three cases have different remedies
+  and asking for the wrong one wastes days. A `STALE_INPUT` verdict prints the
+  snapshot hash and the offending paths, which is exactly what a maintainer
+  needs to confirm the claim against their own service without access to the
+  repository.
+
 - **2026-08-11** — **The skill exists.** `scripts/registry_audit.py` answers
   "is this registry security failure real?" in one command by reading all four
   cached surfaces concurrently, running a throwaway install to capture the risk

--- a/maintainers/skills-registry-security/CHANGELOG.md
+++ b/maintainers/skills-registry-security/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog — skills-registry-security
+
+Maintainer-only. Not part of any installable skill tree.
+
+## Added
+
+- **2026-08-11** — **The skill exists.** `scripts/registry_audit.py` answers
+  "is this registry security failure real?" in one command by reading all four
+  cached surfaces concurrently, running a throwaway install to capture the risk
+  table users actually see, scraping the per-provider finding codes that the
+  JSON API does not expose, and grepping every literal a finding quotes against
+  both a git ref and the freshly installed tree. A literal absent from both is
+  reported as `PHANTOM`, which is the signal that the scan input is stale rather
+  than the code being wrong. Doing this by hand took an afternoon; the script
+  takes about seven seconds with `--no-install` and about forty with it.
+
+- **2026-08-11** — **The gotchas that cost the most time are written down.**
+  SKILL.md records that installing never promptly triggers a re-scan, that the
+  audit cache key carries no commit SHA so merging a fix invalidates nothing,
+  that the JSON API carries no finding codes, that timestamps arrive in two
+  formats on one payload, and — the expensive one — that a re-audit can re-run
+  scanners against a stored snapshot, so a fresh `auditedAt` is not evidence
+  that current code was read. `references/registry-surfaces.md` carries the URL
+  shapes, response schemas, and the `E`/`W` finding-code split.
+
+- **2026-08-11** — **The re-index versus re-audit distinction is load-bearing.**
+  Asking for a plain re-audit of a stale snapshot reproduces the same finding,
+  so the skill names re-indexing explicitly as the thing to request, and lists
+  the three artifacts that make such a request verifiable without access to the
+  repository: the finding code with its quoted literal, the commit that removed
+  that literal, and an `auditedAt` proving the scan ran afterwards.

--- a/maintainers/skills-registry-security/CHANGELOG.md
+++ b/maintainers/skills-registry-security/CHANGELOG.md
@@ -45,3 +45,20 @@ Maintainer-only. Not part of any installable skill tree.
   the three artifacts that make such a request verifiable without access to the
   repository: the finding code with its quoted literal, the commit that removed
   that literal, and an `auditedAt` proving the scan ran afterwards.
+
+- **2026-08-11** — **Retracted "installs never trigger indexing", which was the
+  costliest wrong conclusion in the original investigation.** The nine-install
+  experiment behind it ran in an environment where `api.github.com` answers
+  403; the CLI reads a non-OK response there as "cannot determine visibility"
+  and silently drops the install beacon, so the experiment exercised a code
+  path that never fired. The beacon is what triggers content ingest, and ingest
+  appears repo-scoped. Documented the precondition check to run *before*
+  concluding anything from an install, since a suppressed beacon looks
+  identical to a registry that ignores installs. Added a twenty-second summary
+  and an annotated real timeline at the top of the pipeline reference — the
+  earlier draft was accurate but too dense to act on. Recorded the dead ends
+  with their evidence (a live but orphaned `check-updates` endpoint, an
+  auth-gated `revalidate` hook, origin-side rather than edge staleness, ignored
+  ref parameters) so they are not re-derived, and the fact that the indexer
+  drops files above roughly 500-600 KB, which means a snapshot is not a
+  faithful copy of the folder.

--- a/maintainers/skills-registry-security/CHANGELOG.md
+++ b/maintainers/skills-registry-security/CHANGELOG.md
@@ -39,6 +39,22 @@ Maintainer-only. Not part of any installable skill tree.
   that current code was read. `references/registry-surfaces.md` carries the URL
   shapes, response schemas, and the `E`/`W` finding-code split.
 
+- **2026-08-13** — **The chain is now observed end to end, so "wait" is a
+  procedure with a number on it rather than advice.** A watched cycle closed
+  every link on one skill: beacon-capable install → snapshot rebuilt ~3 h later
+  → **audit re-ran unattended ~22 h after that** → Snyk went fail/CRITICAL with
+  E005+W011 to warn/MEDIUM with W011 alone. Nothing was requested at any step
+  after the install. Added a *When a re-audit happens* section and three
+  measured rows: re-index → re-audit ~22 h, audit-to-audit 24–28 h (loose
+  enough that a missed day means nothing), and all three providers re-stamping
+  within 38 s, which shows audits are one batched per-skill sweep rather than
+  independent provider schedules. The practical rule that falls out: after an
+  install, budget ~3 h for the snapshot and up to another day for the badge,
+  and do not poll in between — twenty polls across that window returned a
+  byte-identical payload every time and established nothing. Left explicitly
+  open whether a re-index *enqueues* the audit or the sweep is purely
+  periodic; 22 h fits both.
+
 - **2026-08-11** — **The re-index versus re-audit distinction is load-bearing.**
   Asking for a plain re-audit of a stale snapshot reproduces the same finding,
   so the skill names re-indexing explicitly as the thing to request, and lists
@@ -62,6 +78,23 @@ Maintainer-only. Not part of any installable skill tree.
   ref parameters) so they are not re-derived, and the fact that the indexer
   drops files above roughly 500-600 KB, which means a snapshot is not a
   faithful copy of the folder.
+
+- **2026-08-13** — **Retracted "gone from repo and snapshot means the scanner
+  cached it", the mirror image of the original mistake.** `verify_literals`
+  classified any literal absent from both corpora as `PHANTOM` — scanner at
+  fault, re-index will not help, escalate. That verdict was produced for a real
+  finding and an escalation packet was drafted on it; four hours later the
+  audit re-ran on its own and cleared the finding. Absence from both is equally
+  consistent with the ordinary post-fix state: the fix landed, the snapshot
+  caught up, and the audit had not read it yet. The original error was reading
+  a fresh timestamp over stale content as "the fix did not work"; this is the
+  same error with the operands swapped. The verdict now splits three ways on
+  whether the audit predates the snapshot — `LAGGING` (wait, do not escalate),
+  `PHANTOM` (the scanner has read this snapshot and still cites the literal, so
+  escalate), and `PHANTOM_OR_LAGGING` when the new `--snapshot-changed-at` is
+  not supplied, which refuses to guess and names the flag that would decide it.
+  The oldest provider stamp is used, not the newest: a literal is only phantom
+  if *every* scanner citing it has read the current snapshot.
 
 - **2026-08-12** — **The remedy is confirmed by experiment, so the skill now
   states it as a procedure rather than a hypothesis.** One install whose

--- a/maintainers/skills-registry-security/CHANGELOG.md
+++ b/maintainers/skills-registry-security/CHANGELOG.md
@@ -21,8 +21,26 @@ Maintainer-only. Not part of any installable skill tree.
   escalation reframed as an optional long-shot draft (never auto-filed, never
   "the fix"), and rails — read-only research subagents by default, no
   rename/re-slug remediation, fetched-clock timing, and an evidence checklist
-  before concluding. Twelve tests pin `decide()`'s branches and
-  `beacon_precondition()`'s suppression paths.
+  before concluding. A `/registry-security` slash command runs the whole thing
+  against a target, since the skill lives in `maintainers/` and is therefore
+  never installed or auto-discovered. Tests pin `decide()`'s branches,
+  `beacon_precondition()`'s suppression paths, and the rendered NEXT ACTION.
+
+- **2026-08-13** — **An unread surface is no longer reported as a clean badge.**
+  Three defects found in review, all the same shape: `decide()` classified from
+  provider status and literal verdicts alone and never consulted the `error` /
+  `http` fields the fetchers already record, so it could not tell "verified
+  clean" from "never fetched". An unreachable provider API returned no
+  providers, which read as nothing-failing and resolved to `RESOLVED` — an
+  unattended watch stopping on a badge it never actually read. A failing
+  provider whose finding-detail page 503'd landed in the benign "keep watching"
+  branch instead of being flagged unclassifiable. Both now return `UNVERIFIED`
+  naming the unreachable surface. Separately, the risk half of the
+  failing-provider test read `riskLevel`, a key the fetchers never write (they
+  store `risk`), so it was dead code and a HIGH/CRITICAL provider whose status
+  read pass-or-blank scored as clean; the test fixtures carried the same typo,
+  so the suite confirmed the bug rather than catching it. Fixtures now use the
+  shape `fetch_api` really emits.
 
 - **2026-08-11** — **The stored snapshot is now read directly, which turns the
   central claim from an inference into an artifact.** `GET

--- a/maintainers/skills-registry-security/CHANGELOG.md
+++ b/maintainers/skills-registry-security/CHANGELOG.md
@@ -62,3 +62,15 @@ Maintainer-only. Not part of any installable skill tree.
   ref parameters) so they are not re-derived, and the fact that the indexer
   drops files above roughly 500-600 KB, which means a snapshot is not a
   faithful copy of the folder.
+
+- **2026-08-12** — **The remedy is confirmed by experiment, so the skill now
+  states it as a procedure rather than a hypothesis.** One install whose
+  telemetry beacon actually reaches the service rebuilds the stored snapshot;
+  nine installs from an environment where the beacon was suppressed did
+  nothing. Same repository, same skill, the beacon the only difference — which
+  makes the precondition check the single most valuable line in the document,
+  since a suppressed beacon and an unresponsive registry look identical from
+  outside. Recorded the measured latency: re-indexing an already-known skill
+  took about three hours, against roughly fifty minutes to first-index a new
+  one, so a couple of quiet hours is not evidence of failure and the guidance
+  is to budget half a day before concluding an install did not work.

--- a/maintainers/skills-registry-security/CHANGELOG.md
+++ b/maintainers/skills-registry-security/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 Maintainer-only. Not part of any installable skill tree.
 
+## Fixed
+
+- **2026-08-13** — **An unscanned skill is no longer reported as a passing one,
+  and the operator loop no longer contradicts itself about installs.** Three
+  defects found in adversarial review. (1) `decide()` gated on the status API's
+  `http`/`error` fields but not on its contents, so a 200 carrying an empty
+  `audits` list — nobody has scanned this skill yet, the normal state of a
+  just-published one, which is precisely when this skill gets run — produced
+  zero failing providers and resolved to `RESOLVED`, stopping an unattended
+  watch before the first scan ever landed. It now returns `UNVERIFIED` saying
+  no provider has reported. (2) The Gotchas claim "Installing never triggers a
+  re-scan … polling on a timer is wasted effort — check once, then act"
+  contradicted both *Forcing a refresh* (one beacon-capable install rebuilds the
+  snapshot) and the operator loop (watch on a durable Routine; on `MONITOR` with
+  a live beacon, run one install). It is the pre-beacon-experiment belief the
+  skill exists to refute, and an agent executing the loop would have hit it as
+  authoritative guidance. Reworded to split the install's cached audit *lookup*
+  (changes nothing) from its telemetry *beacon* (enqueues a re-index when it can
+  fire). (3) The decision table described `UNVERIFIED` as only the no-local-corpus
+  case and prescribed `--repo-root`, though `decide()` also emits it for an
+  unreachable API, an API with no records, and an unreachable finding-detail
+  page — for which that instruction is a no-op. The row now covers all four and
+  says never to treat the verdict as green.
+
 ## Added
 
 - **2026-08-13** — **The skill moves from one-shot diagnostic to unattended

--- a/maintainers/skills-registry-security/README.md
+++ b/maintainers/skills-registry-security/README.md
@@ -1,0 +1,73 @@
+# skills-registry-security
+
+Maintainer-only. Deliberately outside `skills/`, so it never ships to end users.
+
+Answers one question quickly: **a published skill shows a failing security
+audit — is that real, or is the registry auditing stale content?**
+
+The security analysis itself belongs to the registry's providers (Gen Agent
+Trust Hub, Socket, Snyk). This tool triages *their verdict*: it decides whether
+a finding describes the skill as it is today, and if not, produces the evidence
+that says so.
+
+## Running it
+
+```bash
+python3 maintainers/skills-registry-security/scripts/registry_audit.py \
+    starslingdev/skills/ci-secure
+```
+
+About 6 seconds with a live install, ~1.4s with `--no-install`. Everything is
+read-only: HTTP GETs, a throwaway install into a temp directory, and greps over
+a local checkout. Nothing is written to the repository and nothing is POSTed to
+the registry.
+
+## What one run does, in order
+
+1. **Fans out concurrently** across every cached surface: the JSON audit API,
+   the install-path cache the CLI actually reads, the rendered page badges, and
+   the three per-provider detail pages.
+2. **Scrapes the finding codes** (`E005`, `W011`, …) from those detail pages.
+   The JSON API returns only prose like `"CRITICAL · 2 issues"`, so the pages
+   are the only place the actual findings exist.
+3. **Runs a real `npx skills add`** in a temp directory and captures the
+   "Security Risk Assessments" table verbatim — what a user actually sees.
+4. **Fetches the stored snapshot** (`/api/download/...`), the content the
+   scanners read, along with its hash.
+5. **Searches every literal a finding quotes** against three corpora: the git
+   ref, the freshly installed tree, and the snapshot.
+6. **Classifies each literal and prints a verdict:**
+   - `REAL` — still in current content. The finding stands; fix it or accept it
+     with a written rationale.
+   - `STALE_INPUT` — gone from the repository but still in the snapshot. Nothing
+     to patch. Prints the snapshot hash and offending paths, which is what makes
+     an escalation verifiable without access to your repository.
+   - `PHANTOM` — gone from both. The scanner is likely serving its own cached
+     result, so a re-index alone may not clear it.
+   - `UNVERIFIED` — no corpus to compare against, so it declines to guess.
+
+It also reports disagreement between surfaces, which is common and usually
+resolves on its own as caches catch up.
+
+## What ships with it
+
+| Path | What it is |
+|---|---|
+| `SKILL.md` | The agent-facing contract, plus the gotchas that cost the most time |
+| `scripts/registry_audit.py` | The engine. stdlib only |
+| `references/audit-pipeline.md` | How the registry actually works: the twenty-second diagram, an annotated real timeline, the precondition check, observed timings, tested dead ends, an evidence log, and how to gate CI so this cannot recur |
+| `references/registry-surfaces.md` | Exact URL shapes, response schemas, the `E`/`W` finding-code split |
+| `evals/evals.json` | Four scenarios |
+| `tests/` | Offline tests, wired into the repo suite |
+
+## Why it exists
+
+The investigation this came from took about six hours and produced four wrong
+conclusions along the way — including "installs never trigger indexing," which
+came from an experiment invalidated by a silently suppressed telemetry beacon.
+
+The script reproduces the correct answer in seconds. The references record both
+the working model and the mistakes, so the next person does not repeat them.
+The most important single line in there is the precondition check: an install
+whose beacon never fired looks exactly like a registry that ignores installs,
+and confusing the two sends you hunting a bug that does not exist.

--- a/maintainers/skills-registry-security/README.md
+++ b/maintainers/skills-registry-security/README.md
@@ -42,8 +42,14 @@ the registry.
    - `STALE_INPUT` — gone from the repository but still in the snapshot. Nothing
      to patch. Prints the snapshot hash and offending paths, which is what makes
      an escalation verifiable without access to your repository.
-   - `PHANTOM` — gone from both. The scanner is likely serving its own cached
-     result, so a re-index alone may not clear it.
+   - `LAGGING` — gone from both, and the audit predates the current snapshot.
+     The ordinary post-fix state: the fix worked and the badge has not caught
+     up. Wait ~a day; do not escalate.
+   - `PHANTOM` — gone from both, and the audit has already read this snapshot.
+     Only then is the scanner serving its own cached result, so a re-index
+     alone may not clear it.
+   - `PHANTOM_OR_LAGGING` — gone from both, with no `--snapshot-changed-at` to
+     tell those two apart. It declines to guess rather than accuse the scanner.
    - `UNVERIFIED` — no corpus to compare against, so it declines to guess.
 
 It also reports disagreement between surfaces, which is common and usually

--- a/maintainers/skills-registry-security/SKILL.md
+++ b/maintainers/skills-registry-security/SKILL.md
@@ -180,7 +180,7 @@ The script emits a **`NEXT ACTION` decision** (`--json` puts it under
 | `ACTION_REQUIRED` | a cited literal is still in HEAD — a real finding | surface it with the evidence; fix the code or accept it with a rationale; **stop watching** |
 | `MONITOR` | a provider still fails but every cited literal is gone from HEAD | **nothing to fix** — keep watching until the registry re-audits it away |
 | `DISAGREEMENT` | cached surfaces disagree | re-check shortly before trusting either |
-| `UNVERIFIED` | no local corpus to classify against | supply `--repo-root`/`--ref` and re-run |
+| `UNVERIFIED` | something could not be read, so nothing can be concluded — the status API was unreachable, it returned no audit records at all (nobody has scanned this skill yet), a finding detail page failed to load, or there is no local corpus to classify literals against | read `why`: supply `--repo-root`/`--ref` if it names the corpus, otherwise **keep watching** and re-run — never treat this as green |
 
 **The watch MUST run on a durable server-side Routine, never an in-session
 timer.** In a suspending session, `CronCreate`, `ScheduleWakeup`, and a
@@ -230,10 +230,15 @@ file it automatically**, and never present it as "the fix."
 These are the traps that make this task take hours instead of a minute. Most of
 them look like a bug in your own reasoning when you hit them cold.
 
-- **Installing never triggers a re-scan.** The CLI's audit call is a plain GET
-  keyed on `owner/repo` plus the skill slug, with no commit SHA anywhere in it.
-  Installing repeatedly, waiting, and re-installing accomplishes nothing.
-  Polling on a timer is wasted effort — check once, then act.
+- **The install's *audit lookup* never triggers a re-scan — the install's
+  *beacon* is what rebuilds the snapshot.** The CLI's audit call is a plain GET
+  keyed on `owner/repo` plus the skill slug, with no commit SHA anywhere in it,
+  so it reads a cache and changes nothing. The separate telemetry beacon does
+  enqueue a re-index — but only when it can fire (see *Forcing a refresh*).
+  Hence: one beacon-capable install is worth running once; re-installing after
+  it is worth nothing, and installing from a beacon-suppressed environment is
+  worth nothing at all. Nine suppressed installs over six hours moved the
+  snapshot hash zero times.
 
 - **Merging a fix does not invalidate anything.** Because the cache key carries
   no SHA, pushing the fix to the default branch leaves the audit untouched.

--- a/maintainers/skills-registry-security/SKILL.md
+++ b/maintainers/skills-registry-security/SKILL.md
@@ -45,6 +45,22 @@ The script is read-only: HTTP GETs, a throwaway install into a temp directory,
 and greps over a local checkout. It never POSTs to the registry and never
 writes to the repository.
 
+### Invoking this skill
+
+**This skill has no automatic trigger.** It lives under `maintainers/`, which is
+excluded from every installable skill tree, so its frontmatter is never loaded
+and its description never fires on its own. It runs only when a maintainer asks
+for it by name, or through the bundled slash command:
+
+```bash
+ln -sf "$PWD/maintainers/skills-registry-security/commands/registry-security.md" \
+       .claude/commands/registry-security.md    # then: /registry-security <owner/repo/skill>
+```
+
+`.claude/` is gitignored, so that symlink is per-checkout; the command source is
+tracked under `commands/` here. The unattended loop below is armed the same way
+— by a maintainer session — and then runs server-side without one.
+
 ## What it reports, and how to read it
 
 The output has six parts. Read them in this order, because each one narrows

--- a/maintainers/skills-registry-security/SKILL.md
+++ b/maintainers/skills-registry-security/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: skills-registry-security
+description: >-
+  Checks the third-party security audit status of a skill published to a skills
+  registry (skills.sh), across every cached surface at once, and decides whether
+  a failing finding is real or points at content that was already removed. Runs
+  a real install to capture what users actually see, reads the per-provider
+  finding codes the JSON API does not expose, and greps each flagged literal
+  against the repository and the shipped tree. Use when a published skill shows
+  a FAIL or CRITICAL security audit, when an audit looks stale or predates a fix,
+  when someone asks why a registry badge disagrees with a merged change, when
+  deciding whether to request a re-index, or before or after publishing a skill
+  that has been flagged. Also use when a Snyk, Socket, or Gen Agent Trust Hub
+  verdict on a published skill needs to be explained or disputed.
+---
+
+# Registry security status for a published skill
+
+A registry stores a skill's audit in several places that drift apart, and the
+verdict a user sees at install time is not the one the JSON API returns. Worse,
+a re-audit can run against a stored snapshot rather than the current default
+branch, so a finding can survive long after the code it describes is deleted.
+Answering "is this failure real?" therefore means reading four surfaces and then
+proving, by grep, whether the flagged string still exists.
+
+`scripts/registry_audit.py` does all of that concurrently. Run it first; read
+the rest of this file only when the output needs interpreting.
+
+## Quick start
+
+```bash
+python3 maintainers/skills-registry-security/scripts/registry_audit.py \
+    starslingdev/skills/ci-secure
+```
+
+Roughly 40 seconds, most of it the install. Add `--no-install` for a ~3 second
+check when only the cached verdicts matter. `--json` emits the same data
+machine-readably; `--ref` picks the git ref to verify literals against
+(default `origin/main`).
+
+The script is read-only: HTTP GETs, a throwaway install into a temp directory,
+and greps over a local checkout. It never POSTs to the registry and never
+writes to the repository.
+
+## What it reports, and how to read it
+
+The output has five parts. Read them in this order, because each one narrows
+the question:
+
+1. **Provider status** — status, risk level, and `auditedAt` per provider from
+   the JSON API. If every `auditedAt` predates the fix you are checking, the
+   audit simply has not re-run yet and nothing else matters.
+2. **Install-path cache** — the separate endpoint the CLI reads. This is what
+   users see. It has lagged the API by a full day.
+3. **Fresh install output** — the verbatim risk table the CLI prints.
+4. **Findings** — the actual codes (`E005`, `W011`, …) scraped from the
+   per-provider pages, plus every literal each finding quotes, each tagged
+   `present` or `PHANTOM`.
+5. **Verdict** — whether any flagged literal is absent from both the git ref and
+   the freshly installed tree.
+
+A literal tagged `PHANTOM` is the finding worth escalating: the scanner is
+objecting to a string that exists in neither the default branch nor the shipped
+skill, which can only happen if the scan input is stale.
+
+## Deciding what to do
+
+The output separates three cases that need very different responses. Getting
+this wrong wastes days, so decide deliberately:
+
+**The finding is real.** The literal is `present`. The scanner is describing
+today's content. Fix it or consciously accept it — a re-scan will keep
+reporting it, correctly. Warning-class codes are frequently accurate
+descriptions of what a skill legitimately does, and accepting one with a
+written rationale is a valid outcome.
+
+**The scan input is stale.** A literal is `PHANTOM`. There is nothing to patch.
+Requesting a plain re-audit is the trap here: re-auditing the same stored
+snapshot reproduces the same finding. Ask for a **re-index** — refreshing the
+stored snapshot — and say so explicitly, because the two are different
+operations and only one of them helps.
+
+**The surfaces disagree.** The reconciliation section fires. The underlying
+audit may be fine while users still see a stale badge. This resolves on its own
+as caches catch up; confirm by re-running rather than by acting.
+
+To make a stale-input case airtight, gather the three pieces of evidence a
+maintainer can verify without your repository: the finding code and the exact
+literal it quotes, the commit that removed that literal with its timestamp, and
+the `auditedAt` timestamp showing the scan ran *after* that commit. If the
+project runs the same scanner in its own CI, a passing run on the current
+default branch is the strongest single exhibit — same scanner, opposite verdict.
+
+## Gotchas
+
+These are the traps that make this task take hours instead of a minute. Most of
+them look like a bug in your own reasoning when you hit them cold.
+
+- **Installing never triggers a re-scan.** The CLI's audit call is a plain GET
+  keyed on `owner/repo` plus the skill slug, with no commit SHA anywhere in it.
+  Installing repeatedly, waiting, and re-installing accomplishes nothing.
+  Polling on a timer is wasted effort — check once, then act.
+
+- **Merging a fix does not invalidate anything.** Because the cache key carries
+  no SHA, pushing the fix to the default branch leaves the audit untouched.
+  Expect no change from a merge alone.
+
+- **The JSON API does not carry finding codes.** It returns only a summary
+  string like `Risk: CRITICAL · 2 issues`. The codes and the quoted literals
+  live exclusively on the per-provider HTML pages. Any workflow that reads only
+  the API cannot tell a real finding from a phantom one.
+
+- **Timestamps come in two formats on the same payload** — some providers emit
+  `...Z`, others `...+00:00`. Compare parsed datetimes, never strings.
+
+- **A re-audit is not a re-index.** A refresh can re-run the scanner against the
+  stored snapshot, producing a brand-new `auditedAt` on a finding derived from
+  old content. A fresh timestamp is therefore not evidence that current code was
+  read.
+
+- **Warning-class and critical-class codes are different animals.** A single
+  critical code drives the whole verdict; warning codes usually describe
+  inherent behavior and often should be accepted rather than chased.
+
+- **Check the sibling skills too.** Registry sweeps have re-audited the skills
+  that did not change while skipping the one that did. Comparing timestamps
+  across every skill in the same repository exposes that inversion, and it is
+  strong evidence for an escalation.
+
+- **A finding can be about a test fixture.** Vendored third-party workflows and
+  deliberately malicious-looking fixtures get scanned like real code. These are
+  usually false positives, but they are genuinely present in the tree, so the
+  script reports them as `present` — that tag means "really there", not
+  "really a problem".
+
+- **A URL whose host ends in `.sh` is not a shell script.** Rules about download
+  URLs key on the *path* ending in `.sh`, `.ps1`, or `.bash`. A documentation
+  link to a `.sh` domain is a false alarm when triaging by hand.
+
+- **Install counters do not reflect your installs.** They appear deduplicated,
+  so a rising count is not confirmation that an install registered.
+
+## Deeper reference
+
+`references/registry-surfaces.md` documents each surface's exact URL shape and
+response schema, and the finding-code classes. Read it when the script's parsing
+breaks — for example after a registry redesign changes the page markup — or when
+adding a provider.

--- a/maintainers/skills-registry-security/SKILL.md
+++ b/maintainers/skills-registry-security/SKILL.md
@@ -11,7 +11,12 @@ description: >-
   when someone asks why a registry badge disagrees with a merged change, when
   deciding whether to request a re-index, or before or after publishing a skill
   that has been flagged. Also use when a Snyk, Socket, or Gen Agent Trust Hub
-  verdict on a published skill needs to be explained or disputed.
+  verdict on a published skill needs to be explained or disputed. Beyond
+  diagnosing, it drives a failing badge to green unattended: it emits a
+  next-action verdict, checks whether an install can even fire the re-index
+  beacon in this environment, and is meant to watch on a durable schedule until
+  the registry's own re-audit clears a stale finding — so no one has to babysit
+  a rescan by hand.
 ---
 
 # Registry security status for a published skill
@@ -144,6 +149,67 @@ look impossible.
 
 Do not escalate before doing this. Most "the registry is stuck" reports are
 really "no beacon-capable install has happened since the fix landed."
+
+## Drive it to green unattended (the operator loop)
+
+This is the point of the skill: **you own the outcome, not the human.** A stale
+badge takes hours-to-days to clear (re-index ~3h, re-audit ~22h behind it, and
+the registry's own sweep runs ~daily), so you must WATCH it yourself and surface
+only when something changes — never hand the human a timer to babysit.
+
+The script emits a **`NEXT ACTION` decision** (`--json` puts it under
+`decision`) so a watch loop can act without anyone reading the report:
+
+| decision | what it means | what you do |
+| --- | --- | --- |
+| `RESOLVED` | every provider passes, no outstanding literal | report green, **stop watching** |
+| `ACTION_REQUIRED` | a cited literal is still in HEAD — a real finding | surface it with the evidence; fix the code or accept it with a rationale; **stop watching** |
+| `MONITOR` | a provider still fails but every cited literal is gone from HEAD | **nothing to fix** — keep watching until the registry re-audits it away |
+| `DISAGREEMENT` | cached surfaces disagree | re-check shortly before trusting either |
+| `UNVERIFIED` | no local corpus to classify against | supply `--repo-root`/`--ref` and re-run |
+
+**The watch MUST run on a durable server-side Routine, never an in-session
+timer.** In a suspending session, `CronCreate`, `ScheduleWakeup`, and a
+background `sleep` loop do **not** fire while the turn is idle — the loop stalls
+until a human re-pings (this is the failure that turned one real run into ~31
+manual re-pings). Arm `mcp__Claude_Code_Remote__create_trigger` with a cron that
+matches the timings (every few hours is plenty) and a prompt that re-runs the
+script and acts on `decision`. **Surface to the owner only when the decision
+CHANGES** (to `RESOLVED` / `ACTION_REQUIRED` / `DISAGREEMENT`) or a max-elapsed
+cap is hit; on an unchanged `MONITOR`, re-arm silently. **Disable the Routine the
+moment it resolves.**
+
+On a `MONITOR`, branch on the beacon (the `decision.beacon` block):
+- **Beacon can fire AND no beacon-capable install has happened since the fix** →
+  run ONE ordinary install to nudge the re-index, then watch the snapshot hash.
+- **Beacon suppressed** (the common CI/sandbox case — the `github probe` isn't
+  200, e.g. a 403) → do **NOT** loop installs; an install is a no-op here. Just
+  watch the registry's own re-audit cadence, which clears a stale finding on its
+  own. Looping suppressed installs manufactures a false "installs do nothing"
+  record — the exact trap this skill exists to avoid.
+
+**Escalation is a last-resort nudge, not a fix — and it is optional.** A
+re-index issue on `vercel-labs/skills` (the registry's repo, not yours) is a
+long shot: recent re-scan requests sit open and unactioned, and in the run this
+skill came from the finding cleared on the registry's *own* cadence, not from
+any issue. So **draft** such an issue for the owner only if they ask, **never
+file it automatically**, and never present it as "the fix."
+
+**Rails (non-negotiable):**
+- **Any research subagent you spawn is READ-ONLY by default** — say verbatim in
+  its prompt: no `add_repo`/attach, no push, no comments, no issues; read via
+  public WebFetch/WebSearch for any repo outside scope (e.g. `vercel-labs/skills`).
+  Never add the constraint reactively after a push-access prompt appears.
+- **Never rename or re-slug a published skill to force a fresh scan.** It breaks
+  the skill's identity, installs, and marketing. The artifact's identity is not a
+  variable; exclude it from every remediation menu.
+- **Compute every elapsed-time and "when did X happen" from a fetched clock**
+  (the `auditedAt`/snapshot timestamps and the fix commit time), never a narrated
+  estimate.
+- **Before concluding, run the evidence checklist:** `git blame`/history on the
+  flagged lines, your own CI's scanner output on `main` (same scanner — strong
+  corroboration), the finding detail page, and the actual network calls. Don't
+  speculate about content you can read.
 
 ## Gotchas
 

--- a/maintainers/skills-registry-security/SKILL.md
+++ b/maintainers/skills-registry-security/SKILL.md
@@ -82,9 +82,28 @@ hash and the stale file paths — quote both, since they let a maintainer confir
 the claim with a single request against their own service and without access to
 your repository.
 
-**`PHANTOM` — gone from the repository *and* the snapshot.** The scanner is
-likely serving a cached result of its own, so a re-index alone may not clear it.
-Say that explicitly rather than asking for the wrong remedy.
+**Gone from the repository *and* the snapshot — check which of two cases this
+is before saying anything.** They look identical and need opposite responses,
+and the discriminator is one comparison: **is the finding's `auditedAt` older
+than the time the snapshot hash last changed?**
+
+- **`LAGGING` — the audit predates the snapshot.** The ordinary post-fix state:
+  the fix landed, the snapshot caught up, the audit has not read it yet. The
+  literal is missing from the snapshot *because the fix worked*. Wait for the
+  next sweep — measured at ~22 h, unattended — and re-check. Do not escalate,
+  do not re-install, nothing is stuck.
+- **`PHANTOM` — the audit has run against this snapshot and still cites the
+  literal.** Only now is a scanner-side cache the explanation, and a re-index
+  alone may not clear it. Escalate with the evidence.
+- **`PHANTOM_OR_LAGGING` — you did not pass `--snapshot-changed-at`.** The
+  script refuses to guess. Supply the time the hash last changed; until then
+  assume the lagging case, which is far more common and costs only patience.
+
+Getting this backwards has already happened once here: a `PHANTOM` verdict sent
+an investigation toward an escalation packet four hours before the audit re-ran
+on its own and cleared the finding. Corroborate with the code split — warning
+codes reproducing while a critical code vanishes is the signature of stale
+input, not of a phantom.
 
 **Surfaces disagree.** The reconciliation section fires. The audit may be fine
 while users still see a stale badge. This resolves as caches catch up; confirm

--- a/maintainers/skills-registry-security/SKILL.md
+++ b/maintainers/skills-registry-security/SKILL.md
@@ -161,6 +161,14 @@ them look like a bug in your own reasoning when you hit them cold.
 
 ## Deeper reference
 
+`references/audit-pipeline.md` is the model behind all of this: an ASCII map of
+the two pipelines, what each timestamp does and does not mean, observed timings
+with an escalation threshold, two fully worked timelines, how to prevent the
+problem in CI, and an evidence log recording how every claim was established
+plus the overreaches that were ruled out. Read it when deciding whether to wait
+or escalate, when a timing question comes up, or before repeating any of the
+reverse-engineering.
+
 `references/registry-surfaces.md` documents each surface's exact URL shape and
 response schema, and the finding-code classes. Read it when the script's parsing
 breaks — for example after a registry redesign changes the page markup — or when

--- a/maintainers/skills-registry-security/SKILL.md
+++ b/maintainers/skills-registry-security/SKILL.md
@@ -2,21 +2,19 @@
 name: skills-registry-security
 description: >-
   Checks the third-party security audit status of a skill published to a skills
-  registry (skills.sh), across every cached surface at once, and decides whether
-  a failing finding is real or points at content that was already removed. Runs
-  a real install to capture what users actually see, reads the per-provider
-  finding codes the JSON API does not expose, and greps each flagged literal
-  against the repository and the shipped tree. Use when a published skill shows
-  a FAIL or CRITICAL security audit, when an audit looks stale or predates a fix,
-  when someone asks why a registry badge disagrees with a merged change, when
-  deciding whether to request a re-index, or before or after publishing a skill
-  that has been flagged. Also use when a Snyk, Socket, or Gen Agent Trust Hub
-  verdict on a published skill needs to be explained or disputed. Beyond
-  diagnosing, it drives a failing badge to green unattended: it emits a
-  next-action verdict, checks whether an install can even fire the re-index
-  beacon in this environment, and is meant to watch on a durable schedule until
-  the registry's own re-audit clears a stale finding — so no one has to babysit
-  a rescan by hand.
+  registry (skills.sh) across every cached surface, decides whether a failing
+  finding is real or points at content already removed, and drives a stale badge
+  to green unattended. Runs a real install to capture what users see, reads the
+  per-provider finding codes the JSON API omits, and greps each flagged literal
+  against the repository and shipped tree; emits a next-action verdict, checks
+  whether an install can even fire the re-index beacon in this environment, and
+  watches on a durable schedule until the registry's own re-audit clears a stale
+  finding. Use when a published skill shows a FAIL or CRITICAL audit, when an
+  audit looks stale or predates a fix, when a registry badge disagrees with a
+  merged change, when deciding whether to request a re-index, before or after
+  publishing a flagged skill, or when a Snyk, Socket, or Gen Agent Trust Hub
+  verdict needs to be explained or disputed — so no one has to babysit a rescan
+  by hand.
 ---
 
 # Registry security status for a published skill

--- a/maintainers/skills-registry-security/SKILL.md
+++ b/maintainers/skills-registry-security/SKILL.md
@@ -44,52 +44,55 @@ writes to the repository.
 
 ## What it reports, and how to read it
 
-The output has five parts. Read them in this order, because each one narrows
+The output has six parts. Read them in this order, because each one narrows
 the question:
 
 1. **Provider status** — status, risk level, and `auditedAt` per provider from
-   the JSON API. If every `auditedAt` predates the fix you are checking, the
-   audit simply has not re-run yet and nothing else matters.
+   the JSON API. A fresh `auditedAt` proves only that scanners ran, not that
+   current code was read; keep going.
 2. **Install-path cache** — the separate endpoint the CLI reads. This is what
    users see. It has lagged the API by a full day.
 3. **Fresh install output** — the verbatim risk table the CLI prints.
-4. **Findings** — the actual codes (`E005`, `W011`, …) scraped from the
-   per-provider pages, plus every literal each finding quotes, each tagged
-   `present` or `PHANTOM`.
-5. **Verdict** — whether any flagged literal is absent from both the git ref and
-   the freshly installed tree.
-
-A literal tagged `PHANTOM` is the finding worth escalating: the scanner is
-objecting to a string that exists in neither the default branch nor the shipped
-skill, which can only happen if the scan input is stale.
+4. **Stored snapshot** — the `skillsComputedHash` and file count of the content
+   the registry has on hand. This is the scanners' actual input.
+5. **Findings** — the codes (`E005`, `W011`, …) scraped from the per-provider
+   pages, plus every literal each finding quotes, classified against all three
+   corpora.
+6. **Verdict** — which of the cases below applies, with the evidence to quote.
 
 ## Deciding what to do
 
-The output separates three cases that need very different responses. Getting
-this wrong wastes days, so decide deliberately:
+Each literal is classified by comparing what the skill *is* (the git ref and the
+installed tree) against what the scanner was *handed* (the stored snapshot).
+Those two questions have opposite remedies, so the classification is the whole
+decision:
 
-**The finding is real.** The literal is `present`. The scanner is describing
-today's content. Fix it or consciously accept it — a re-scan will keep
+**`REAL` — present in current content.** The scanner is describing today's
+skill. Fix it, or accept it with a written rationale; a re-scan will keep
 reporting it, correctly. Warning-class codes are frequently accurate
-descriptions of what a skill legitimately does, and accepting one with a
-written rationale is a valid outcome.
+descriptions of what a skill legitimately does, and accepting one is a valid
+outcome. Staleness is not the explanation here.
 
-**The scan input is stale.** A literal is `PHANTOM`. There is nothing to patch.
-Requesting a plain re-audit is the trap here: re-auditing the same stored
-snapshot reproduces the same finding. Ask for a **re-index** — refreshing the
-stored snapshot — and say so explicitly, because the two are different
-operations and only one of them helps.
+**`STALE_INPUT` — gone from the repository, still in the stored snapshot.**
+Nothing to patch. The scanner is right about its input and the input is old.
+Requesting a plain re-audit is the trap: re-auditing the same snapshot
+reproduces the finding. Ask for a **re-index**, and say the word, because these
+are different operations and only one helps. The script prints the snapshot
+hash and the stale file paths — quote both, since they let a maintainer confirm
+the claim with a single request against their own service and without access to
+your repository.
 
-**The surfaces disagree.** The reconciliation section fires. The underlying
-audit may be fine while users still see a stale badge. This resolves on its own
-as caches catch up; confirm by re-running rather than by acting.
+**`PHANTOM` — gone from the repository *and* the snapshot.** The scanner is
+likely serving a cached result of its own, so a re-index alone may not clear it.
+Say that explicitly rather than asking for the wrong remedy.
 
-To make a stale-input case airtight, gather the three pieces of evidence a
-maintainer can verify without your repository: the finding code and the exact
-literal it quotes, the commit that removed that literal with its timestamp, and
-the `auditedAt` timestamp showing the scan ran *after* that commit. If the
-project runs the same scanner in its own CI, a passing run on the current
-default branch is the strongest single exhibit — same scanner, opposite verdict.
+**Surfaces disagree.** The reconciliation section fires. The audit may be fine
+while users still see a stale badge. This resolves as caches catch up; confirm
+by re-running rather than by acting.
+
+If the project runs the same scanner in its own CI, a passing run on the current
+default branch is a strong supporting exhibit — same scanner, opposite verdict,
+which isolates the input as the variable.
 
 ## Gotchas
 
@@ -116,7 +119,23 @@ them look like a bug in your own reasoning when you hit them cold.
 - **A re-audit is not a re-index.** A refresh can re-run the scanner against the
   stored snapshot, producing a brand-new `auditedAt` on a finding derived from
   old content. A fresh timestamp is therefore not evidence that current code was
-  read.
+  read — fetch the snapshot and check it directly instead of trusting the clock.
+
+- **A rescan can make the case *harder* to argue.** While the audit predated the
+  fix, "the scan is older than the commit" was enough. After a rescan on a stale
+  snapshot, the finding carries a current timestamp and reads as "your fix did
+  not work". Expect to need the snapshot as evidence, not the timestamps.
+
+- **Install and audit are fed by different pipelines.** Installing can clone the
+  current default branch while the audit reads the stored snapshot, so a clean
+  installed tree is entirely compatible with a failing audit. Neither one proves
+  anything about the other.
+
+- **Deterministic and model-based providers fail differently on stale input.** A
+  rule-based scanner reproduces its previous finding exactly; a model-based
+  reviewer may reverse itself on identical content. If a rule-based critical
+  finding survives a rescan even though its literal is gone, the input did not
+  change — that pattern is itself evidence.
 
 - **Warning-class and critical-class codes are different animals.** A single
   critical code drives the whole verdict; warning codes usually describe

--- a/maintainers/skills-registry-security/SKILL.md
+++ b/maintainers/skills-registry-security/SKILL.md
@@ -94,6 +94,38 @@ If the project runs the same scanner in its own CI, a passing run on the current
 default branch is a strong supporting exhibit — same scanner, opposite verdict,
 which isolates the input as the variable.
 
+## Forcing a refresh when the input is stale
+
+Confirmed by experiment, not inference: **one install that reaches the telemetry
+service rebuilds the snapshot.** There is no button, no API, and no ticket
+required — but there is a precondition, and getting it wrong is what makes this
+look impossible.
+
+1. **Verify the beacon can actually fire.** On the machine doing the install:
+
+   ```bash
+   curl -sS -o /dev/null -w '%{http_code}\n' https://api.github.com/repos/OWNER/REPO   # need 200
+   env | grep -iE 'DO_NOT_TRACK|DISABLE_TELEMETRY'                                     # need empty
+   ```
+
+   The CLI decides whether the repo is private with an unauthenticated call to
+   that endpoint and treats any non-OK response as "cannot tell", which silently
+   suppresses the install event. Sandboxes, CI containers, and rate-limited IPs
+   routinely fail this. An install with a suppressed beacon is indistinguishable
+   from a registry that ignores installs, which is exactly the wrong conclusion
+   to reach.
+
+2. **Run one ordinary install** — `npx skills add OWNER/REPO`. Nothing special,
+   no flags. One is enough; repeating it does not speed anything up.
+
+3. **Watch the snapshot hash**, not the audit timestamps. Re-index for an
+   already-indexed skill took **~3 hours** in the observed case (a first index
+   of a brand-new skill was faster, ~50 minutes). The audit then re-runs behind
+   it on its own cadence and the finding clears.
+
+Do not escalate before doing this. Most "the registry is stuck" reports are
+really "no beacon-capable install has happened since the fix landed."
+
 ## Gotchas
 
 These are the traps that make this task take hours instead of a minute. Most of

--- a/maintainers/skills-registry-security/commands/registry-security.md
+++ b/maintainers/skills-registry-security/commands/registry-security.md
@@ -1,0 +1,32 @@
+---
+description: Check a published skill's skills.sh security audit, decide the next action, and drive a stale badge to green unattended
+argument-hint: [owner/repo/skill]
+---
+
+Run the maintainer-only `skills-registry-security` skill against `$ARGUMENTS`
+(default `starslingdev/skills/ci-secure` if no target is given).
+
+Read `maintainers/skills-registry-security/SKILL.md` and follow it. In short:
+
+1. Run the audit and read the `NEXT ACTION` verdict:
+
+   ```bash
+   python3 maintainers/skills-registry-security/scripts/registry_audit.py <owner/repo/skill> --repo-root .
+   ```
+
+   Add `--no-install` for the ~3s check instead of ~40s.
+
+2. Act on the verdict:
+   - `RESOLVED` — the badge is clean. Report and stop.
+   - `ACTION_REQUIRED` — a cited literal is still in HEAD. It is a real finding;
+     surface it with the code and stop. Do not fix silently.
+   - `MONITOR` — the finding is stale, there is nothing to patch, and the
+     registry's own ~daily re-audit is what clears it. Arm the unattended watch
+     per SKILL.md's "Drive it to green unattended" section and report only on a
+     decision change.
+   - `DISAGREEMENT` / `UNVERIFIED` — surfaces disagree or could not be
+     classified. Re-check before trusting; never report a badge as clean.
+
+Rails from SKILL.md that always apply: never rename or re-slug a published
+skill, never auto-file an issue on the registry's repo, and keep any research
+subagents read-only.

--- a/maintainers/skills-registry-security/evals/evals.json
+++ b/maintainers/skills-registry-security/evals/evals.json
@@ -1,0 +1,33 @@
+{
+  "skill_name": "skills-registry-security",
+  "evals": [
+    {
+      "id": 1,
+      "name": "stale-critical-finding",
+      "prompt": "Our ci-secure skill on skills.sh is showing a CRITICAL Snyk audit but we removed the flagged content days ago. Figure out what's actually going on and tell me whether there's anything left for us to fix.",
+      "expected_output": "Runs registry_audit.py rather than manually curling surfaces. Reports the E005 finding and the literal it quotes, identifies that literal as absent from both the git ref and the installed tree, and concludes the scan input is stale with nothing to patch. Recommends requesting a re-index rather than a plain re-audit.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "install-does-not-trigger-rescan",
+      "prompt": "The registry says a skill gets re-audited when it's freshly installed. Can we just reinstall our skill in a loop until the audit refreshes? Set that up if so.",
+      "expected_output": "Declines to set up a polling loop. Explains the install-time audit call is a read-only GET keyed on owner/repo plus slug with no commit SHA, so installs cannot invalidate the cache, and that merging a fix does not invalidate it either. Offers a single check instead of repeated installs.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "name": "real-finding-not-phantom",
+      "prompt": "Check the security audit status of starslingdev/skills/ci-speedup and tell me whether the finding it has is something we need to fix or something we can accept.",
+      "expected_output": "Runs the script for ci-speedup, reports the W011 warning-class finding, notes no phantom literal was detected, and distinguishes warning-class from critical-class handling: W011 describes inherent behavior for a repo-auditing skill and is reasonable to accept with a written rationale rather than chase.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "name": "surface-disagreement",
+      "prompt": "The skills.sh page for one of our skills shows a passing badge but a teammate says the CLI printed a failure when they installed it. Which is right?",
+      "expected_output": "Recognizes these are separately cached surfaces, runs the script, and compares the JSON API, the install-path endpoint, and the rendered page. Reports which surface is stale and identifies the install-path value as what users actually see. Does not treat the disagreement as a bug in the skill itself.",
+      "files": []
+    }
+  ]
+}

--- a/maintainers/skills-registry-security/references/audit-pipeline.md
+++ b/maintainers/skills-registry-security/references/audit-pipeline.md
@@ -43,6 +43,7 @@ the evidence for each claim.
 - The precondition that invalidates most experiments
 - What each timestamp actually means
 - What the vendors say
+- When a re-audit happens
 - Observed timings
 - Worked example: one repo-wide ingest, and a fix that missed it
 - Dating a snapshot exactly
@@ -83,7 +84,20 @@ Aug 12
           |     hash changed; the flagged URL is gone from the scan input;
           |     the post-fix placeholder is present.
           |     Audit still stamped 19:44 - it drains behind ingest.
+          |
+          |   ... 22 hours of nothing. Audit still stamped Aug 11 19:44.
+          |       Polled ~20 times; byte-identical payload every time.
+Aug 13
+ 00:01  --> RE-AUDIT FIRES ON ITS OWN. No install, no push, no request.
+          |     Snyk  fail/CRITICAL/2 issues -> warn/MEDIUM/1 issue
+          |     E005 (the flagged URL) GONE; W011 remains.
+          |     Socket +22s, Gen Agent Trust Hub +38s - one batched sweep.
 ```
+
+That last line closes the loop the rest of this document only inferred:
+**install → ingest → audit → badge, all four links observed end to end on one
+skill.** The remedy is real, it is unattended, and the only thing it needed
+was time.
 
 That last step is the whole remedy, and it was confirmed by experiment rather
 than inferred: **one install whose beacon actually fires rebuilds the
@@ -225,6 +239,36 @@ Sources: <https://snyk.io/blog/snyk-vercel-securing-agent-skill-ecosystem/>,
 <https://www.skills.sh/docs/customize> (the snyk.io domain may be unreachable
 from restricted networks; that quote was recovered via search excerpts).
 
+## When a re-audit happens
+
+Ingest has a known trigger — the install beacon. The audit does not appear to
+have one you can pull. What has been observed:
+
+- **Audits re-run unattended.** A re-audit fired 22 h after a re-index with no
+  install, no push, and no request of any kind in between. Nothing needs to be
+  done to make the badge catch up with a fresh snapshot except wait.
+- **Ingest is the thing worth chasing; the audit follows.** Since scanners read
+  the snapshot, a re-audit is only useful once the snapshot already contains
+  the fix. Spending effort trying to trigger an audit before that just re-reads
+  the old photocopy — which is exactly how a fix that already landed keeps
+  reappearing as a live finding.
+- **All three providers move together.** Snyk, Socket and Gen Agent Trust Hub
+  re-stamped within 38 s of each other, so this is one batched per-skill sweep
+  rather than three independent schedules. A single provider with an old
+  `auditedAt` while its siblings are fresh would be the anomaly, not the norm.
+- **The cadence is loose.** Two consecutive audits of the same skill were
+  28.3 h apart, and an earlier pair ~24 h. Treat "roughly daily, but do not set
+  a watch by it" as the model. A gap of 28 h is not evidence of anything stuck.
+- **No client-controllable trigger exists.** Every attempt is in *Dead ends,
+  already tested* below. The remaining unknown is whether a re-index enqueues
+  the audit or whether the sweep is purely periodic; 22 h is consistent with
+  either, so the question is open.
+
+The practical consequence: after a beacon-capable install, budget **~3 h for
+the snapshot and up to another day for the badge**, and do not poll in between.
+Twenty polls over that window produced a byte-identical payload every time and
+told nobody anything. Check once, then check the next day.
+
 ## Observed timings
 
 From directly observed cycles, not documentation. Re-derive rather than
@@ -235,6 +279,9 @@ trusting these numbers forever.
 | install beacon → **first** index | ~50 min | brand-new skill, never seen before |
 | install beacon → **re**-index | **~3 h** | measured end to end: install 22:50, snapshot changed by 02:07 |
 | ingest → audit | ~77 min in one case | the audit queue drains behind ingest |
+| **re-index → re-audit** | **~22 h** | measured: snapshot 02:00, audit 00:01 next day. Unattended — no install or push in between |
+| audit → next audit | ~24 h, once 28.3 h | loose cadence; do not read a missed day as stuck |
+| provider spread within one sweep | **38 s** | Snyk 00:01:48, Socket 00:02:10, Gen ATH 00:02:26 — one batched sweep |
 | audit → all caches agree | up to ~1 day | install-path cache lagged the JSON API by a day |
 | merge with no install | **never** | two pushes produced no ingest at all |
 | install with beacon suppressed | **never** | nine installs, zero effect — the beacon never fired |
@@ -297,9 +344,25 @@ Work down this list; stop at the first match.
    repository, the input is stale — the scanner is right about what it was
    handed.
 3. **Is it in the repository too?** The finding is real. Fix or accept it.
-4. **In neither?** The scanner is likely serving its own cached result; a fresh
-   ingest may not clear it. Say so rather than requesting the wrong remedy.
+4. **In neither?** Do NOT jump to "the scanner cached its own result". First
+   ask the discriminating question: **is the finding's `auditedAt` older than
+   the snapshot's re-index?** If it is, this is an ordinary stale finding that
+   simply has not been re-audited yet — the literal is absent from the current
+   snapshot precisely *because* the fix landed, and the audit has not read it.
+   Wait for the next sweep (see *When a re-audit happens*). Only once an audit
+   has demonstrably run **against the current snapshot** and still cites a
+   literal present in neither corpus is a scanner-side cache the explanation.
 5. **Verdicts differ across surfaces?** Cache propagation. Re-run later.
+
+Step 4 is the trap this document exists to prevent, in a new costume. The
+original mistake was reading a fresh timestamp on stale content as "the fix
+did not work". The mirror-image mistake is reading fresh content under a stale
+timestamp as "the scanner is broken" — and it was made here, four hours before
+the audit re-ran on its own and cleared the finding. Both are the same error:
+comparing a timestamp and a hash without asking which one moved first. The
+corroborating signal is in `registry-surfaces.md`: warning codes reproducing
+while a critical code vanishes is the signature of stale input, not of a
+phantom.
 
 Corroborate with the project's own scanner run if it has one: same scanner,
 current branch, opposite verdict isolates the input as the variable.
@@ -373,6 +436,10 @@ matching reality.
 | The snapshot pins to an exact commit | Byte-compared every snapshot file against candidate commit trees; one matched with zero differences. |
 | Audits re-run over an unchanged snapshot | Audit timestamps advanced ~24h while the snapshot hash and the finding text stayed byte-identical. |
 | Findings clear once the fix is in the snapshot | A sibling skill went FAIL/HIGH with two findings to WARN/MEDIUM with one, after the fixing commit's file appeared in its snapshot. |
+| **The whole chain works end to end, unattended** | Watched on one skill across three days: beacon-capable install 22:50 → snapshot rebuilt ~02:00 (+3 h) → audit re-ran 00:01 next day (+22 h) → Snyk fail/CRITICAL/E005+W011 became warn/MEDIUM/W011. Nothing was requested at any step; the only input was one install. |
+| A re-audit needs no trigger from you | The re-audit above fired with no install, push, or API call in the preceding 22 h — the tree and every registry surface were untouched apart from read-only GETs. |
+| Audits are one batched sweep, not per-provider schedules | Three providers re-stamped within 38 s of each other, and the model-based one returned a freshly written summary naming code it had not previously described. |
+| Warning codes reproduce while stale critical codes vanish | Across four audits of the same skill, W011 appeared in every one; E005 disappeared the moment the audit read a snapshot without the literal. |
 | Caches disagree | The install-path endpoint served day-old values while the JSON API served current ones for the same skill. |
 | Model-based providers re-judge unchanged input | One provider went fail to pass across two audits of the same snapshot, its category list growing rather than shrinking. |
 | The indexer drops large files | Two snapshots omit files of ~600 KB and ~900 KB; the largest included file is ~470 KB. |
@@ -388,6 +455,18 @@ retracted while investigating.
   suppressed. Always verify the precondition first.
 - **"Indexing happens once and never repeats."** False. Snapshots demonstrably
   rebuild.
+- **"A literal absent from both the repository and the snapshot means the
+  scanner cached its own result."** Asserted here, with an escalation packet
+  drafted on the strength of it, and disproven four hours later when the audit
+  re-ran unattended and dropped the finding. Absence from both corpora is
+  equally consistent with the ordinary case — the fix landed, the snapshot
+  caught up, and the audit simply had not run yet. The verdict is only
+  supportable once an audit has run *against the current snapshot*; check
+  `auditedAt` against the re-index before claiming it.
+- **"A re-index is what causes the next audit."** Unknown. The one observed
+  re-audit came 22 h after a re-index, which fits both "the re-index enqueued
+  it" and "a periodic sweep happened to come round". Nothing distinguishes them
+  yet, so neither is claimed.
 - **"The scanners read the snapshot."** Consistent with every observation and
   strongly supported by a finding clearing exactly when the fix appeared in the
   snapshot, but never directly verified.

--- a/maintainers/skills-registry-security/references/audit-pipeline.md
+++ b/maintainers/skills-registry-security/references/audit-pipeline.md
@@ -3,70 +3,170 @@
 The mental model that makes registry audits legible, the timings observed for
 each stage, and — for every load-bearing claim — how it was established. Read
 this when an audit disagrees with the repository and you need to know whether
-to wait, fix, or escalate.
+to wait, act, or escalate.
 
-The short version: **there are two independent pipelines on two different
-slow cadences, and neither one is triggered by anything you do.** Almost every
-confusing symptom follows from that.
+## The whole thing in twenty seconds
+
+```
+  YOUR MERGE ──────────────X   nothing happens. ever.
+
+  SOMEONE INSTALLS (with working telemetry)
+        │
+        └─> beacon ──> INGEST ──> SNAPSHOT ──> AUDIT ──> badge
+                       "photocopy   frozen     runs
+                        of your     copy       later, on
+                        repo RIGHT             whatever the
+                        NOW"                   snapshot holds
+```
+
+**The snapshot is a photocopy.** Scanners read the photocopy, never the
+repository. The only thing that takes a new photocopy is an install whose
+telemetry beacon actually reaches the service.
+
+Three consequences follow, and they cover nearly every confusing symptom:
+
+1. **Merging a fix changes nothing.** No install, no new photocopy.
+2. **A fix that lands after the last photocopy is invisible** until the next
+   one, no matter how many times the audit re-runs.
+3. **Re-audits keep reporting the old finding with a fresh timestamp**, which
+   reads as "your fix did not work" when it actually means "the photocopy
+   predates your fix."
+
+The rest of this document is the detail behind that picture, the timings, and
+the evidence for each claim.
 
 ## Contents
 
+- The whole thing in twenty seconds
+- A real timeline, annotated
 - The pipeline
+- The precondition that invalidates most experiments
 - What each timestamp actually means
 - What the vendors say
 - Observed timings
-- Worked example: a complete, successful cycle (ci-speedup)
-- Worked example: a fix that has not landed yet (ci-secure)
+- Worked example: one repo-wide ingest, and a fix that missed it
+- Dating a snapshot exactly
 - Reading a disagreement
+- Dead ends, already tested
 - Preventing it: scan before you publish
 - Evidence log: how each claim was established
 - Claims deliberately NOT made
 
+## A real timeline, annotated
+
+The incident this skill was written from. Three skills in one repository; only
+one of them was new. All times UTC.
+
+```
+Aug 10
+ 14:04  commit 3f5df92 - a new skill is added to the repo
+ 17:13  commit 27d9ca9 - two SIBLING skills edited
+          |
+ 17:54  * someone installs the new skill  -->  INGEST FIRES
+          |    photocopy taken of the WHOLE REPO as of 27d9ca9
+          |    all three snapshots rebuilt at this instant
+          |
+ 19:09  commit f5c51a2 - THE FIX (removes the flagged URL)
+          |    ^^^ 75 minutes too late. Photocopy already taken.
+          |
+ 19:11  audits run against that photocopy - the two siblings pass
+ 19:49  commit 063d560 - no install, so nothing happens
+
+Aug 11
+ 19:44  the audit RE-RUNS, still against the 17:54 photocopy
+          |    -> the deterministic finding repeats, with a NEW timestamp
+          |    -> looks like "the fix did not work". It is not what happened.
+ 22:50  * a real install finally happens  -->  ingest expected
+   ?    photocopy rebuilds, finding clears on the next audit pass
+```
+
+Two things this makes obvious that prose does not:
+
+- **The fix missed the bus by 75 minutes.** Everything downstream follows from
+  that single gap, not from anything being broken.
+- **The two skills the fix did NOT touch look "fresh" while the one it DID
+  touch looks "stale."** That inversion is purely an artifact of when the one
+  ingest fired. It is not per-skill logic, and chasing it wastes hours.
+
 ## The pipeline
 
 ```
-   GitHub default branch  (your merge lands here, and nothing happens)
+   GitHub default branch   (merging a fix triggers NOTHING on its own)
              |
-             |   (1) INDEX — irregular. Observed ~2 days after a change.
-             |       Not triggered by: merging, pushing, or installing.
+             |  read by the indexer, but only when something asks it to
              v
-   +---------------------------------------------+
-   |  STORED SNAPSHOT                             |
-   |    { files: [{path, contents}], hash }       |   <-- inspect this
-   |  GET /api/download/{owner}/{repo}/{skill}    |
-   +---------------------------------------------+
+   +--------------------------------------------------------------+
+   |  INGEST                                                        |
+   |    triggered by an install that REACHES the telemetry service: |
+   |    GET add-skill.vercel.sh/t?event=install&source={o}/{r}      |
+   |        &skills=<names>&skillFiles={"name":"path/SKILL.md"}     |
+   |    skillFiles is the map an indexer needs to locate each skill |
+   |    Appears to be REPO-SCOPED: one install rebuilt all three    |
+   |    sibling snapshots at the same instant.                      |
+   +--------------------------------------------------------------+
              |
-             |   (2) AUDIT — separate cadence. Ran 11 days after the
-             |       index in the one fully observed case. Re-runs the
-             |       scanners over WHATEVER the snapshot holds.
              v
-   +---------------------------------------------+
-   |  PER-PROVIDER VERDICTS                       |
-   |    Gen Agent Trust Hub | Socket | Snyk       |
-   +---------------------------------------------+
+   +--------------------------------------------------------------+
+   |  STORED SNAPSHOT          <-- inspect this; it is the scan input
+   |    { files: [{path, contents}], hash }                         |
+   |  GET www.skills.sh/api/download/{owner}/{repo}/{skill}         |
+   |  NOT a faithful copy: files above ~500-600 KB are dropped.     |
+   +--------------------------------------------------------------+
+             |
+             |  (2) AUDIT — separate cadence, drains behind ingest.
+             |      Re-runs scanners over WHATEVER the snapshot holds.
+             v
+   +--------------------------------------------------------------+
+   |  PER-PROVIDER VERDICTS                                         |
+   |    Gen Agent Trust Hub | Socket | Snyk                         |
+   +--------------------------------------------------------------+
              |
              +--> GET /api/v1/skills/audit/{o}/{r}/{s}
              |      status + riskLevel + auditedAt. NO finding codes.
-             |
              +--> GET /{o}/{r}/{s}/security/{provider-slug}
              |      the codes (E005, W011) and the literals they quote.
-             |      HTML only. This is the only place findings exist.
-             |
              +--> GET add-skill.vercel.sh/audit?source=..&skills=..
-             |      the install-path cache. What users see. Lags.
-             |
-             +--> the rendered skill page badges (third cache)
+             |      install-path cache. What users see. Lags.
+             +--> rendered page badges (a third cache)
 
 
-   npx skills add  ── clones the CURRENT default branch ──> user's disk
-             |
-             +── fires a read-only GET at the audit cache for display
-                 (owner/repo + skill names only; no SHA, no trigger)
+   npx skills add ── clones the CURRENT default branch ──> user's disk
+        |             (unless the owner is on the blob allowlist)
+        +── fires the install beacon above, IF it is not suppressed
+        +── fires a read-only audit GET purely for display
 ```
 
-The install arrow is drawn separately on purpose. It touches neither stage.
-A clean freshly-installed tree and a failing audit are entirely compatible,
-and neither is evidence about the other.
+Installing delivers current content to the user while the audit reads the
+snapshot. A clean installed tree and a failing audit are therefore entirely
+compatible, and that gap is cosmetic-versus-real: **users are not receiving the
+flagged content; only the scanners are.** Establish which case you are in
+before escalating, because it changes the urgency completely.
+
+## The precondition that invalidates most experiments
+
+Before concluding anything from an install, verify the beacon could actually
+have been sent. It is dropped silently — no warning, no non-zero exit — when:
+
+- **`api.github.com/repos/{owner}/{repo}` does not answer 200.** The CLI calls
+  it unauthenticated to decide whether the repo is private, and returns `null`
+  on any non-OK response. The beacon is sent only when the result is exactly
+  `false`, so `null` suppresses it. This bites in sandboxes and CI containers
+  that proxy or block GitHub, and on any IP that has burned the 60-requests/hour
+  unauthenticated limit.
+- **`DISABLE_TELEMETRY` or `DO_NOT_TRACK` is set.**
+- **The repo is genuinely private.**
+
+Check before, not after:
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' https://api.github.com/repos/OWNER/REPO   # need 200
+env | grep -iE 'DO_NOT_TRACK|DISABLE_TELEMETRY'                                     # need empty
+```
+
+This is not a footnote. An entire investigation concluded "installs never
+trigger indexing" from nine installs in an environment where that GitHub probe
+returned 403 — so the beacon never fired once, and the null result measured
+nothing. If the precondition fails, an install tells you nothing at all.
 
 ## What each timestamp actually means
 
@@ -77,15 +177,14 @@ and neither is evidence about the other.
 | `hash` | snapshot API | identity of the **stored content** | anything about scan time |
 | "First Seen" | skill page | when the skill was first indexed | last index |
 
-The single most expensive misreading in this whole system: **a fresh
-`auditedAt` on a stale snapshot.** It makes a finding about deleted content
-look current, which reads as "your fix did not work." The snapshot `hash` is
-the only field that tracks content, so it is the one to watch.
+The most expensive misreading here: **a fresh `auditedAt` on a stale
+snapshot.** It makes a finding about deleted content look current, which reads
+as "your fix did not work." The snapshot `hash` is the only field that tracks
+content, so it is the signal to watch. Note the `hash` is not reproducible from
+the served files by the CLI's own algorithm, so treat it as an opaque identity
+token, not a verifiable checksum.
 
 ## What the vendors say
-
-Two published statements corroborate the model and explain provider behavior
-that otherwise looks like a bug.
 
 On the trigger, from Snyk's write-up of the partnership:
 
@@ -94,195 +193,197 @@ On the trigger, from Snyk's write-up of the partnership:
 > API. This happens automatically, with no action required from the skill
 > author or the end user."
 
-Note the word *new*. This is the first-index trigger, not a per-install one,
-which is exactly what the observations show: repeat installs of an already
-known skill do nothing.
+And from the registry's own docs (`skills.sh/docs/customize`):
 
-On the engine:
+> "skills.sh picks up skills.sh.json **after the repository is seen by the
+> telemetry service**. In practice, that usually means **after someone installs
+> from the repo with the skills CLI**."
+
+Both name the install as the ingest trigger. On the engine:
 
 > "built on the **agent-scan** scanning engine (also known as mcp-scan), which
 > combines multiple customized **LLM-based judges with deterministic rules**."
 
-That hybrid is why one finding can reproduce byte-for-byte across two scans of
-the same content while another flips. A deterministic rule (a download-URL
-pattern like E005) returns the same answer every time it sees the same bytes;
-a judge can reach a different conclusion on identical input. So **a verdict
-changing is not evidence that the content changed** — and conversely, a
+That hybrid explains why one finding reproduces byte-for-byte across two scans
+of the same content while another flips. A deterministic rule returns the same
+answer on the same bytes; a judge can reach a different conclusion on identical
+input. So **a verdict changing is not evidence that content changed** — and a
 deterministic finding surviving a rescan after its literal was deleted is
-strong evidence the input did not change.
+strong evidence the input did not.
 
-Source: <https://snyk.io/blog/snyk-vercel-securing-agent-skill-ecosystem/>
-(the domain may be unreachable from restricted networks; the quotes above were
-recovered via search excerpts).
+Sources: <https://snyk.io/blog/snyk-vercel-securing-agent-skill-ecosystem/>,
+<https://www.skills.sh/docs/customize> (the snyk.io domain may be unreachable
+from restricted networks; that quote was recovered via search excerpts).
 
 ## Observed timings
 
-Ranges from directly observed cycles, not documentation. Treat as
-order-of-magnitude, and re-derive rather than trusting these numbers forever.
+From directly observed cycles, not documentation. Re-derive rather than
+trusting these numbers forever.
 
 | Stage | Observed | Notes |
 |---|---|---|
-| first index | at first install | "Audits are generated automatically after a skill is installed for the first time" |
-| re-index after a change | **~2 days** | one fully observed cycle |
-| re-audit after an index | **~11 days** | same cycle; the two are decoupled |
-| audit → all caches agree | up to **~1 day** | install-path cache lagged the JSON API by a day |
-| install → any effect | **none** | 9 installs over 6 hours produced no index and no audit |
+| install beacon → ingest | tens of minutes | first index landed ~50 min after the first plausible install |
+| ingest → audit | ~77 min in one case | the audit queue drains behind ingest |
+| audit → all caches agree | up to ~1 day | install-path cache lagged the JSON API by a day |
+| merge with no install | **never** | two pushes produced no ingest at all |
+| install with beacon suppressed | **never** | nine installs, zero effect — the beacon never fired |
 
-**Escalation threshold.** Below roughly 2–3 days after a fix, nothing is wrong
-— the re-index has not come due. Escalating early wastes your time and a
-maintainer's. Beyond that window, with the literal still in the snapshot, the
-case is real.
+**Before escalating**, confirm a beacon-capable install has actually happened
+since the fix. Most "stuck" reports in the wild are missing that step.
 
-## Worked example: a complete, successful cycle (ci-speedup)
+## Worked example: one repo-wide ingest, and a fix that missed it
 
-The whole loop, start to finish, with no intervention from anyone:
+All times UTC. Three skills in one repo; only one was new:
 
 ```
- Jul 22            Jul 28 01:12       ~Jul 30             Aug 10 19:11
- first seen        PR #15 merges      snapshot            Snyk re-audits
- + first audit     the W007 fix       RE-INDEXED          that snapshot
-     |                  |                  |                   |
-     v                  v                  v                   v
- FAIL / HIGH            +---- ~2 days -----+                   |
- W007 + W011                               |                   |
-                                           +---- ~11 days -----+
-                                           |                   |
-                              snapshot now contains       WARN / MEDIUM
-                              tests/test_secret_          W011 only
-                              redaction.py                (W007 CLEARED)
+ 14:04  3f5df92 adds ci-secure to the repo
+ 17:13  27d9ca9 edits ci-speedup + ci-score SKILL.md (adds `license: MIT`)
+ 17:54  first install of the new skill registers the repo
+          -> REPO-WIDE INGEST: all three snapshots rebuilt from the tree
+             as of 27d9ca9
+ 19:09  f5c51a2 removes the flagged URL from ci-secure
+          -> 75 minutes AFTER the ingest. Missed it.
+ 19:11  ci-speedup + ci-score audits run (queue draining behind ingest)
+ 19:49  another push. No install -> no ingest.
+ next day 19:44  ci-secure re-audited over the UNCHANGED snapshot
+          -> the deterministic finding repeats, with a fresh timestamp
 ```
 
-Two things this proves and one it strongly suggests:
+The lesson is the 75 minutes. The ingest captured the repository just before
+the fix, and every later audit re-ran over that capture. Nothing was stuck and
+nothing was broken — no beacon-capable install had happened since.
 
-- Re-indexing **does** happen, unprompted. The snapshot moved from Jul-22-era
-  content to Jul-30-era content on its own.
-- Findings **do** clear once the fix is in the snapshot. W007 disappeared.
-- It strongly suggests the scanners read the snapshot: W007 cleared precisely
-  when the fixing commit's file appeared there. Not proof — the scanners could
-  read the branch independently — but the correlation is exact.
+Note also that the two skills the push did *not* touch appear "fresh" while the
+one it did appears "stale." That inversion is an artifact of when the single
+ingest fired, not evidence of per-skill logic.
 
-## Worked example: a fix that has not landed yet (ci-secure)
+## Dating a snapshot exactly
 
-```
- Aug 10 17:54       Aug 10 19:09        Aug 11 19:44        Aug 11 22:12
- first index        f5c51a2 removes     audit re-runs on    snapshot still
- + first audit      the flagged URL     the OLD snapshot    holds Aug-09
-     |                   |                   |               content
-     v                   v                   v                   |
- FAIL / CRITICAL     fix lands 75 min    E005 REPEATS with       v
- E005 + W011         AFTER the index     a NEW timestamp    ~27h elapsed:
-                                         (Gen flips to      still inside
-                                          SAFE on the       the ~2-day
-                                          same input)       window
-```
+Comparing the newest date in the snapshot's `CHANGELOG.md` against the
+repository's is a fast approximation, but it is coarse: a commit that does not
+touch the changelog is invisible to it.
 
-The 75-minute gap is the whole story: the index captured the repository just
-before the fix, and the audit a day later re-ran over that capture. Nothing is
-stuck; the next index had not come due.
+The exact method is to byte-compare every snapshot file against each candidate
+commit's tree and find the one with zero differences. That pins the snapshot to
+a specific commit, which is what makes an escalation concrete: "your snapshot
+is commit X; the fix is commit Y; here are the N files that differ."
 
-Note Gen flipping fail→pass across those two audits **on unchanged input**.
-Model-based providers re-judge; rule-based ones reproduce. A verdict changing
-is therefore not evidence that content changed.
+Remember the indexer drops files above roughly 500–600 KB, so expect large
+files to be absent from the snapshot entirely rather than stale. Compare only
+the paths the snapshot actually contains.
 
 ## Reading a disagreement
 
 Work down this list; stop at the first match.
 
-1. **Is the quoted literal in the snapshot?** If yes and it is gone from the
-   repository, the input is stale. Check elapsed time before escalating.
-2. **Is it in the repository too?** Then the finding is real. Fix or accept it.
-3. **In neither?** The scanner is likely serving its own cached result; a
-   re-index may not clear it. Say so rather than requesting the wrong remedy.
-4. **Verdicts differ across surfaces?** Cache propagation. Re-run later.
+1. **Has a beacon-capable install happened since the fix?** If not, that is the
+   whole answer. Do it, then wait.
+2. **Is the quoted literal in the snapshot?** If yes and it is gone from the
+   repository, the input is stale — the scanner is right about what it was
+   handed.
+3. **Is it in the repository too?** The finding is real. Fix or accept it.
+4. **In neither?** The scanner is likely serving its own cached result; a fresh
+   ingest may not clear it. Say so rather than requesting the wrong remedy.
+5. **Verdicts differ across surfaces?** Cache propagation. Re-run later.
 
 Corroborate with the project's own scanner run if it has one: same scanner,
 current branch, opposite verdict isolates the input as the variable.
+
+## Dead ends, already tested
+
+Recorded so nobody spends a day re-deriving them.
+
+| Attempt | Result |
+|---|---|
+| Repeat installs from an environment where the GitHub probe 403s | Nothing. The beacon never fired; the experiment measured nothing. |
+| `POST add-skill.vercel.sh/check-updates` with `forceRefresh:true` | Route is live and self-documenting, and accepted a well-formed call — but returned `"No cached hash available (skill may need reinstall)"` and moved nothing. It compares against a **separate** update-check cache, and the CLI stopped sending hashes to the server, so that cache is never populated. A zombie endpoint. |
+| `POST www.skills.sh/api/revalidate` | `{"error":"Unauthorized"}`. Secret-gated. Do not attempt to bypass. |
+| Cache-busting `/api/download?x=1` | `x-vercel-cache: MISS, age: 0` — a genuine origin hit — returning a **byte-identical** body. The staleness is at origin; no edge trick can help. |
+| `?ref=`, `?sha=`, `?version=`, `?commit=` on the snapshot or audit endpoints | Silently ignored. Even a nonexistent branch returns the same snapshot. No client-controllable cache key exists. |
+| `npx skills use` | Sends no telemetry at all. Cannot be the ingest signal. |
+| Installing with `@ref` / `@sha` | The ref is stripped before anything reaches the registry. |
+| The documented v1 API | Read-only, all five routes are GETs. No publish, refresh, or index endpoint. |
 
 ## Preventing it: scan before you publish
 
 Everything above is remediation. The cheap fix is upstream: run the registry's
 own scanner in CI so a violation fails your build instead of surfacing as a
-public FAIL badge days later, on a snapshot you cannot refresh. This repo's
-`.github/workflows/registry-scan.yml` is a working implementation; the design
-points that matter are portable.
+public FAIL badge days later, on a snapshot you cannot refresh on demand. The
+scanner is publicly available — `uvx snyk-agent-scan@latest scan <path>` — and
+needs a `SNYK_TOKEN`.
 
 **Gate on the critical class only.** The scanner has no severity threshold, so
 the rule is expressed by enumerating the warning class into
 `--ignore-issues-codes`. Warning-class findings are usually accurate
 descriptions of what a repository-auditing skill legitimately does; blocking on
-them trains people to suppress findings. Surface them (annotations, job
-summary, uploaded artifact) and let a human judge.
+them trains people to suppress findings. Surface them and let a human judge.
 
 **Never let an E-code into the ignore list.** One there silently disarms the
-gate, and nothing else in the system would tell you. Pin it with a test that
-asserts every ignored code starts with `W`, and a second that pins the list to
-exactly the published warning class — short of it, a warning reddens the build
-and someone "fixes" it by guessing; beyond it, a code nobody read is being
-suppressed.
+gate and nothing else would tell you. Pin it with a test asserting every ignored
+code starts with `W`, and another pinning the list to exactly the published
+warning class.
 
 **Prove the gate can go red, on every run.** A check that cannot fail is not a
-check, and a scanner's rule catalog changes with no commit of yours. Before the
-real scan, build a throwaway skill carrying the exact violation class you care
-about, scan it **with the gate's real ignore list**, and fail unless the
-scanner both reports the anchor code and exits non-zero. Running it with the
-real ignore list is the subtle part: with an empty one you would only prove the
-scanner can fail, not that *this gate* can. This also fails upward — if the
-anchor rule is renamed or retired, the step goes red and a human re-anchors it
-rather than the gate quietly protecting nothing.
+check, and the rule catalog changes with no commit of yours. Before the real
+scan, build a throwaway skill carrying the exact violation class, scan it **with
+the gate's real ignore list**, and fail unless the scanner both reports the
+anchor code and exits non-zero. With an empty ignore list you would only prove
+the scanner can fail, not that *this gate* can. It fails upward too: if the
+anchor rule is renamed, the step goes red and a human re-anchors it.
 
-**Add a cheap offline guard for the shape you already got burned by.** The
-scanner needs a token, network, and minutes. A plain text rule needs none and
-runs in the normal test suite, so it blocks the commit rather than the merge.
-Assemble any test fixture that must contain the offending shape at runtime, or
-the guard will correctly reject your own tests.
+**Add a cheap offline guard for the shape that burned you.** The scanner needs a
+token, network, and minutes; a text rule needs none and blocks the commit rather
+than the merge. Assemble test fixtures containing the offending shape at
+runtime, or the guard will correctly reject your own tests.
 
-**Schedule it.** A weekly run is what notices a catalog change that needed no
-commit of yours.
-
-**Make it a required status check.** A gate that can be merged past is
-advisory. Confirm it is required in branch protection, not merely present.
-
-Two layers is the goal: a text guard that fails in seconds with no
-dependencies, and the real scanner as the authoritative check. The first
-catches the mistake while you are typing; the second catches everything you did
-not anticipate.
+**Schedule it**, so a catalog change that needed no commit of yours is noticed.
+**And make it a required status check** — a gate that can be merged past is
+advisory.
 
 ## Evidence log: how each claim was established
 
-Nothing here is from documentation; the registry documents almost none of it.
-Re-derive any claim that stops matching reality.
+The registry documents almost none of this. Re-derive any claim that stops
+matching reality.
 
 | Claim | How it was established |
 |---|---|
-| Install never triggers an index or audit | Read the CLI source: the audit call is a `GET` keyed on owner/repo + skill display names, gated only on the repo being public, with `blobResult` absent from the expression. Confirmed empirically: 9 installs over 6 hours moved nothing. |
-| The audit key carries no commit SHA | Same source read; the request carries owner/repo and names only. |
-| The JSON API has no finding codes | Its `summary` is prose plus a count. Codes appear only on the per-provider HTML pages. |
-| A stored snapshot exists and is fetchable | Found `/api/download/...` referenced in the CLI's blob module; fetched it directly and got `{files[], hash}`. |
-| The snapshot can be stale | Fetched ci-secure's: 80 files, hash `a2f6d76e…`, containing the removed URL in 4 files and zero occurrences of the placeholder that replaced it. |
-| The snapshot can be dated | Read `CHANGELOG.md` out of the snapshot: newest entry 2026-08-09 versus 2026-08-10 on the default branch. |
-| Re-indexing happens | ci-speedup was first seen Jul 22 but its snapshot contains `tests/test_secret_redaction.py`, added by PR #15 on Jul 28. Content postdating the first index can only arrive by re-indexing. |
-| Findings clear once the fix is in the snapshot | ci-speedup went FAIL/HIGH with W007+W011 (issue #12, scanned Jul 22) to WARN/MEDIUM with W011 only, after the fix appeared in the snapshot. |
-| Audits re-run over an unchanged snapshot | ci-secure's audit timestamps advanced ~24h while its snapshot hash stayed `a2f6d76e…` and the finding text stayed byte-identical. |
-| Caches disagree | The install-path endpoint served 2026-08-10 values while the JSON API served 2026-08-11 for the same skill. |
-| Model-based providers re-judge unchanged input | Gen went HIGH/fail to SAFE/pass across two audits of the same snapshot, and its category list grew rather than shrank. |
-| The pages expose no other API | A browser network capture was blocked by egress policy, but the page source is an RSC payload plus Vercel Web Analytics (`/_vercel/insights/*`); no audit or index endpoint is called client-side. |
+| The install beacon carries what an indexer needs | Read the CLI source: the install event sends `skillFiles`, a JSON map of skill name to repo-relative `SKILL.md` path. A pure install counter would not need paths. |
+| The beacon is suppressed on a non-200 GitHub probe | Read the source (`isRepoPrivate()` returns `null` on any non-OK; the send is gated on `=== false`), then confirmed the probe returns 403 in the environment where the null result was produced. |
+| Ingest is repo-scoped | One install of a newly added skill coincided with all three sibling snapshots being rebuilt at the same instant. |
+| The audit call is read-only and carries no SHA | Source read: a GET keyed on owner/repo plus display names, gated only on the repo being public. |
+| The JSON API has no finding codes | Its `summary` is prose plus a count; codes appear only on the per-provider HTML pages. |
+| A stored snapshot exists and is fetchable | Found `/api/download/...` in the CLI's blob module; fetched it directly. |
+| The snapshot can be stale | Fetched it: 80 files containing the removed URL in 4 of them, and zero occurrences of the placeholder that replaced it. |
+| The snapshot pins to an exact commit | Byte-compared every snapshot file against candidate commit trees; one matched with zero differences. |
+| Audits re-run over an unchanged snapshot | Audit timestamps advanced ~24h while the snapshot hash and the finding text stayed byte-identical. |
+| Findings clear once the fix is in the snapshot | A sibling skill went FAIL/HIGH with two findings to WARN/MEDIUM with one, after the fixing commit's file appeared in its snapshot. |
+| Caches disagree | The install-path endpoint served day-old values while the JSON API served current ones for the same skill. |
+| Model-based providers re-judge unchanged input | One provider went fail to pass across two audits of the same snapshot, its category list growing rather than shrinking. |
+| The indexer drops large files | Two snapshots omit files of ~600 KB and ~900 KB; the largest included file is ~470 KB. |
+| The pages expose no other API | Page source is an RSC payload plus Vercel Web Analytics; no audit or index endpoint is called client-side. |
 
 ## Claims deliberately NOT made
 
-Recorded so nobody re-derives a dead end or repeats an overreach:
+Recorded so nobody repeats an overreach — several of these were made and
+retracted while investigating.
 
+- **"Installs never trigger indexing."** False, and the most costly error made
+  here. It came from nine installs in an environment where the beacon was
+  suppressed. Always verify the precondition first.
+- **"Indexing happens once and never repeats."** False. Snapshots demonstrably
+  rebuild.
 - **"The scanners read the snapshot."** Consistent with every observation and
-  strongly supported by the W007 timing, but never verified. The scanners could
-  read the branch through a separate path.
-- **"Indexing happens once and never repeats."** Tempting after watching one
-  skill sit still for a day. It is false — ci-speedup re-indexed.
+  strongly supported by a finding clearing exactly when the fix appeared in the
+  snapshot, but never directly verified.
+- **"Users are receiving the stale content."** False for repos not on the blob
+  allowlist: the CLI clones the current default branch, and the installed tree
+  was verified clean. Only the audit reads the snapshot.
 - **"Self-hosting the snapshot fixes the audit."** The CLI has an allowlist for
   repos serving their own snapshot, but the audit call does not consult it.
-  Being added would change installs, not audits.
 - **"Renaming the skill forces a fresh audit."** A new name means a new slug
   means a new identity with no cached audit — and it is not an acceptable
   remedy. It discards the skill's URL, install count, and recognition to work
-  around someone else's caching. Do not propose it.
+  around a cache. Do not propose it.
 - **"Filing an issue reliably works."** At the time of writing, a search for
   re-index and rescan requests returned a dozen matches, all open and
-  unanswered. It costs little, but do not present it as a fix.
+  unanswered, and no maintainer has publicly described the mechanism.

--- a/maintainers/skills-registry-security/references/audit-pipeline.md
+++ b/maintainers/skills-registry-security/references/audit-pipeline.md
@@ -76,9 +76,19 @@ Aug 11
  19:44  the audit RE-RUNS, still against the 17:54 photocopy
           |    -> the deterministic finding repeats, with a NEW timestamp
           |    -> looks like "the fix did not work". It is not what happened.
- 22:50  * a real install finally happens  -->  ingest expected
-   ?    photocopy rebuilds, finding clears on the next audit pass
+ 22:50  * a real install finally happens (beacon NOT suppressed)
+          |
+Aug 12
+ ~02:00  --> RE-INDEX CONFIRMED. New photocopy, ~3h after the install.
+          |     hash changed; the flagged URL is gone from the scan input;
+          |     the post-fix placeholder is present.
+          |     Audit still stamped 19:44 - it drains behind ingest.
 ```
+
+That last step is the whole remedy, and it was confirmed by experiment rather
+than inferred: **one install whose beacon actually fires rebuilds the
+snapshot.** Nine installs with the beacon suppressed did nothing; one without
+the suppression did everything.
 
 Two things this makes obvious that prose does not:
 
@@ -222,11 +232,16 @@ trusting these numbers forever.
 
 | Stage | Observed | Notes |
 |---|---|---|
-| install beacon → ingest | tens of minutes | first index landed ~50 min after the first plausible install |
+| install beacon → **first** index | ~50 min | brand-new skill, never seen before |
+| install beacon → **re**-index | **~3 h** | measured end to end: install 22:50, snapshot changed by 02:07 |
 | ingest → audit | ~77 min in one case | the audit queue drains behind ingest |
 | audit → all caches agree | up to ~1 day | install-path cache lagged the JSON API by a day |
 | merge with no install | **never** | two pushes produced no ingest at all |
 | install with beacon suppressed | **never** | nine installs, zero effect — the beacon never fired |
+
+Re-indexing an existing skill is markedly slower than first-indexing a new one,
+so do not treat a couple of quiet hours as failure. Budget half a day before
+concluding an install did not work, and check the precondition again first.
 
 **Before escalating**, confirm a beacon-capable install has actually happened
 since the fix. Most "stuck" reports in the wild are missing that step.
@@ -349,6 +364,7 @@ matching reality.
 |---|---|
 | The install beacon carries what an indexer needs | Read the CLI source: the install event sends `skillFiles`, a JSON map of skill name to repo-relative `SKILL.md` path. A pure install counter would not need paths. |
 | The beacon is suppressed on a non-200 GitHub probe | Read the source (`isRepoPrivate()` returns `null` on any non-OK; the send is gated on `=== false`), then confirmed the probe returns 403 in the environment where the null result was produced. |
+| **An install with a live beacon rebuilds the snapshot** | Direct experiment. Nine installs from a beacon-suppressed environment over six hours: hash unchanged. One ordinary install from a normal machine: hash changed within ~3 h, the flagged literal dropped to zero occurrences, the post-fix placeholder appeared, and the snapshot's changelog advanced a day. Same repo, same skill, only the beacon differed. |
 | Ingest is repo-scoped | One install of a newly added skill coincided with all three sibling snapshots being rebuilt at the same instant. |
 | The audit call is read-only and carries no SHA | Source read: a GET keyed on owner/repo plus display names, gated only on the repo being public. |
 | The JSON API has no finding codes | Its `summary` is prose plus a count; codes appear only on the per-provider HTML pages. |

--- a/maintainers/skills-registry-security/references/audit-pipeline.md
+++ b/maintainers/skills-registry-security/references/audit-pipeline.md
@@ -1,0 +1,288 @@
+# How skills.sh audits actually work
+
+The mental model that makes registry audits legible, the timings observed for
+each stage, and — for every load-bearing claim — how it was established. Read
+this when an audit disagrees with the repository and you need to know whether
+to wait, fix, or escalate.
+
+The short version: **there are two independent pipelines on two different
+slow cadences, and neither one is triggered by anything you do.** Almost every
+confusing symptom follows from that.
+
+## Contents
+
+- The pipeline
+- What each timestamp actually means
+- What the vendors say
+- Observed timings
+- Worked example: a complete, successful cycle (ci-speedup)
+- Worked example: a fix that has not landed yet (ci-secure)
+- Reading a disagreement
+- Preventing it: scan before you publish
+- Evidence log: how each claim was established
+- Claims deliberately NOT made
+
+## The pipeline
+
+```
+   GitHub default branch  (your merge lands here, and nothing happens)
+             |
+             |   (1) INDEX — irregular. Observed ~2 days after a change.
+             |       Not triggered by: merging, pushing, or installing.
+             v
+   +---------------------------------------------+
+   |  STORED SNAPSHOT                             |
+   |    { files: [{path, contents}], hash }       |   <-- inspect this
+   |  GET /api/download/{owner}/{repo}/{skill}    |
+   +---------------------------------------------+
+             |
+             |   (2) AUDIT — separate cadence. Ran 11 days after the
+             |       index in the one fully observed case. Re-runs the
+             |       scanners over WHATEVER the snapshot holds.
+             v
+   +---------------------------------------------+
+   |  PER-PROVIDER VERDICTS                       |
+   |    Gen Agent Trust Hub | Socket | Snyk       |
+   +---------------------------------------------+
+             |
+             +--> GET /api/v1/skills/audit/{o}/{r}/{s}
+             |      status + riskLevel + auditedAt. NO finding codes.
+             |
+             +--> GET /{o}/{r}/{s}/security/{provider-slug}
+             |      the codes (E005, W011) and the literals they quote.
+             |      HTML only. This is the only place findings exist.
+             |
+             +--> GET add-skill.vercel.sh/audit?source=..&skills=..
+             |      the install-path cache. What users see. Lags.
+             |
+             +--> the rendered skill page badges (third cache)
+
+
+   npx skills add  ── clones the CURRENT default branch ──> user's disk
+             |
+             +── fires a read-only GET at the audit cache for display
+                 (owner/repo + skill names only; no SHA, no trigger)
+```
+
+The install arrow is drawn separately on purpose. It touches neither stage.
+A clean freshly-installed tree and a failing audit are entirely compatible,
+and neither is evidence about the other.
+
+## What each timestamp actually means
+
+| Field | Where | Means | Does NOT mean |
+|---|---|---|---|
+| `auditedAt` | audit API, detail page | when the **scanners last ran** | that current code was read |
+| `analyzedAt` | install-path cache | same value, different key name | — |
+| `hash` | snapshot API | identity of the **stored content** | anything about scan time |
+| "First Seen" | skill page | when the skill was first indexed | last index |
+
+The single most expensive misreading in this whole system: **a fresh
+`auditedAt` on a stale snapshot.** It makes a finding about deleted content
+look current, which reads as "your fix did not work." The snapshot `hash` is
+the only field that tracks content, so it is the one to watch.
+
+## What the vendors say
+
+Two published statements corroborate the model and explain provider behavior
+that otherwise looks like a bug.
+
+On the trigger, from Snyk's write-up of the partnership:
+
+> "When a **new** agent skill is installed using the npx skills installer,
+> Vercel's infrastructure triggers a call to Snyk's high-throughput scanning
+> API. This happens automatically, with no action required from the skill
+> author or the end user."
+
+Note the word *new*. This is the first-index trigger, not a per-install one,
+which is exactly what the observations show: repeat installs of an already
+known skill do nothing.
+
+On the engine:
+
+> "built on the **agent-scan** scanning engine (also known as mcp-scan), which
+> combines multiple customized **LLM-based judges with deterministic rules**."
+
+That hybrid is why one finding can reproduce byte-for-byte across two scans of
+the same content while another flips. A deterministic rule (a download-URL
+pattern like E005) returns the same answer every time it sees the same bytes;
+a judge can reach a different conclusion on identical input. So **a verdict
+changing is not evidence that the content changed** — and conversely, a
+deterministic finding surviving a rescan after its literal was deleted is
+strong evidence the input did not change.
+
+Source: <https://snyk.io/blog/snyk-vercel-securing-agent-skill-ecosystem/>
+(the domain may be unreachable from restricted networks; the quotes above were
+recovered via search excerpts).
+
+## Observed timings
+
+Ranges from directly observed cycles, not documentation. Treat as
+order-of-magnitude, and re-derive rather than trusting these numbers forever.
+
+| Stage | Observed | Notes |
+|---|---|---|
+| first index | at first install | "Audits are generated automatically after a skill is installed for the first time" |
+| re-index after a change | **~2 days** | one fully observed cycle |
+| re-audit after an index | **~11 days** | same cycle; the two are decoupled |
+| audit → all caches agree | up to **~1 day** | install-path cache lagged the JSON API by a day |
+| install → any effect | **none** | 9 installs over 6 hours produced no index and no audit |
+
+**Escalation threshold.** Below roughly 2–3 days after a fix, nothing is wrong
+— the re-index has not come due. Escalating early wastes your time and a
+maintainer's. Beyond that window, with the literal still in the snapshot, the
+case is real.
+
+## Worked example: a complete, successful cycle (ci-speedup)
+
+The whole loop, start to finish, with no intervention from anyone:
+
+```
+ Jul 22            Jul 28 01:12       ~Jul 30             Aug 10 19:11
+ first seen        PR #15 merges      snapshot            Snyk re-audits
+ + first audit     the W007 fix       RE-INDEXED          that snapshot
+     |                  |                  |                   |
+     v                  v                  v                   v
+ FAIL / HIGH            +---- ~2 days -----+                   |
+ W007 + W011                               |                   |
+                                           +---- ~11 days -----+
+                                           |                   |
+                              snapshot now contains       WARN / MEDIUM
+                              tests/test_secret_          W011 only
+                              redaction.py                (W007 CLEARED)
+```
+
+Two things this proves and one it strongly suggests:
+
+- Re-indexing **does** happen, unprompted. The snapshot moved from Jul-22-era
+  content to Jul-30-era content on its own.
+- Findings **do** clear once the fix is in the snapshot. W007 disappeared.
+- It strongly suggests the scanners read the snapshot: W007 cleared precisely
+  when the fixing commit's file appeared there. Not proof — the scanners could
+  read the branch independently — but the correlation is exact.
+
+## Worked example: a fix that has not landed yet (ci-secure)
+
+```
+ Aug 10 17:54       Aug 10 19:09        Aug 11 19:44        Aug 11 22:12
+ first index        f5c51a2 removes     audit re-runs on    snapshot still
+ + first audit      the flagged URL     the OLD snapshot    holds Aug-09
+     |                   |                   |               content
+     v                   v                   v                   |
+ FAIL / CRITICAL     fix lands 75 min    E005 REPEATS with       v
+ E005 + W011         AFTER the index     a NEW timestamp    ~27h elapsed:
+                                         (Gen flips to      still inside
+                                          SAFE on the       the ~2-day
+                                          same input)       window
+```
+
+The 75-minute gap is the whole story: the index captured the repository just
+before the fix, and the audit a day later re-ran over that capture. Nothing is
+stuck; the next index had not come due.
+
+Note Gen flipping fail→pass across those two audits **on unchanged input**.
+Model-based providers re-judge; rule-based ones reproduce. A verdict changing
+is therefore not evidence that content changed.
+
+## Reading a disagreement
+
+Work down this list; stop at the first match.
+
+1. **Is the quoted literal in the snapshot?** If yes and it is gone from the
+   repository, the input is stale. Check elapsed time before escalating.
+2. **Is it in the repository too?** Then the finding is real. Fix or accept it.
+3. **In neither?** The scanner is likely serving its own cached result; a
+   re-index may not clear it. Say so rather than requesting the wrong remedy.
+4. **Verdicts differ across surfaces?** Cache propagation. Re-run later.
+
+Corroborate with the project's own scanner run if it has one: same scanner,
+current branch, opposite verdict isolates the input as the variable.
+
+## Preventing it: scan before you publish
+
+Everything above is remediation. The cheap fix is upstream: run the registry's
+own scanner in CI so a violation fails your build instead of surfacing as a
+public FAIL badge days later, on a snapshot you cannot refresh. This repo's
+`.github/workflows/registry-scan.yml` is a working implementation; the design
+points that matter are portable.
+
+**Gate on the critical class only.** The scanner has no severity threshold, so
+the rule is expressed by enumerating the warning class into
+`--ignore-issues-codes`. Warning-class findings are usually accurate
+descriptions of what a repository-auditing skill legitimately does; blocking on
+them trains people to suppress findings. Surface them (annotations, job
+summary, uploaded artifact) and let a human judge.
+
+**Never let an E-code into the ignore list.** One there silently disarms the
+gate, and nothing else in the system would tell you. Pin it with a test that
+asserts every ignored code starts with `W`, and a second that pins the list to
+exactly the published warning class — short of it, a warning reddens the build
+and someone "fixes" it by guessing; beyond it, a code nobody read is being
+suppressed.
+
+**Prove the gate can go red, on every run.** A check that cannot fail is not a
+check, and a scanner's rule catalog changes with no commit of yours. Before the
+real scan, build a throwaway skill carrying the exact violation class you care
+about, scan it **with the gate's real ignore list**, and fail unless the
+scanner both reports the anchor code and exits non-zero. Running it with the
+real ignore list is the subtle part: with an empty one you would only prove the
+scanner can fail, not that *this gate* can. This also fails upward — if the
+anchor rule is renamed or retired, the step goes red and a human re-anchors it
+rather than the gate quietly protecting nothing.
+
+**Add a cheap offline guard for the shape you already got burned by.** The
+scanner needs a token, network, and minutes. A plain text rule needs none and
+runs in the normal test suite, so it blocks the commit rather than the merge.
+Assemble any test fixture that must contain the offending shape at runtime, or
+the guard will correctly reject your own tests.
+
+**Schedule it.** A weekly run is what notices a catalog change that needed no
+commit of yours.
+
+**Make it a required status check.** A gate that can be merged past is
+advisory. Confirm it is required in branch protection, not merely present.
+
+Two layers is the goal: a text guard that fails in seconds with no
+dependencies, and the real scanner as the authoritative check. The first
+catches the mistake while you are typing; the second catches everything you did
+not anticipate.
+
+## Evidence log: how each claim was established
+
+Nothing here is from documentation; the registry documents almost none of it.
+Re-derive any claim that stops matching reality.
+
+| Claim | How it was established |
+|---|---|
+| Install never triggers an index or audit | Read the CLI source: the audit call is a `GET` keyed on owner/repo + skill display names, gated only on the repo being public, with `blobResult` absent from the expression. Confirmed empirically: 9 installs over 6 hours moved nothing. |
+| The audit key carries no commit SHA | Same source read; the request carries owner/repo and names only. |
+| The JSON API has no finding codes | Its `summary` is prose plus a count. Codes appear only on the per-provider HTML pages. |
+| A stored snapshot exists and is fetchable | Found `/api/download/...` referenced in the CLI's blob module; fetched it directly and got `{files[], hash}`. |
+| The snapshot can be stale | Fetched ci-secure's: 80 files, hash `a2f6d76e…`, containing the removed URL in 4 files and zero occurrences of the placeholder that replaced it. |
+| The snapshot can be dated | Read `CHANGELOG.md` out of the snapshot: newest entry 2026-08-09 versus 2026-08-10 on the default branch. |
+| Re-indexing happens | ci-speedup was first seen Jul 22 but its snapshot contains `tests/test_secret_redaction.py`, added by PR #15 on Jul 28. Content postdating the first index can only arrive by re-indexing. |
+| Findings clear once the fix is in the snapshot | ci-speedup went FAIL/HIGH with W007+W011 (issue #12, scanned Jul 22) to WARN/MEDIUM with W011 only, after the fix appeared in the snapshot. |
+| Audits re-run over an unchanged snapshot | ci-secure's audit timestamps advanced ~24h while its snapshot hash stayed `a2f6d76e…` and the finding text stayed byte-identical. |
+| Caches disagree | The install-path endpoint served 2026-08-10 values while the JSON API served 2026-08-11 for the same skill. |
+| Model-based providers re-judge unchanged input | Gen went HIGH/fail to SAFE/pass across two audits of the same snapshot, and its category list grew rather than shrank. |
+| The pages expose no other API | A browser network capture was blocked by egress policy, but the page source is an RSC payload plus Vercel Web Analytics (`/_vercel/insights/*`); no audit or index endpoint is called client-side. |
+
+## Claims deliberately NOT made
+
+Recorded so nobody re-derives a dead end or repeats an overreach:
+
+- **"The scanners read the snapshot."** Consistent with every observation and
+  strongly supported by the W007 timing, but never verified. The scanners could
+  read the branch through a separate path.
+- **"Indexing happens once and never repeats."** Tempting after watching one
+  skill sit still for a day. It is false — ci-speedup re-indexed.
+- **"Self-hosting the snapshot fixes the audit."** The CLI has an allowlist for
+  repos serving their own snapshot, but the audit call does not consult it.
+  Being added would change installs, not audits.
+- **"Renaming the skill forces a fresh audit."** A new name means a new slug
+  means a new identity with no cached audit — and it is not an acceptable
+  remedy. It discards the skill's URL, install count, and recognition to work
+  around someone else's caching. Do not propose it.
+- **"Filing an issue reliably works."** At the time of writing, a search for
+  re-index and rescan requests returned a dozen matches, all open and
+  unanswered. It costs little, but do not present it as a fix.

--- a/maintainers/skills-registry-security/references/registry-surfaces.md
+++ b/maintainers/skills-registry-security/references/registry-surfaces.md
@@ -11,6 +11,7 @@ provider.
 - Surface B: the install-path audit endpoint
 - Surface C: the rendered skill page
 - Surface D: the per-provider detail page
+- Surface E: the stored snapshot (the scan input)
 - Finding-code classes
 - Provider slugs and display names
 - Why the surfaces disagree
@@ -112,6 +113,40 @@ pointing at the registry's own domain.
 The page carries **no file paths or line numbers**. A finding is therefore
 identified only by its code plus the literal it quotes, which is exactly why
 grepping that literal is the decisive test.
+
+## Surface E: the stored snapshot (the scan input)
+
+```
+GET https://www.skills.sh/api/download/{owner}/{repo}/{skill}
+```
+
+The single most useful surface, and the least obvious. Returns the pre-built
+snapshot the registry keeps for fast installs — and the same content the
+scanners read:
+
+```json
+{"files": [{"path": "SKILL.md", "contents": "..."}, ...],
+ "hash": "a2f6d76e…"}
+```
+
+`hash` is the `skillsComputedHash`. Note the bare `skills.sh` host may fail to
+connect from some networks; use `www.skills.sh`.
+
+Because this returns **actual file contents**, a finding's quoted literal can be
+searched directly in the bytes the scanner saw. That converts "the string is
+gone from our repository, so the scan must be stale" — an inference — into "the
+string is still in your snapshot, here is its hash and the four files that
+contain it", which a maintainer can verify against their own service without
+access to the repository.
+
+Dating a snapshot is easy when the skill keeps a dated changelog: read
+`CHANGELOG.md` out of the snapshot and compare its newest entry against the
+repository's. A snapshot whose newest entry predates the fix commit is
+conclusive.
+
+Installing does not necessarily consume this snapshot — the CLI may clone the
+default branch instead — so a clean installed tree and a stale snapshot coexist
+happily. Do not treat the install as evidence about the audit.
 
 ## Finding-code classes
 

--- a/maintainers/skills-registry-security/references/registry-surfaces.md
+++ b/maintainers/skills-registry-security/references/registry-surfaces.md
@@ -1,0 +1,201 @@
+# Registry surfaces reference
+
+Exact URL shapes, response schemas, and finding-code classes behind
+`scripts/registry_audit.py`. Read this when the script's parsing breaks — a
+registry redesign changes page markup without notice — or when adding a
+provider.
+
+## Contents
+
+- Surface A: the JSON audit API
+- Surface B: the install-path audit endpoint
+- Surface C: the rendered skill page
+- Surface D: the per-provider detail page
+- Finding-code classes
+- Provider slugs and display names
+- Why the surfaces disagree
+- Verifying a literal
+- Comparing against a project's own scan
+
+## Surface A: the JSON audit API
+
+```
+GET https://www.skills.sh/api/v1/skills/audit/{owner}/{repo}/{skill}
+```
+
+Returns one entry per provider:
+
+```json
+{
+  "id": "owner/repo/skill",
+  "audits": [
+    {"provider": "Gen Agent Trust Hub", "slug": "agent-trust-hub",
+     "status": "pass", "riskLevel": "SAFE",
+     "auditedAt": "2026-08-11T19:44:35.075Z", "summary": "...",
+     "categories": ["PROMPT_INJECTION", "..."]}
+  ]
+}
+```
+
+`status` is one of `pass`, `fail`, `warn`. `summary` is prose plus an issue
+count — **it never contains finding codes**, which is why Surface D exists.
+
+A skill that has never been audited returns a not-found body stating that
+audits are generated after a skill is installed for the first time. That is the
+only documented trigger, and it fires on first indexing, not on later installs.
+
+Requesting `/{provider}` as a fourth path segment returns HTTP 400; the API
+accepts only the three-segment form. A `?provider=` query parameter is accepted
+but ignored — the full provider list comes back regardless.
+
+## Surface B: the install-path audit endpoint
+
+```
+GET https://add-skill.vercel.sh/audit?source={owner}/{repo}&skills={slug}
+```
+
+This is what the CLI reads at install time, and it is a **different cache** from
+Surface A. Response is keyed by skill slug, with abbreviated provider keys:
+
+```json
+{"ci-secure": {
+  "ath":    {"risk": "safe",     "analyzedAt": "..."},
+  "socket": {"risk": "medium", "alerts": 0, "score": 79, "analyzedAt": "..."},
+  "snyk":   {"risk": "critical", "analyzedAt": "..."}}}
+```
+
+Note `analyzedAt` here versus `auditedAt` on Surface A, and `ath` versus the
+`agent-trust-hub` slug. The timestamps are the reliable join key.
+
+This endpoint has served results a full day older than Surface A. Since it
+drives what users see, treat it — not the API — as the answer to "what does a
+user see today?".
+
+## Surface C: the rendered skill page
+
+```
+GET https://www.skills.sh/{owner}/{repo}/{skill}
+```
+
+HTML. Carries a `Security Audits` block with a `Pass`/`Fail`/`Warn` badge per
+provider, plus `Installs` and `First Seen`. Independently cached again, so it
+can disagree with both A and B.
+
+Flatten it by stripping `<script>`/`<style>`, then all tags, then collapsing
+whitespace. The badges appear as `<provider name> <verdict>` pairs between the
+literal strings `Security Audits` and `Browse All`.
+
+## Surface D: the per-provider detail page
+
+```
+GET https://www.skills.sh/{owner}/{repo}/{skill}/security/{provider-slug}
+```
+
+**The only place finding codes and their prose live.** Structure after
+flattening:
+
+```
+... {skill} {Pass|Fail|Warn} Audited by {Provider} on {date}
+Risk Level: {LEVEL}
+Full Analysis
+  {SEVERITY} {CODE}: {title}. {body prose, which quotes offending literals}
+  ...
+Issues ( {n} ) {CODE} {SEVERITY} {title} ...
+Audit Metadata Risk Level {LEVEL} Analyzed {timestamp} Issues {n}
+```
+
+Parse between `Full Analysis` and `Audit Metadata`. Finding codes match
+`[EW]\d{3}`. Literals the scanner objected to appear inline in the prose,
+usually parenthesized — extract URLs with a permissive pattern and drop any
+pointing at the registry's own domain.
+
+The page carries **no file paths or line numbers**. A finding is therefore
+identified only by its code plus the literal it quotes, which is exactly why
+grepping that literal is the decisive test.
+
+## Finding-code classes
+
+Snyk Agent Scan splits its catalog into two classes, and conflating them causes
+bad triage:
+
+| Class | Meaning | How to treat it |
+|-------|---------|-----------------|
+| `E###` | Critical. Drives the overall risk level. | Gate on these. One is enough to turn a skill red. |
+| `W###` | Warning. | Usually an accurate description of inherent behavior. Accept with a rationale, or fix if cheap. |
+
+Two that recur for repository-auditing skills:
+
+- **`E005` — suspicious download URL in skill instructions.** Fires on a literal
+  http(s) URL whose *path* ends in `.sh`, `.ps1`, or `.bash`, whether or not it
+  is executed. Teaching material showing a `curl … | bash` example trips it. A
+  reserved or example host does not clear it: the rule keys on the shape, not
+  the domain. Replacing the address with a placeholder does clear it.
+- **`W011` — third-party content exposure.** Fires when a skill ingests
+  outsider-authored text at runtime. For a skill that audits other people's
+  repositories this is simply true, and it fires even when the ingested text is
+  already wrapped in explicit untrusted-content delimiters.
+
+The catalog changes without any commit of yours, so a skill can go red with no
+local change. A scheduled re-run of your own scanner is what notices.
+
+## Provider slugs and display names
+
+| Display name | Surface A slug | Surface B key | Detail-page slug |
+|---|---|---|---|
+| Gen Agent Trust Hub | `agent-trust-hub` | `ath` | `agent-trust-hub` |
+| Socket | `socket` | `socket` | `socket` |
+| Snyk | `snyk` | `snyk` | `snyk` |
+
+Gen's verdicts are model-generated prose rather than a fixed rule catalog, so it
+can reverse itself between scans on unchanged content. Socket reports an alert
+count and a score. Snyk reports the coded findings above.
+
+## Why the surfaces disagree
+
+Each surface caches independently, and none of them keys on a commit SHA. The
+practical consequences:
+
+- Pushing a fix invalidates nothing.
+- A refresh can reach one surface hours or a day before another.
+- A re-audit may re-run the scanner against the **stored snapshot** rather than
+  the current default branch, producing a new `auditedAt` on a finding derived
+  from deleted content. This is the single most confusing behavior in the whole
+  system, and the reason a fresh timestamp proves nothing on its own.
+
+Re-indexing (refreshing the stored snapshot) and re-auditing (re-running
+scanners over whatever is stored) are separate operations. A stale-content
+finding needs the former.
+
+## Verifying a literal
+
+For each literal a finding quotes, check two corpora:
+
+1. **The git ref** — `git grep -I -l -F "<literal>" origin/main`. Covers every
+   tracked file, so it answers "is this in the published default branch?".
+2. **The freshly installed tree** — `grep -rIlF "<literal>" <install-dir>`.
+   Covers exactly the bytes the registry ships, which can differ from the
+   repository if the install excludes paths.
+
+Absent from both ⇒ the finding cannot describe current content. Present in
+either ⇒ treat the finding as real and decide whether to fix or accept it.
+
+Search for the literal string, not a regex built from it, and search
+case-sensitively. Matching a hand-built pattern instead of the quoted literal
+reintroduces exactly the false-positive class this test exists to eliminate.
+
+## Comparing against a project's own scan
+
+If the project runs the same scanner in CI, that run is the strongest available
+counter-evidence, because it removes any argument about scanner behavior and
+isolates the input. Useful things to extract:
+
+- Whether the gate distinguishes critical from warning codes; a green build
+  usually means "no critical codes", not "no findings".
+- Whether the workflow proves its gate can fail before trusting a pass. Without
+  that, a green result may be vacuous.
+- The run's timestamp and head SHA, so it can be quoted against the registry's
+  `auditedAt`.
+
+Agreement on warning codes combined with disagreement on a critical code is a
+strong signature of stale input: the finding tied to live behavior reproduces,
+while the one tied to deleted content does not.

--- a/maintainers/skills-registry-security/scripts/registry_audit.py
+++ b/maintainers/skills-registry-security/scripts/registry_audit.py
@@ -35,6 +35,11 @@ from pathlib import Path
 API_BASE = "https://www.skills.sh/api/v1/skills/audit"
 CLI_AUDIT = "https://add-skill.vercel.sh/audit"
 SITE_BASE = "https://www.skills.sh"
+# The stored snapshot the registry serves and the scanners read. Fetching this
+# turns "the flagged string is gone from our repo" into "the flagged string is
+# still in the bytes you are scanning", which is the difference between an
+# inference and an artifact a maintainer can verify with one request.
+SNAPSHOT_BASE = "https://www.skills.sh/api/download"
 UA = "skills-registry-security/1.0 (maintainer audit; read-only)"
 TIMEOUT = 20
 
@@ -156,6 +161,31 @@ def fetch_html_badges(owner: str, repo: str, skill: str) -> dict:
     return out
 
 
+def fetch_snapshot(owner: str, repo: str, skill: str) -> dict:
+    """Surface E - the stored snapshot the scanners actually read.
+
+    Returns the file contents the registry has on hand plus its
+    skillsComputedHash. When a finding's literal is still in here but gone from
+    the repository, the scanner is right about its input and the input is what
+    needs refreshing - which is a re-index, not a re-audit.
+    """
+    status, body = _get(f"{SNAPSHOT_BASE}/{owner}/{repo}/{skill}")
+    out = {"surface": "stored-snapshot", "http": status, "hash": None,
+           "files": {}, "error": None}
+    if status != 200:
+        out["error"] = f"HTTP {status}" if status else body[:200]
+        return out
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError as exc:
+        out["error"] = f"unparseable: {exc}"
+        return out
+    out["hash"] = data.get("hash")
+    out["files"] = {f["path"]: f.get("contents", "")
+                    for f in data.get("files", []) if "path" in f}
+    return out
+
+
 def fetch_findings(owner: str, repo: str, skill: str, provider: str) -> dict:
     """Surface D - per-provider detail page. The ONLY place finding codes live.
 
@@ -238,18 +268,29 @@ def fresh_install(owner: str, repo: str, timeout: int = 300) -> dict:
 # phantom-finding verification
 # --------------------------------------------------------------------------
 
-def verify_literals(literals: list[str], repo_root: Path | None,
-                    ref: str, install_dir: str | None) -> dict:
-    """Decide whether a cited literal still exists in the shipped content.
+def verify_literals(literals: list[str], repo_root: Path | None, ref: str,
+                    install_dir: str | None, snapshot: dict) -> dict:
+    """Classify each cited literal by which corpora still contain it.
 
-    A finding whose quoted string is absent from both the git ref and the
-    freshly installed tree cannot be describing today's skill. That is the
-    single most useful signal this tool produces, because it separates "the
-    scanner is right and we must fix it" from "the scan input is stale".
+    Three corpora answer three different questions. The git ref and the
+    installed tree say what the skill is today. The stored snapshot says what
+    the scanner was handed. Comparing them separates the two cases that need
+    opposite responses:
+
+      REAL        - still in today's content; the finding stands, fix or accept.
+      STALE_INPUT - gone from today's content but still in the snapshot. The
+                    scanner is right about its input; the input is stale. This
+                    is a re-index request, and the snapshot is the evidence.
+      PHANTOM     - gone everywhere, including the snapshot. The scanner is
+                    reporting something no longer in any corpus we can see,
+                    which usually means it cached its own finding.
     """
     results = {}
+    snap_files = snapshot.get("files") or {}
     for lit in literals:
-        rec = {"in_git": None, "in_install": None}
+        rec = {"in_git": None, "in_install": None, "in_snapshot": None,
+               "snapshot_paths": []}
+
         if repo_root and (repo_root / ".git").exists():
             p = subprocess.run(["git", "grep", "-I", "-l", "-F", lit, ref],
                                cwd=repo_root, capture_output=True, text=True)
@@ -258,8 +299,24 @@ def verify_literals(literals: list[str], repo_root: Path | None,
             p = subprocess.run(["grep", "-rIlF", lit, install_dir],
                                capture_output=True, text=True)
             rec["in_install"] = bool(p.stdout.strip())
-        present = [v for v in (rec["in_git"], rec["in_install"]) if v is not None]
-        rec["phantom"] = bool(present) and not any(present)
+        if snap_files:
+            hits = sorted(path for path, body in snap_files.items() if lit in body)
+            rec["in_snapshot"] = bool(hits)
+            rec["snapshot_paths"] = hits
+
+        checked = [v for v in (rec["in_git"], rec["in_install"]) if v is not None]
+        live = any(checked)
+        if live:
+            rec["verdict"] = "REAL"
+        elif rec["in_snapshot"]:
+            rec["verdict"] = "STALE_INPUT"
+        elif checked and rec["in_snapshot"] is False:
+            rec["verdict"] = "PHANTOM"
+        else:
+            # Nothing to compare against - say so rather than guess.
+            rec["verdict"] = "UNVERIFIED"
+        # Retained for callers that only care about "not in today's content".
+        rec["phantom"] = rec["verdict"] in ("STALE_INPUT", "PHANTOM")
         results[lit] = rec
     return results
 
@@ -304,21 +361,24 @@ def audit(owner: str, repo: str, skill: str, do_install: bool,
         f_api = pool.submit(fetch_api, owner, repo, skill)
         f_cli = pool.submit(fetch_cli_audit, owner, repo, skill)
         f_html = pool.submit(fetch_html_badges, owner, repo, skill)
+        f_snap = pool.submit(fetch_snapshot, owner, repo, skill)
         f_find = {p: pool.submit(fetch_findings, owner, repo, skill, p)
                   for p in PROVIDER_SLUGS}
         f_inst = pool.submit(fresh_install, owner, repo) if do_install else None
 
         api, cli, html = f_api.result(), f_cli.result(), f_html.result()
+        snapshot = f_snap.result()
         findings = {p: f.result() for p, f in f_find.items()}
         install = f_inst.result() if f_inst else {"ran": False}
 
     literals = sorted({u for f in findings.values() for u in f.get("cited_urls", [])})
-    checked = verify_literals(literals, repo_root, ref, install.get("install_dir"))
+    checked = verify_literals(literals, repo_root, ref,
+                              install.get("install_dir"), snapshot)
 
     return {
         "target": f"{owner}/{repo}/{skill}",
         "checked_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-        "api": api, "cli": cli, "html": html,
+        "api": api, "cli": cli, "html": html, "snapshot": snapshot,
         "findings": findings, "install": install,
         "literals": checked,
         "skew": reconcile(api, cli, html),
@@ -358,6 +418,21 @@ def render(r: dict) -> str:
     elif r["install"].get("error"):
         L.append(f"## Fresh install: SKIPPED - {r['install']['error']}\n")
 
+    snap = r.get("snapshot", {})
+    if snap.get("hash"):
+        L.append("## Stored snapshot (what the scanners read)")
+        L.append(f"  hash  {snap['hash']}")
+        L.append(f"  files {len(snap.get('files', {}))}")
+        L.append("")
+    elif snap.get("error"):
+        L.append(f"## Stored snapshot: unavailable - {snap['error']}\n")
+
+    TAG = {
+        "REAL": "present in current content - finding stands",
+        "STALE_INPUT": "STALE INPUT - gone from repo, still in stored snapshot",
+        "PHANTOM": "PHANTOM - gone from repo AND snapshot",
+        "UNVERIFIED": "unverified - no corpus to check against",
+    }
     L.append("## Findings (from per-provider pages - not in the API)")
     any_found = False
     for prov, f in r["findings"].items():
@@ -367,8 +442,10 @@ def render(r: dict) -> str:
         L.append(f"  {prov}: {f.get('verdict') or '?'} - {', '.join(f['codes'])}")
         for u in f.get("cited_urls", []):
             rec = r["literals"].get(u, {})
-            tag = "PHANTOM (absent from repo AND install)" if rec.get("phantom") else "present"
-            L.append(f"       cites {u}  ->  {tag}")
+            L.append(f"       cites {u}")
+            L.append(f"         -> {TAG.get(rec.get('verdict'), '?')}")
+            for path in rec.get("snapshot_paths", [])[:6]:
+                L.append(f"            still in snapshot: {path}")
     if not any_found:
         L.append("  (no finding codes parsed)")
     L.append("")
@@ -379,18 +456,33 @@ def render(r: dict) -> str:
             L.append(f"  ! {n}")
         L.append("")
 
-    phantoms = [k for k, v in r["literals"].items() if v.get("phantom")]
+    stale = [k for k, v in r["literals"].items() if v.get("verdict") == "STALE_INPUT"]
+    phantom = [k for k, v in r["literals"].items() if v.get("verdict") == "PHANTOM"]
+    real = [k for k, v in r["literals"].items() if v.get("verdict") == "REAL"]
+
     L.append("## Verdict")
-    if phantoms:
-        L.append("  STALE INPUT - a finding cites content that exists in neither the")
-        L.append("  git ref nor the freshly installed tree:")
-        for p in phantoms:
-            L.append(f"    - {p}")
-        L.append("  Re-auditing the same snapshot will reproduce it. Ask for a")
-        L.append("  RE-INDEX (refresh the stored snapshot), not just a re-audit.")
+    if stale:
+        L.append("  STALE INPUT, PROVEN. The registry is still serving content the")
+        L.append("  repository no longer has, and that is what the scanners read:")
+        for s in stale:
+            L.append(f"    - {s}")
+        L.append("")
+        L.append("  There is nothing to patch. Re-auditing this snapshot reproduces")
+        L.append("  the finding, so ask for a RE-INDEX. Quote in the request:")
+        L.append(f"    snapshot hash : {snap.get('hash') or '(unavailable)'}")
+        L.append("    stale paths   : " + ", ".join(
+            sorted({p for k in stale for p in r["literals"][k]["snapshot_paths"]})[:4])
+            or "    stale paths   : (none recorded)")
+    elif phantom:
+        L.append("  Findings cite content absent from the repository AND from the")
+        L.append("  stored snapshot, so the scanner is likely serving a cached")
+        L.append("  result of its own. A re-index alone may not clear it; say so.")
+    elif real:
+        L.append("  Flagged literals are present in current content. The findings")
+        L.append("  describe the skill as it is - fix them or accept them with a")
+        L.append("  written rationale. Staleness is not the explanation here.")
     else:
-        L.append("  No phantom literals detected. Findings that remain are most")
-        L.append("  likely describing content that is really there - fix or accept them.")
+        L.append("  No literals to verify. Judge the findings on their prose.")
     return "\n".join(L)
 
 

--- a/maintainers/skills-registry-security/scripts/registry_audit.py
+++ b/maintainers/skills-registry-security/scripts/registry_audit.py
@@ -262,6 +262,36 @@ def fetch_findings(owner: str, repo: str, skill: str, provider: str) -> dict:
 ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
 
 
+def beacon_precondition(owner: str, repo: str) -> dict:
+    """Whether a fresh install would actually fire the telemetry beacon that
+    rebuilds the registry's snapshot — the ONLY self-serve nudge that exists.
+
+    The beacon is SILENTLY suppressed unless the GitHub repo probe returns 200
+    AND neither DO_NOT_TRACK nor DISABLE_TELEMETRY is set (references/
+    audit-pipeline.md). A suppressed beacon makes an install a no-op — the exact
+    trap that produced the false "installs never trigger a re-audit" conclusion
+    from nine beacon-suppressed installs. Check this BEFORE looping installs: if
+    the beacon can't fire, do not pretend an install probe means anything; just
+    monitor the registry's own re-audit cadence.
+    """
+    status, _ = _get(f"https://api.github.com/repos/{owner}/{repo}")
+    disabled = [v for v in ("DO_NOT_TRACK", "DISABLE_TELEMETRY")
+                if os.environ.get(v)]
+    ok = status == 200 and not disabled
+    if status != 200:
+        reason = (f"github repo probe returned {status}, not 200 — the install "
+                  "telemetry beacon is silently suppressed here, so an install "
+                  "cannot rebuild the snapshot. Do NOT loop installs; monitor the "
+                  "registry's own re-audit cadence instead.")
+    elif disabled:
+        reason = (f"telemetry disabled by {', '.join(disabled)} — the beacon is "
+                  "suppressed; an install is a no-op here.")
+    else:
+        reason = "beacon can fire: a fresh install will enqueue a re-index."
+    return {"ok": ok, "github_http": status,
+            "telemetry_disabled_by": disabled, "reason": reason}
+
+
 def fresh_install(owner: str, repo: str, timeout: int = 300) -> dict:
     """Run a real install and capture the risk table the user actually sees.
 
@@ -506,6 +536,72 @@ def audit(owner: str, repo: str, skill: str, do_install: bool,
     }
 
 
+def decide(result: dict, precond: dict | None = None) -> dict:
+    """The operator's next-action verdict, so an unattended watch can act without
+    a human reading the report. Exactly one of:
+
+      RESOLVED        every provider passes and no cited literal is outstanding —
+                      the badge is clean. STOP watching.
+      ACTION_REQUIRED a cited literal is REAL (still in HEAD) — the finding is
+                      legitimate. Fix the code or accept it. STOP watching.
+      MONITOR         a provider still fails, but every failing literal is gone
+                      from HEAD (stale/phantom/lagging) — nothing to fix. The
+                      registry re-audits on its own (~daily) and clears it; keep
+                      watching. This is the common, no-self-serve-fix case: do NOT
+                      loop installs when the beacon is suppressed, and treat a
+                      re-index issue on vercel-labs/skills as an OPTIONAL long-shot
+                      to DRAFT for the owner, never an auto-action or "the fix."
+      DISAGREEMENT    the cached surfaces disagree — re-check before trusting.
+      UNVERIFIED      no local corpus to classify the cited literals against.
+    """
+    providers = (result.get("api") or {}).get("providers") or {}
+    failing = sorted(
+        slug for slug, p in providers.items()
+        if str(p.get("status", "")).lower() not in ("pass", "safe", "")
+        or str(p.get("riskLevel", "")).upper() in ("HIGH", "CRITICAL"))
+    verdicts = {lit: rec.get("verdict")
+                for lit, rec in (result.get("literals") or {}).items()}
+    real = sorted(l for l, v in verdicts.items() if v == "REAL")
+    stale = sorted(l for l, v in verdicts.items()
+                   if v in ("STALE_INPUT", "PHANTOM", "LAGGING",
+                            "PHANTOM_OR_LAGGING"))
+
+    if result.get("skew"):
+        decision = "DISAGREEMENT"
+        why = "cached surfaces disagree: " + "; ".join(result["skew"])
+    elif real:
+        decision = "ACTION_REQUIRED"
+        why = (f"{len(real)} cited literal(s) still present in HEAD — a real "
+               f"finding, not staleness: {', '.join(real[:3])}")
+    elif not failing:
+        decision = "RESOLVED"
+        why = "all providers pass; no outstanding finding"
+    elif stale:
+        kinds = ", ".join(sorted({v for v in verdicts.values() if v}))
+        decision = "MONITOR"
+        why = (f"provider(s) {', '.join(failing)} still fail, but the cited "
+               f"literal(s) are gone from HEAD ({kinds}) — nothing to fix; wait "
+               "for the registry's own re-audit to clear it")
+    elif verdicts:
+        decision = "UNVERIFIED"
+        why = (f"provider(s) {', '.join(failing)} fail but the cited literals "
+               "could not be classified (no local corpus?)")
+    else:
+        decision = "MONITOR"
+        why = (f"provider(s) {', '.join(failing)} fail; no cited literals were "
+               "extracted to classify — re-check the finding detail pages")
+
+    out = {"decision": decision, "why": why, "providers_failing": failing,
+           "real_literals": real, "stale_literals": stale}
+    if precond is not None:
+        out["beacon"] = precond
+        if decision == "MONITOR" and not precond.get("ok"):
+            out["note"] = ("the install beacon is suppressed here, so do NOT loop "
+                           "installs — monitor the registry's own re-audit "
+                           "cadence instead")
+    return out
+
+
 def render(r: dict) -> str:
     L = []
     L.append(f"# registry security - {r['target']}")
@@ -624,6 +720,17 @@ def render(r: dict) -> str:
         L.append("  written rationale. Staleness is not the explanation here.")
     else:
         L.append("  No literals to verify. Judge the findings on their prose.")
+
+    d = r.get("decision")
+    if d:
+        L.append("")
+        L.append(f"NEXT ACTION: {d['decision']} — {d['why']}")
+        if d.get("note"):
+            L.append(f"  ({d['note']})")
+        b = d.get("beacon")
+        if b:
+            L.append(f"  install beacon: {'CAN FIRE' if b.get('ok') else 'SUPPRESSED'}"
+                     f" (github probe {b.get('github_http')})")
     return "\n".join(L)
 
 
@@ -662,6 +769,10 @@ def main(argv=None) -> int:
 
     result = audit(owner, repo, skill, not args.no_install, root, args.ref,
                    snapshot_changed_at=changed_at)
+    # The operator verdict: what an unattended watch should DO next, plus whether
+    # the install beacon can even fire here (so a suppressed-beacon environment
+    # is never mistaken for "installs don't trigger a re-audit").
+    result["decision"] = decide(result, beacon_precondition(owner, repo))
     print(json.dumps(result, indent=2) if args.json else render(result))
     return 0
 

--- a/maintainers/skills-registry-security/scripts/registry_audit.py
+++ b/maintainers/skills-registry-security/scripts/registry_audit.py
@@ -269,7 +269,9 @@ def fresh_install(owner: str, repo: str, timeout: int = 300) -> dict:
 # --------------------------------------------------------------------------
 
 def verify_literals(literals: list[str], repo_root: Path | None, ref: str,
-                    install_dir: str | None, snapshot: dict) -> dict:
+                    install_dir: str | None, snapshot: dict,
+                    audited_at: "datetime | None" = None,
+                    snapshot_changed_at: "datetime | None" = None) -> dict:
     """Classify each cited literal by which corpora still contain it.
 
     Three corpora answer three different questions. The git ref and the
@@ -281,9 +283,18 @@ def verify_literals(literals: list[str], repo_root: Path | None, ref: str,
       STALE_INPUT - gone from today's content but still in the snapshot. The
                     scanner is right about its input; the input is stale. This
                     is a re-index request, and the snapshot is the evidence.
-      PHANTOM     - gone everywhere, including the snapshot. The scanner is
-                    reporting something no longer in any corpus we can see,
-                    which usually means it cached its own finding.
+      PHANTOM     - gone everywhere, including the snapshot, AND the audit has
+                    demonstrably run since the snapshot was built. Only then is
+                    a scanner-side cache the explanation.
+      LAGGING     - gone everywhere, but the audit predates the current
+                    snapshot, so it has not read it yet. The ordinary case
+                    after a fix: wait for the next sweep, do not escalate.
+
+    The PHANTOM/LAGGING split matters more than it looks. Both present as "the
+    literal is nowhere", and treating the second as the first sends a
+    maintainer to escalate a finding that would clear on its own within a day.
+    Distinguishing them needs `snapshot_changed_at`; without it this refuses to
+    assert PHANTOM at all.
     """
     results = {}
     snap_files = snapshot.get("files") or {}
@@ -311,12 +322,22 @@ def verify_literals(literals: list[str], repo_root: Path | None, ref: str,
         elif rec["in_snapshot"]:
             rec["verdict"] = "STALE_INPUT"
         elif checked and rec["in_snapshot"] is False:
-            rec["verdict"] = "PHANTOM"
+            # Absent everywhere. Two very different causes look identical here:
+            # the scanner cached its own result, or the audit simply has not
+            # read the current snapshot yet. Only the timestamps separate them,
+            # and without both we decline to accuse the scanner.
+            if audited_at and snapshot_changed_at and audited_at < snapshot_changed_at:
+                rec["verdict"] = "LAGGING"
+            elif audited_at and snapshot_changed_at:
+                rec["verdict"] = "PHANTOM"
+            else:
+                rec["verdict"] = "PHANTOM_OR_LAGGING"
         else:
             # Nothing to compare against - say so rather than guess.
             rec["verdict"] = "UNVERIFIED"
         # Retained for callers that only care about "not in today's content".
-        rec["phantom"] = rec["verdict"] in ("STALE_INPUT", "PHANTOM")
+        rec["phantom"] = rec["verdict"] in (
+            "STALE_INPUT", "PHANTOM", "PHANTOM_OR_LAGGING", "LAGGING")
         results[lit] = rec
     return results
 
@@ -356,7 +377,8 @@ def reconcile(api: dict, cli: dict, html: dict) -> list[str]:
 # --------------------------------------------------------------------------
 
 def audit(owner: str, repo: str, skill: str, do_install: bool,
-          repo_root: Path | None, ref: str) -> dict:
+          repo_root: Path | None, ref: str,
+          snapshot_changed_at: "datetime | None" = None) -> dict:
     with ThreadPoolExecutor(max_workers=8) as pool:
         f_api = pool.submit(fetch_api, owner, repo, skill)
         f_cli = pool.submit(fetch_cli_audit, owner, repo, skill)
@@ -372,8 +394,14 @@ def audit(owner: str, repo: str, skill: str, do_install: bool,
         install = f_inst.result() if f_inst else {"ran": False}
 
     literals = sorted({u for f in findings.values() for u in f.get("cited_urls", [])})
+    # The OLDEST provider stamp is the honest one here: a literal is only
+    # phantom if every scanner that cites it has read the current snapshot.
+    stamps = [s for s in (parse_iso(p.get("auditedAt", ""))
+                          for p in (api.get("providers") or {}).values()) if s]
     checked = verify_literals(literals, repo_root, ref,
-                              install.get("install_dir"), snapshot)
+                              install.get("install_dir"), snapshot,
+                              audited_at=min(stamps) if stamps else None,
+                              snapshot_changed_at=snapshot_changed_at)
 
     return {
         "target": f"{owner}/{repo}/{skill}",
@@ -430,7 +458,10 @@ def render(r: dict) -> str:
     TAG = {
         "REAL": "present in current content - finding stands",
         "STALE_INPUT": "STALE INPUT - gone from repo, still in stored snapshot",
-        "PHANTOM": "PHANTOM - gone from repo AND snapshot",
+        "PHANTOM": "PHANTOM - gone everywhere, and the audit HAS read this snapshot",
+        "LAGGING": "LAGGING AUDIT - gone everywhere; audit predates this snapshot, so wait",
+        "PHANTOM_OR_LAGGING": ("gone from repo AND snapshot - cannot tell phantom from "
+                               "a not-yet-re-run audit without --snapshot-changed-at"),
         "UNVERIFIED": "unverified - no corpus to check against",
     }
     L.append("## Findings (from per-provider pages - not in the API)")
@@ -458,6 +489,9 @@ def render(r: dict) -> str:
 
     stale = [k for k, v in r["literals"].items() if v.get("verdict") == "STALE_INPUT"]
     phantom = [k for k, v in r["literals"].items() if v.get("verdict") == "PHANTOM"]
+    lagging = [k for k, v in r["literals"].items() if v.get("verdict") == "LAGGING"]
+    unknown_lag = [k for k, v in r["literals"].items()
+                   if v.get("verdict") == "PHANTOM_OR_LAGGING"]
     real = [k for k, v in r["literals"].items() if v.get("verdict") == "REAL"]
 
     L.append("## Verdict")
@@ -473,10 +507,24 @@ def render(r: dict) -> str:
         L.append("    stale paths   : " + ", ".join(
             sorted({p for k in stale for p in r["literals"][k]["snapshot_paths"]})[:4])
             or "    stale paths   : (none recorded)")
+    elif lagging:
+        L.append("  Findings cite content absent from the repository AND from the")
+        L.append("  stored snapshot, but the audit PREDATES this snapshot - it has")
+        L.append("  not read the fix yet. This is the ordinary post-fix state, not")
+        L.append("  a broken scanner. Wait for the next sweep (~a day) and re-check.")
+        L.append("  Do NOT escalate and do NOT re-install; nothing is stuck.")
+    elif unknown_lag:
+        L.append("  Findings cite content absent from the repository AND from the")
+        L.append("  stored snapshot. That is EITHER a scanner-side cache OR an audit")
+        L.append("  that has not re-run since the snapshot was rebuilt - and those")
+        L.append("  need opposite responses. Re-run with --snapshot-changed-at set to")
+        L.append("  when the hash last changed to tell them apart. Until then, assume")
+        L.append("  the lagging case: it is far more common, and waiting costs nothing.")
     elif phantom:
         L.append("  Findings cite content absent from the repository AND from the")
-        L.append("  stored snapshot, so the scanner is likely serving a cached")
-        L.append("  result of its own. A re-index alone may not clear it; say so.")
+        L.append("  stored snapshot, and the audit HAS run against this snapshot, so")
+        L.append("  the scanner is serving a cached result of its own. A re-index")
+        L.append("  alone will not clear it; escalate with the evidence above.")
     elif real:
         L.append("  Flagged literals are present in current content. The findings")
         L.append("  describe the skill as it is - fix them or accept them with a")
@@ -494,6 +542,11 @@ def main(argv=None) -> int:
     ap.add_argument("--repo-root", default=".", help="local checkout for literal verification")
     ap.add_argument("--ref", default="origin/main", help="git ref to verify against")
     ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument("--snapshot-changed-at", metavar="TS", default=None,
+                    help="ISO time the snapshot hash last changed. Separates a "
+                         "scanner-side phantom from an audit that simply has not "
+                         "re-run since the fix was ingested; without it the two "
+                         "are reported as indistinguishable.")
     args = ap.parse_args(argv)
 
     parts = args.target.strip("/").split("/")
@@ -506,7 +559,16 @@ def main(argv=None) -> int:
     if not (root / ".git").exists():
         root = None
 
-    result = audit(owner, repo, skill, not args.no_install, root, args.ref)
+    changed_at = None
+    if args.snapshot_changed_at:
+        changed_at = parse_iso(args.snapshot_changed_at)
+        if changed_at is None:
+            print(f"unparseable --snapshot-changed-at: {args.snapshot_changed_at}",
+                  file=sys.stderr)
+            return 2
+
+    result = audit(owner, repo, skill, not args.no_install, root, args.ref,
+                   snapshot_changed_at=changed_at)
     print(json.dumps(result, indent=2) if args.json else render(result))
     return 0
 

--- a/maintainers/skills-registry-security/scripts/registry_audit.py
+++ b/maintainers/skills-registry-security/scripts/registry_audit.py
@@ -18,7 +18,6 @@ stdlib only, to match the other engines in this repo.
 from __future__ import annotations
 
 import argparse
-import html as htmllib
 import json
 import os
 import re
@@ -28,6 +27,7 @@ import sys
 import tempfile
 import urllib.error
 import urllib.request
+from html.parser import HTMLParser
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
@@ -68,18 +68,54 @@ def _get(url: str) -> tuple[int, str]:
         return 0, f"__ERROR__ {type(exc).__name__}: {exc}"
 
 
-def _page_text(raw: str) -> str:
-    """Flatten rendered HTML to searchable text.
+class _TextExtractor(HTMLParser):
+    """Collect visible text, dropping `<script>` and `<style>` bodies entirely.
 
-    Tag matching is case-insensitive: HTML tag names are, and a surviving
-    `<SCRIPT>` body would be scanned for finding codes like any other text,
-    which is how a page's own JavaScript could invent an `E005` that no
-    scanner ever reported.
+    This was three successive regexes, and CodeQL found a hole in each: first
+    `<SCRIPT>`, then `</script >`, then `</script\t\n bar>` — all legal, since
+    an end tag may carry whitespace and even ignored attributes. That is the
+    rule's actual point: tag grammar is not a regular language, and each patch
+    only moves the hole. A parser closes the class instead of the instance.
+
+    It matters here because the flattened text is scanned for finding codes, so
+    a surviving script body lets a page's own JavaScript invent an `E005` that
+    no scanner ever reported.
     """
-    t = re.sub(r"<script\b[^>]*>.*?</script\s*>", " ", raw, flags=re.S | re.I)
-    t = re.sub(r"<style\b[^>]*>.*?</style\s*>", " ", t, flags=re.S | re.I)
-    t = re.sub(r"<[^>]+>", " ", t)
-    return re.sub(r"\s+", " ", htmllib.unescape(t)).strip()
+
+    _SKIP = {"script", "style"}
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.parts: list[str] = []
+        self._depth = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag in self._SKIP:
+            self._depth += 1
+
+    def handle_endtag(self, tag):
+        if tag in self._SKIP and self._depth:
+            self._depth -= 1
+
+    def handle_data(self, data):
+        if not self._depth:
+            self.parts.append(data)
+
+
+def _page_text(raw: str) -> str:
+    """Flatten rendered HTML to searchable text."""
+    p = _TextExtractor()
+    try:
+        p.feed(raw)
+        p.close()
+    except Exception:
+        # Malformed markup: keep whatever was parsed rather than losing the
+        # page. Partial text still beats crashing a diagnostic tool.
+        pass
+    # Joined on a space, not "": the old tag-to-space substitution is what put
+    # a gap between text in adjacent elements, and the verdict scrape relies on
+    # it ("Warn" and "Audited by" are separate nodes).
+    return re.sub(r"\s+", " ", " ".join(p.parts)).strip()
 
 
 def parse_iso(ts: str):
@@ -445,17 +481,20 @@ def audit(owner: str, repo: str, skill: str, do_install: bool,
         if citing:
             per_literal[lit] = min(citing)
 
-    checked = verify_literals(literals, repo_root, ref,
-                              _installed_skill_dir(install.get("install_dir"), skill),
-                              snapshot,
-                              snapshot_changed_at=snapshot_changed_at,
-                              audited_at_by_literal=per_literal)
-
     # The install has served its only purpose (the risk table plus the corpus
-    # above). Leaving it behind means every run of a "read-only" tool deposits
-    # a full skill tree in the system temp dir.
-    if install.get("install_dir"):
-        shutil.rmtree(install["install_dir"], ignore_errors=True)
+    # below), so it is removed in a finally: verification shells out to git and
+    # grep, and if either is missing the raise would otherwise leave a full
+    # skill tree behind — on exactly the repeated-failure path where the leak
+    # accumulates fastest.
+    try:
+        checked = verify_literals(literals, repo_root, ref,
+                                  _installed_skill_dir(install.get("install_dir"), skill),
+                                  snapshot,
+                                  snapshot_changed_at=snapshot_changed_at,
+                                  audited_at_by_literal=per_literal)
+    finally:
+        if install.get("install_dir"):
+            shutil.rmtree(install["install_dir"], ignore_errors=True)
 
     return {
         "target": f"{owner}/{repo}/{skill}",

--- a/maintainers/skills-registry-security/scripts/registry_audit.py
+++ b/maintainers/skills-registry-security/scripts/registry_audit.py
@@ -69,9 +69,15 @@ def _get(url: str) -> tuple[int, str]:
 
 
 def _page_text(raw: str) -> str:
-    """Flatten rendered HTML to searchable text."""
-    t = re.sub(r"<script.*?</script>", " ", raw, flags=re.S)
-    t = re.sub(r"<style.*?</style>", " ", t, flags=re.S)
+    """Flatten rendered HTML to searchable text.
+
+    Tag matching is case-insensitive: HTML tag names are, and a surviving
+    `<SCRIPT>` body would be scanned for finding codes like any other text,
+    which is how a page's own JavaScript could invent an `E005` that no
+    scanner ever reported.
+    """
+    t = re.sub(r"<script.*?</script>", " ", raw, flags=re.S | re.I)
+    t = re.sub(r"<style.*?</style>", " ", t, flags=re.S | re.I)
     t = re.sub(r"<[^>]+>", " ", t)
     return re.sub(r"\s+", " ", htmllib.unescape(t)).strip()
 

--- a/maintainers/skills-registry-security/scripts/registry_audit.py
+++ b/maintainers/skills-registry-security/scripts/registry_audit.py
@@ -536,6 +536,20 @@ def audit(owner: str, repo: str, skill: str, do_install: bool,
     }
 
 
+def _decided(decision: str, why: str, failing: list, real: list, stale: list,
+             precond: dict | None) -> dict:
+    """Assemble a verdict, attaching the beacon precondition when one was checked."""
+    out = {"decision": decision, "why": why, "providers_failing": failing,
+           "real_literals": real, "stale_literals": stale}
+    if precond is not None:
+        out["beacon"] = precond
+        if decision == "MONITOR" and not precond.get("ok"):
+            out["note"] = ("the install beacon is suppressed here, so do NOT loop "
+                           "installs — monitor the registry's own re-audit "
+                           "cadence instead")
+    return out
+
+
 def decide(result: dict, precond: dict | None = None) -> dict:
     """The operator's next-action verdict, so an unattended watch can act without
     a human reading the report. Exactly one of:
@@ -552,13 +566,31 @@ def decide(result: dict, precond: dict | None = None) -> dict:
                       re-index issue on vercel-labs/skills as an OPTIONAL long-shot
                       to DRAFT for the owner, never an auto-action or "the fix."
       DISAGREEMENT    the cached surfaces disagree — re-check before trusting.
-      UNVERIFIED      no local corpus to classify the cited literals against.
+      UNVERIFIED      a surface could not be read, or the cited literals could
+                      not be classified. Never confuse this with RESOLVED: a
+                      surface nobody fetched is not a surface that came back
+                      clean, and reporting one as the other stops the watch on
+                      an unread badge.
     """
-    providers = (result.get("api") or {}).get("providers") or {}
+    api = result.get("api") or {}
+    providers = api.get("providers") or {}
+    # `fetch_api` stores the registry's riskLevel under "risk"; reading
+    # "riskLevel" here made the whole risk clause dead code, so a HIGH/CRITICAL
+    # provider whose status happened to read pass/blank scored as RESOLVED.
     failing = sorted(
-        slug for slug, p in providers.items()
+        name for name, p in providers.items()
         if str(p.get("status", "")).lower() not in ("pass", "safe", "")
-        or str(p.get("riskLevel", "")).upper() in ("HIGH", "CRITICAL"))
+        or str(p.get("risk") or "").upper() in ("HIGH", "CRITICAL"))
+    # A surface we never read is not a surface that came back clean. Without
+    # this gate an unreachable API (network error, 500, rate-limit 403) yields
+    # zero providers, reads as "nothing failing", and STOPS the watch on a
+    # badge nobody looked at.
+    if api.get("error") or api.get("http") != 200:
+        return _decided("UNVERIFIED",
+                        "the provider status API was unreachable "
+                        f"(HTTP {api.get('http')}: {api.get('error')}) - cannot "
+                        "tell a clean badge from an unread one",
+                        [], [], [], precond)
     verdicts = {lit: rec.get("verdict")
                 for lit, rec in (result.get("literals") or {}).items()}
     real = sorted(l for l, v in verdicts.items() if v == "REAL")
@@ -587,19 +619,24 @@ def decide(result: dict, precond: dict | None = None) -> dict:
         why = (f"provider(s) {', '.join(failing)} fail but the cited literals "
                "could not be classified (no local corpus?)")
     else:
-        decision = "MONITOR"
-        why = (f"provider(s) {', '.join(failing)} fail; no cited literals were "
-               "extracted to classify — re-check the finding detail pages")
+        # No literals to classify splits two ways that need opposite responses:
+        # a detail page that loaded and cited nothing (benign, keep watching)
+        # versus one we could not fetch at all (zero information, not benign).
+        unread = sorted(p for p in failing
+                        if (result.get("findings") or {}).get(p, {}).get("error")
+                        or ((result.get("findings") or {}).get(p, {}).get("http")
+                            not in (200, None)))
+        if unread:
+            decision = "UNVERIFIED"
+            why = (f"provider(s) {', '.join(failing)} fail and the finding detail "
+                   f"page(s) for {', '.join(unread)} were unreachable - the "
+                   "finding could not be classified")
+        else:
+            decision = "MONITOR"
+            why = (f"provider(s) {', '.join(failing)} fail; no cited literals were "
+                   "extracted to classify — re-check the finding detail pages")
 
-    out = {"decision": decision, "why": why, "providers_failing": failing,
-           "real_literals": real, "stale_literals": stale}
-    if precond is not None:
-        out["beacon"] = precond
-        if decision == "MONITOR" and not precond.get("ok"):
-            out["note"] = ("the install beacon is suppressed here, so do NOT loop "
-                           "installs — monitor the registry's own re-audit "
-                           "cadence instead")
-    return out
+    return _decided(decision, why, failing, real, stale, precond)
 
 
 def render(r: dict) -> str:

--- a/maintainers/skills-registry-security/scripts/registry_audit.py
+++ b/maintainers/skills-registry-security/scripts/registry_audit.py
@@ -76,8 +76,8 @@ def _page_text(raw: str) -> str:
     which is how a page's own JavaScript could invent an `E005` that no
     scanner ever reported.
     """
-    t = re.sub(r"<script.*?</script>", " ", raw, flags=re.S | re.I)
-    t = re.sub(r"<style.*?</style>", " ", t, flags=re.S | re.I)
+    t = re.sub(r"<script\b[^>]*>.*?</script\s*>", " ", raw, flags=re.S | re.I)
+    t = re.sub(r"<style\b[^>]*>.*?</style\s*>", " ", t, flags=re.S | re.I)
     t = re.sub(r"<[^>]+>", " ", t)
     return re.sub(r"\s+", " ", htmllib.unescape(t)).strip()
 
@@ -283,13 +283,20 @@ def _installed_skill_dir(install_dir: str | None, skill: str | None) -> str | No
     `.agents/skills/<name>/`. Grepping the whole tree would let a literal that
     only ever appeared in a sibling skill mark this skill's finding REAL — the
     one misclassification that sends a maintainer to edit code that is already
-    clean. Falls back to the full tree only when the per-skill directory is
-    absent, since a wrong-but-narrow corpus beats no corpus.
+    clean.
+
+    When the per-skill directory is absent, this returns None rather than
+    falling back to the whole tree. Dropping the corpus costs an `in_install`
+    of None, which the caller reports honestly as unverified; keeping the whole
+    tree would instead produce a confident wrong answer in the one direction
+    that wastes a maintainer's time. The git corpus is unaffected either way.
     """
-    if not install_dir or not skill:
+    if not install_dir:
+        return None
+    if not skill:
         return install_dir
     scoped = Path(install_dir) / ".agents" / "skills" / skill
-    return str(scoped) if scoped.is_dir() else install_dir
+    return str(scoped) if scoped.is_dir() else None
 
 
 def verify_literals(literals: list[str], repo_root: Path | None, ref: str,

--- a/maintainers/skills-registry-security/scripts/registry_audit.py
+++ b/maintainers/skills-registry-security/scripts/registry_audit.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""One-shot registry security status for a published skill.
+
+The registry keeps a skill's audit in more than one place, and those places go
+out of sync with each other and with the repository. Answering "is this audit
+real?" by hand means opening four surfaces, reading a finding that the JSON API
+does not carry, and then proving by grep whether the flagged content still
+exists. This script does all of it concurrently so the answer arrives in one
+step instead of an afternoon.
+
+Everything here is read-only: HTTP GETs, a throwaway `npx skills add` into a
+temp directory, and greps over a local checkout. Nothing is written to the
+repository and nothing is POSTed to the registry.
+
+stdlib only, to match the other engines in this repo.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html as htmllib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from pathlib import Path
+
+API_BASE = "https://www.skills.sh/api/v1/skills/audit"
+CLI_AUDIT = "https://add-skill.vercel.sh/audit"
+SITE_BASE = "https://www.skills.sh"
+UA = "skills-registry-security/1.0 (maintainer audit; read-only)"
+TIMEOUT = 20
+
+# The registry renders one page per provider; the JSON API carries only a
+# summary string, so finding codes (E005, W011, ...) exist ONLY on these pages.
+PROVIDER_SLUGS = ("agent-trust-hub", "socket", "snyk")
+
+# Snyk Agent Scan splits its catalog into a critical class (E) and a warning
+# class (W). Only the E class should ever gate a release; see references.
+CODE_RE = re.compile(r"\b([EW]\d{3})\b")
+URL_RE = re.compile(r"https?://[^\s)\"'<>\]]+")
+
+
+# --------------------------------------------------------------------------
+# fetching
+# --------------------------------------------------------------------------
+
+def _get(url: str) -> tuple[int, str]:
+    req = urllib.request.Request(url, headers={"User-Agent": UA})
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+            return resp.status, resp.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8", "replace")
+    except Exception as exc:  # network/DNS/proxy - report, do not crash
+        return 0, f"__ERROR__ {type(exc).__name__}: {exc}"
+
+
+def _page_text(raw: str) -> str:
+    """Flatten rendered HTML to searchable text."""
+    t = re.sub(r"<script.*?</script>", " ", raw, flags=re.S)
+    t = re.sub(r"<style.*?</style>", " ", t, flags=re.S)
+    t = re.sub(r"<[^>]+>", " ", t)
+    return re.sub(r"\s+", " ", htmllib.unescape(t)).strip()
+
+
+def parse_iso(ts: str):
+    """The registry mixes `...Z` and `...+00:00` on the same payload."""
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+# --------------------------------------------------------------------------
+# surfaces
+# --------------------------------------------------------------------------
+
+def fetch_api(owner: str, repo: str, skill: str) -> dict:
+    """Surface A - the public JSON API. Status + timestamps, no finding codes."""
+    status, body = _get(f"{API_BASE}/{owner}/{repo}/{skill}")
+    out = {"surface": "api", "http": status, "providers": {}, "error": None}
+    if status != 200:
+        out["error"] = body[:200]
+        return out
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError as exc:
+        out["error"] = f"unparseable: {exc}"
+        return out
+    for a in data.get("audits", []):
+        out["providers"][a.get("provider", "?")] = {
+            "slug": a.get("slug"),
+            "status": a.get("status"),
+            "risk": a.get("riskLevel"),
+            "auditedAt": a.get("auditedAt"),
+            "summary": a.get("summary", ""),
+        }
+    return out
+
+
+def fetch_cli_audit(owner: str, repo: str, skill: str) -> dict:
+    """Surface B - what `npx skills add` reads. A separate cache from the API.
+
+    This is the surface end users actually see, and it has lagged the API by
+    a full day, so a green API does not mean a green install.
+    """
+    url = f"{CLI_AUDIT}?source={owner}/{repo}&skills={skill}"
+    status, body = _get(url)
+    out = {"surface": "cli-endpoint", "http": status, "providers": {}, "error": None}
+    if status != 200:
+        out["error"] = body[:200]
+        return out
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError as exc:
+        out["error"] = f"unparseable: {exc}"
+        return out
+    for prov, rec in (data.get(skill) or {}).items():
+        if isinstance(rec, dict):
+            out["providers"][prov] = {
+                "risk": rec.get("risk"),
+                "alerts": rec.get("alerts"),
+                "auditedAt": rec.get("analyzedAt"),
+            }
+    return out
+
+
+def fetch_html_badges(owner: str, repo: str, skill: str) -> dict:
+    """Surface C - the rendered skill page. A third, independently cached layer."""
+    status, body = _get(f"{SITE_BASE}/{owner}/{repo}/{skill}")
+    out = {"surface": "html-page", "http": status, "badges": {}, "installs": None, "error": None}
+    if status != 200:
+        out["error"] = f"HTTP {status}"
+        return out
+    text = _page_text(body)
+    m = re.search(r"Security Audits (.*?)(?:Browse All|$)", text)
+    if m:
+        seg = m.group(1)
+        for prov in ("Gen Agent Trust Hub", "Socket", "Snyk"):
+            v = re.search(re.escape(prov) + r"\s+(Pass|Fail|Warn)", seg)
+            if v:
+                out["badges"][prov] = v.group(1)
+    inst = re.search(r"Installs\s+(\d+)", text)
+    if inst:
+        out["installs"] = int(inst.group(1))
+    return out
+
+
+def fetch_findings(owner: str, repo: str, skill: str, provider: str) -> dict:
+    """Surface D - per-provider detail page. The ONLY place finding codes live.
+
+    Without this the API tells you "CRITICAL - 2 issues" and nothing about what
+    those issues are, which is exactly the information needed to decide whether
+    a finding is real or points at deleted content.
+    """
+    status, body = _get(f"{SITE_BASE}/{owner}/{repo}/{skill}/security/{provider}")
+    out = {"provider": provider, "http": status, "codes": [], "cited_urls": [],
+           "analysis": "", "verdict": None, "error": None}
+    if status != 200:
+        out["error"] = f"HTTP {status}"
+        return out
+    text = _page_text(body)
+    m = re.search(r"Full Analysis (.*?)(?:Audit Metadata|Browse All|$)", text)
+    analysis = m.group(1).strip() if m else text
+    out["analysis"] = analysis[:4000]
+    out["codes"] = sorted(set(CODE_RE.findall(analysis)))
+    # URLs quoted inside finding prose are the literals the scanner objected to.
+    out["cited_urls"] = sorted({u.rstrip(".,);") for u in URL_RE.findall(analysis)
+                                if "skills.sh" not in u})
+    v = re.search(r"(Pass|Fail|Warn)\s+Audited by", text)
+    if v:
+        out["verdict"] = v.group(1)
+    return out
+
+
+# --------------------------------------------------------------------------
+# fresh install
+# --------------------------------------------------------------------------
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
+
+def fresh_install(owner: str, repo: str, timeout: int = 300) -> dict:
+    """Run a real install and capture the risk table the user actually sees.
+
+    Worth doing even though it never triggers a rescan: it is the only way to
+    confirm what the CLI prints, which is a different cache from the API.
+    """
+    out = {"ran": False, "ok": False, "table": [], "raw_tail": "", "error": None}
+    if shutil.which("npx") is None:
+        out["error"] = "npx not on PATH"
+        return out
+    tmp = tempfile.mkdtemp(prefix="registry-audit-")
+    try:
+        proc = subprocess.run(
+            ["npx", "-y", "skills@latest", "add", f"{owner}/{repo}", "--yes"],
+            cwd=tmp, capture_output=True, text=True, timeout=timeout,
+        )
+        out["ran"] = True
+        blob = ANSI_RE.sub("", (proc.stdout or "") + (proc.stderr or ""))
+        lines = [ln.rstrip() for ln in re.split(r"[\r\n]+", blob)]
+        grab, table = False, []
+        for ln in lines:
+            if "Security Risk Assessments" in ln:
+                grab = True
+                continue
+            if grab:
+                if ln.strip().startswith("+---"):
+                    break
+                if ln.strip().startswith("|"):
+                    body = ln.strip().strip("|").rstrip("|").rstrip()
+                    if body.strip():
+                        table.append(body.rstrip())
+        out["table"] = table
+        out["ok"] = proc.returncode == 0
+        out["raw_tail"] = "\n".join(lines[-15:])
+        out["install_dir"] = tmp
+        return out
+    except subprocess.TimeoutExpired:
+        out["error"] = f"install exceeded {timeout}s"
+        return out
+    except Exception as exc:
+        out["error"] = f"{type(exc).__name__}: {exc}"
+        return out
+
+
+# --------------------------------------------------------------------------
+# phantom-finding verification
+# --------------------------------------------------------------------------
+
+def verify_literals(literals: list[str], repo_root: Path | None,
+                    ref: str, install_dir: str | None) -> dict:
+    """Decide whether a cited literal still exists in the shipped content.
+
+    A finding whose quoted string is absent from both the git ref and the
+    freshly installed tree cannot be describing today's skill. That is the
+    single most useful signal this tool produces, because it separates "the
+    scanner is right and we must fix it" from "the scan input is stale".
+    """
+    results = {}
+    for lit in literals:
+        rec = {"in_git": None, "in_install": None}
+        if repo_root and (repo_root / ".git").exists():
+            p = subprocess.run(["git", "grep", "-I", "-l", "-F", lit, ref],
+                               cwd=repo_root, capture_output=True, text=True)
+            rec["in_git"] = bool(p.stdout.strip())
+        if install_dir and Path(install_dir).exists():
+            p = subprocess.run(["grep", "-rIlF", lit, install_dir],
+                               capture_output=True, text=True)
+            rec["in_install"] = bool(p.stdout.strip())
+        present = [v for v in (rec["in_git"], rec["in_install"]) if v is not None]
+        rec["phantom"] = bool(present) and not any(present)
+        results[lit] = rec
+    return results
+
+
+# --------------------------------------------------------------------------
+# reconciliation
+# --------------------------------------------------------------------------
+
+def newest(surface: dict, key: str = "providers") -> datetime | None:
+    stamps = [parse_iso(p.get("auditedAt", "")) for p in surface.get(key, {}).values()]
+    stamps = [s for s in stamps if s]
+    return max(stamps) if stamps else None
+
+
+def reconcile(api: dict, cli: dict, html: dict) -> list[str]:
+    """Surfaces disagreeing is itself a finding worth printing."""
+    notes = []
+    a, c = newest(api), newest(cli)
+    if a and c:
+        skew = abs((a - c).total_seconds())
+        if skew > 300:
+            notes.append(
+                f"CACHE SKEW: API newest {a:%Y-%m-%d %H:%M}Z vs install-path "
+                f"newest {c:%Y-%m-%d %H:%M}Z ({skew/3600:.1f}h apart) - end users "
+                f"see the install-path value.")
+    verdict_map = {"pass": "Pass", "fail": "Fail", "warn": "Warn"}
+    for prov, rec in api.get("providers", {}).items():
+        badge = html.get("badges", {}).get(prov)
+        want = verdict_map.get((rec.get("status") or "").lower())
+        if badge and want and badge != want:
+            notes.append(f"PAGE SKEW: {prov} - API says {want}, rendered page says {badge}.")
+    return notes
+
+
+# --------------------------------------------------------------------------
+# main
+# --------------------------------------------------------------------------
+
+def audit(owner: str, repo: str, skill: str, do_install: bool,
+          repo_root: Path | None, ref: str) -> dict:
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        f_api = pool.submit(fetch_api, owner, repo, skill)
+        f_cli = pool.submit(fetch_cli_audit, owner, repo, skill)
+        f_html = pool.submit(fetch_html_badges, owner, repo, skill)
+        f_find = {p: pool.submit(fetch_findings, owner, repo, skill, p)
+                  for p in PROVIDER_SLUGS}
+        f_inst = pool.submit(fresh_install, owner, repo) if do_install else None
+
+        api, cli, html = f_api.result(), f_cli.result(), f_html.result()
+        findings = {p: f.result() for p, f in f_find.items()}
+        install = f_inst.result() if f_inst else {"ran": False}
+
+    literals = sorted({u for f in findings.values() for u in f.get("cited_urls", [])})
+    checked = verify_literals(literals, repo_root, ref, install.get("install_dir"))
+
+    return {
+        "target": f"{owner}/{repo}/{skill}",
+        "checked_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "api": api, "cli": cli, "html": html,
+        "findings": findings, "install": install,
+        "literals": checked,
+        "skew": reconcile(api, cli, html),
+    }
+
+
+def render(r: dict) -> str:
+    L = []
+    L.append(f"# registry security - {r['target']}")
+    L.append(f"checked {r['checked_at']}")
+    L.append("")
+
+    L.append("## Provider status (JSON API)")
+    if r["api"].get("error"):
+        L.append(f"  ERROR: {r['api']['error']}")
+    for prov, p in r["api"].get("providers", {}).items():
+        L.append(f"  {prov:<22} {str(p['status']).upper():<5} "
+                 f"risk={p['risk'] or '-':<9} {p['auditedAt']}")
+        if p.get("summary"):
+            L.append(f"       {p['summary'][:100]}")
+    L.append("")
+
+    L.append("## Install-path cache (what `npx skills add` shows)")
+    if r["cli"].get("error"):
+        L.append(f"  ERROR: {r['cli']['error']}")
+    for prov, p in r["cli"].get("providers", {}).items():
+        L.append(f"  {prov:<22} risk={str(p['risk']):<9} {p['auditedAt']}")
+    L.append("")
+
+    if r["install"].get("ran"):
+        L.append("## Fresh install output (verbatim)")
+        for ln in r["install"]["table"]:
+            L.append(f"  {ln}")
+        if r["install"].get("error"):
+            L.append(f"  ERROR: {r['install']['error']}")
+        L.append("")
+    elif r["install"].get("error"):
+        L.append(f"## Fresh install: SKIPPED - {r['install']['error']}\n")
+
+    L.append("## Findings (from per-provider pages - not in the API)")
+    any_found = False
+    for prov, f in r["findings"].items():
+        if f.get("error") or not f.get("codes"):
+            continue
+        any_found = True
+        L.append(f"  {prov}: {f.get('verdict') or '?'} - {', '.join(f['codes'])}")
+        for u in f.get("cited_urls", []):
+            rec = r["literals"].get(u, {})
+            tag = "PHANTOM (absent from repo AND install)" if rec.get("phantom") else "present"
+            L.append(f"       cites {u}  ->  {tag}")
+    if not any_found:
+        L.append("  (no finding codes parsed)")
+    L.append("")
+
+    if r["skew"]:
+        L.append("## Surface disagreement")
+        for n in r["skew"]:
+            L.append(f"  ! {n}")
+        L.append("")
+
+    phantoms = [k for k, v in r["literals"].items() if v.get("phantom")]
+    L.append("## Verdict")
+    if phantoms:
+        L.append("  STALE INPUT - a finding cites content that exists in neither the")
+        L.append("  git ref nor the freshly installed tree:")
+        for p in phantoms:
+            L.append(f"    - {p}")
+        L.append("  Re-auditing the same snapshot will reproduce it. Ask for a")
+        L.append("  RE-INDEX (refresh the stored snapshot), not just a re-audit.")
+    else:
+        L.append("  No phantom literals detected. Findings that remain are most")
+        L.append("  likely describing content that is really there - fix or accept them.")
+    return "\n".join(L)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("target", help="owner/repo/skill (e.g. starslingdev/skills/ci-secure)")
+    ap.add_argument("--no-install", action="store_true",
+                    help="skip the npx install (~3s instead of ~40s)")
+    ap.add_argument("--repo-root", default=".", help="local checkout for literal verification")
+    ap.add_argument("--ref", default="origin/main", help="git ref to verify against")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args(argv)
+
+    parts = args.target.strip("/").split("/")
+    if len(parts) != 3:
+        print("target must be owner/repo/skill", file=sys.stderr)
+        return 2
+    owner, repo, skill = parts
+
+    root = Path(args.repo_root).resolve()
+    if not (root / ".git").exists():
+        root = None
+
+    result = audit(owner, repo, skill, not args.no_install, root, args.ref)
+    print(json.dumps(result, indent=2) if args.json else render(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/maintainers/skills-registry-security/scripts/registry_audit.py
+++ b/maintainers/skills-registry-security/scripts/registry_audit.py
@@ -264,9 +264,11 @@ def fresh_install(owner: str, repo: str, timeout: int = 300) -> dict:
         return out
     except subprocess.TimeoutExpired:
         out["error"] = f"install exceeded {timeout}s"
+        out["install_dir"] = tmp  # recorded so the caller can still clean it up
         return out
     except Exception as exc:
         out["error"] = f"{type(exc).__name__}: {exc}"
+        out["install_dir"] = tmp
         return out
 
 
@@ -274,10 +276,27 @@ def fresh_install(owner: str, repo: str, timeout: int = 300) -> dict:
 # phantom-finding verification
 # --------------------------------------------------------------------------
 
+def _installed_skill_dir(install_dir: str | None, skill: str | None) -> str | None:
+    """Narrow a repo-wide install to the one skill under audit.
+
+    `skills add owner/repo` installs EVERY skill in the repo, side by side under
+    `.agents/skills/<name>/`. Grepping the whole tree would let a literal that
+    only ever appeared in a sibling skill mark this skill's finding REAL — the
+    one misclassification that sends a maintainer to edit code that is already
+    clean. Falls back to the full tree only when the per-skill directory is
+    absent, since a wrong-but-narrow corpus beats no corpus.
+    """
+    if not install_dir or not skill:
+        return install_dir
+    scoped = Path(install_dir) / ".agents" / "skills" / skill
+    return str(scoped) if scoped.is_dir() else install_dir
+
+
 def verify_literals(literals: list[str], repo_root: Path | None, ref: str,
                     install_dir: str | None, snapshot: dict,
                     audited_at: "datetime | None" = None,
-                    snapshot_changed_at: "datetime | None" = None) -> dict:
+                    snapshot_changed_at: "datetime | None" = None,
+                    audited_at_by_literal: "dict | None" = None) -> dict:
     """Classify each cited literal by which corpora still contain it.
 
     Three corpora answer three different questions. The git ref and the
@@ -332,9 +351,14 @@ def verify_literals(literals: list[str], repo_root: Path | None, ref: str,
             # the scanner cached its own result, or the audit simply has not
             # read the current snapshot yet. Only the timestamps separate them,
             # and without both we decline to accuse the scanner.
-            if audited_at and snapshot_changed_at and audited_at < snapshot_changed_at:
+            # Only the providers that actually CITE this literal get a say. A
+            # provider citing nothing (Socket reporting "no alerts") carries an
+            # older stamp forever, and pooling it in would mask every phantom
+            # behind an unrelated scanner's lag.
+            stamp = (audited_at_by_literal or {}).get(lit, audited_at)
+            if stamp and snapshot_changed_at and stamp < snapshot_changed_at:
                 rec["verdict"] = "LAGGING"
-            elif audited_at and snapshot_changed_at:
+            elif stamp and snapshot_changed_at:
                 rec["verdict"] = "PHANTOM"
             else:
                 rec["verdict"] = "PHANTOM_OR_LAGGING"
@@ -400,14 +424,31 @@ def audit(owner: str, repo: str, skill: str, do_install: bool,
         install = f_inst.result() if f_inst else {"ran": False}
 
     literals = sorted({u for f in findings.values() for u in f.get("cited_urls", [])})
-    # The OLDEST provider stamp is the honest one here: a literal is only
-    # phantom if every scanner that cites it has read the current snapshot.
-    stamps = [s for s in (parse_iso(p.get("auditedAt", ""))
-                          for p in (api.get("providers") or {}).values()) if s]
+
+    # Attribute stamps per literal, not globally. A literal is only phantom
+    # once every scanner CITING IT has read the current snapshot, so take the
+    # oldest stamp among exactly those providers.
+    by_slug = {p.get("slug"): parse_iso(p.get("auditedAt", ""))
+               for p in (api.get("providers") or {}).values()}
+    per_literal = {}
+    for lit in literals:
+        citing = [by_slug.get(slug) for slug, f in findings.items()
+                  if lit in (f.get("cited_urls") or [])]
+        citing = [s for s in citing if s]
+        if citing:
+            per_literal[lit] = min(citing)
+
     checked = verify_literals(literals, repo_root, ref,
-                              install.get("install_dir"), snapshot,
-                              audited_at=min(stamps) if stamps else None,
-                              snapshot_changed_at=snapshot_changed_at)
+                              _installed_skill_dir(install.get("install_dir"), skill),
+                              snapshot,
+                              snapshot_changed_at=snapshot_changed_at,
+                              audited_at_by_literal=per_literal)
+
+    # The install has served its only purpose (the risk table plus the corpus
+    # above). Leaving it behind means every run of a "read-only" tool deposits
+    # a full skill tree in the system temp dir.
+    if install.get("install_dir"):
+        shutil.rmtree(install["install_dir"], ignore_errors=True)
 
     return {
         "target": f"{owner}/{repo}/{skill}",

--- a/maintainers/skills-registry-security/scripts/registry_audit.py
+++ b/maintainers/skills-registry-security/scripts/registry_audit.py
@@ -566,11 +566,13 @@ def decide(result: dict, precond: dict | None = None) -> dict:
                       re-index issue on vercel-labs/skills as an OPTIONAL long-shot
                       to DRAFT for the owner, never an auto-action or "the fix."
       DISAGREEMENT    the cached surfaces disagree — re-check before trusting.
-      UNVERIFIED      a surface could not be read, or the cited literals could
-                      not be classified. Never confuse this with RESOLVED: a
-                      surface nobody fetched is not a surface that came back
-                      clean, and reporting one as the other stops the watch on
-                      an unread badge.
+      UNVERIFIED      a surface could not be read, the API carries no audit
+                      records at all, or the cited literals could not be
+                      classified. Never confuse this with RESOLVED: a surface
+                      nobody fetched is not a surface that came back clean, and
+                      a skill nobody scanned is not a skill that passed —
+                      reporting either as green stops the watch on an unread
+                      badge.
     """
     api = result.get("api") or {}
     providers = api.get("providers") or {}
@@ -590,6 +592,16 @@ def decide(result: dict, precond: dict | None = None) -> dict:
                         "the provider status API was unreachable "
                         f"(HTTP {api.get('http')}: {api.get('error')}) - cannot "
                         "tell a clean badge from an unread one",
+                        [], [], [], precond)
+    # The same shape one layer in: a 200 carrying an empty `audits` list means
+    # nobody has scanned this skill, which is NOT every provider passing. It is
+    # the normal state of a just-published skill - exactly when this gets run -
+    # and calling it RESOLVED stops the watch before the first scan ever lands.
+    if not providers:
+        return _decided("UNVERIFIED",
+                        "the status API returned no audit records for this skill - "
+                        "no provider has scanned it yet, which is not the same as "
+                        "every provider passing; keep watching until one reports",
                         [], [], [], precond)
     verdicts = {lit: rec.get("verdict")
                 for lit, rec in (result.get("literals") or {}).items()}

--- a/maintainers/skills-registry-security/tests/test_registry_audit.py
+++ b/maintainers/skills-registry-security/tests/test_registry_audit.py
@@ -131,6 +131,18 @@ def test_page_text_flattens_markup():
     assert "Full Analysis E005" in txt
 
 
+def test_page_text_strips_upper_case_script_and_style_tags():
+    """Tag names are case-insensitive, and a surviving script body gets scanned.
+
+    A page whose own JavaScript mentions a finding code would otherwise have
+    that code scraped as if a scanner had reported it.
+    """
+    txt = ra._page_text("<SCRIPT>var code='E005'</SCRIPT><STYLE>a{}</STYLE>Warn")
+    assert "E005" not in txt
+    assert "a{}" not in txt
+    assert "Warn" in txt
+
+
 # --------------------------------------------------------------------------
 # the phantom decision - the whole point of the tool
 # --------------------------------------------------------------------------

--- a/maintainers/skills-registry-security/tests/test_registry_audit.py
+++ b/maintainers/skills-registry-security/tests/test_registry_audit.py
@@ -494,6 +494,15 @@ def test_decide_unverified_when_provider_api_unreachable():
     assert "unreachable" in d["why"]
 
 
+def test_decide_unverified_when_the_api_carries_no_audit_records():
+    """A 200 with an empty `audits` list is an UNSCANNED skill, not a passing
+    one. It is the normal state of a just-published skill - the moment this gets
+    run - and RESOLVED would stop the watch before the first scan ever landed."""
+    d = ra.decide(_result({}))
+    assert d["decision"] == "UNVERIFIED"
+    assert "no audit records" in d["why"]
+
+
 def test_decide_unreachable_api_still_reports_beacon():
     r = _result({}, api={"http": 500, "error": "boom"})
     d = ra.decide(r, precond={"ok": True, "github_http": 200})

--- a/maintainers/skills-registry-security/tests/test_registry_audit.py
+++ b/maintainers/skills-registry-security/tests/test_registry_audit.py
@@ -143,15 +143,27 @@ def test_page_text_strips_upper_case_script_and_style_tags():
     assert "Warn" in txt
 
 
-def test_page_text_strips_scripts_with_attributes_and_spaced_end_tags():
-    """`<script type=...>` and `</script >` are both legal and both must go."""
-    txt = ra._page_text(
-        "<script type='text/javascript'>var c='E005'</script >"
-        "<style media='all'>b{}</style >Fail"
-    )
+@pytest.mark.parametrize("end", ["</script>", "</script >", "</script\t\n bar>"])
+def test_page_text_strips_every_legal_script_end_tag_form(end):
+    """End tags may carry whitespace and ignored attributes; all are legal.
+
+    Three regexes each missed one of these in turn, which is why this is now
+    parsed rather than pattern-matched.
+    """
+    txt = ra._page_text(f"<script type='text/javascript'>var c='E005'{end}Fail")
     assert "E005" not in txt
-    assert "b{}" not in txt
     assert "Fail" in txt
+
+
+def test_page_text_strips_style_bodies_too():
+    txt = ra._page_text("<style media='all'>b{color:red}</style >Warn")
+    assert "color:red" not in txt
+    assert "Warn" in txt
+
+
+def test_page_text_survives_malformed_markup():
+    """A diagnostic tool must not crash on a half-broken page."""
+    assert "Analysis" in ra._page_text("<div><span>Analysis<script>x=1")
 
 
 # --------------------------------------------------------------------------
@@ -343,3 +355,27 @@ def test_help_names_the_no_install_fast_path():
                        capture_output=True, text=True)
     assert p.returncode == 0
     assert "--no-install" in p.stdout
+
+
+def test_temp_install_is_removed_even_when_verification_raises(tmp_path, monkeypatch):
+    """Cleanup lives in a finally: git/grep can be missing, and the leak would
+    then accumulate fastest on exactly the repeated-failure path."""
+    inst = tmp_path / "inst"
+    (inst / ".agents" / "skills" / "ci-secure").mkdir(parents=True)
+
+    monkeypatch.setattr(ra, "fetch_api", lambda *a: {"providers": {}})
+    monkeypatch.setattr(ra, "fetch_cli_audit", lambda *a: {"providers": {}})
+    monkeypatch.setattr(ra, "fetch_html_badges", lambda *a: {"badges": {}})
+    monkeypatch.setattr(ra, "fetch_snapshot", lambda *a: {"files": {}})
+    monkeypatch.setattr(ra, "fetch_findings",
+                        lambda *a: {"codes": ["E005"], "cited_urls": [GONE_URL]})
+    monkeypatch.setattr(ra, "fresh_install",
+                        lambda *a, **k: {"ran": True, "install_dir": str(inst)})
+
+    def boom(*a, **k):
+        raise FileNotFoundError("grep")
+    monkeypatch.setattr(ra, "verify_literals", boom)
+
+    with pytest.raises(FileNotFoundError):
+        ra.audit("o", "r", "ci-secure", True, None, "HEAD")
+    assert not inst.exists(), "temp install survived a raising verification"

--- a/maintainers/skills-registry-security/tests/test_registry_audit.py
+++ b/maintainers/skills-registry-security/tests/test_registry_audit.py
@@ -383,30 +383,46 @@ def test_temp_install_is_removed_even_when_verification_raises(tmp_path, monkeyp
 
 # --- the operator layer: beacon precondition + next-action decision ----------
 
-def _result(providers, literals=None, skew=None):
-    return {"api": {"providers": providers}, "literals": literals or {},
-            "skew": skew or []}
+def _result(providers, literals=None, skew=None, findings=None, api=None):
+    """Fixtures use the shape `fetch_api` really emits - risk under "risk",
+    and an http/error pair - so a key drift fails here instead of shipping."""
+    base = {"http": 200, "error": None, "providers": providers}
+    base.update(api or {})
+    return {"api": base, "literals": literals or {}, "skew": skew or [],
+            "findings": findings or {}}
 
 
 def test_decide_resolved_when_all_pass_and_no_finding():
-    r = _result({"snyk": {"status": "pass", "riskLevel": "SAFE"},
-                 "socket": {"status": "pass", "riskLevel": "LOW"}})
+    r = _result({"snyk": {"status": "pass", "risk": "SAFE"},
+                 "socket": {"status": "pass", "risk": "LOW"}})
     assert ra.decide(r)["decision"] == "RESOLVED"
 
 
 def test_decide_action_required_when_a_literal_is_real():
-    r = _result({"snyk": {"status": "fail", "riskLevel": "CRITICAL"}},
+    r = _result({"snyk": {"status": "fail", "risk": "CRITICAL"}},
                 literals={"http://ex/pkg": {"verdict": "REAL"}})
     d = ra.decide(r)
     assert d["decision"] == "ACTION_REQUIRED"
     assert d["real_literals"] == ["http://ex/pkg"]
 
 
+def test_decide_action_required_wins_over_stale_in_mixed_set():
+    """One live literal among stale ones is still a real finding. Calling that
+    MONITOR would tell the operator there is nothing to fix."""
+    r = _result({"snyk": {"status": "fail", "risk": "CRITICAL"}},
+                literals={"http://ex/live": {"verdict": "REAL"},
+                          "http://ex/old": {"verdict": "STALE_INPUT"}})
+    d = ra.decide(r)
+    assert d["decision"] == "ACTION_REQUIRED"
+    assert d["real_literals"] == ["http://ex/live"]
+    assert d["stale_literals"] == ["http://ex/old"]
+
+
 def test_decide_monitor_when_failing_literal_is_gone_from_head():
     """The common case: provider still CRITICAL but the cited string is stale —
     nothing to fix, wait for the registry's own re-audit. Must NOT be
     ACTION_REQUIRED."""
-    r = _result({"snyk": {"status": "fail", "riskLevel": "CRITICAL"}},
+    r = _result({"snyk": {"status": "fail", "risk": "CRITICAL"}},
                 literals={"http://ex/pkg": {"verdict": "STALE_INPUT"}})
     d = ra.decide(r)
     assert d["decision"] == "MONITOR"
@@ -419,17 +435,83 @@ def test_decide_disagreement_when_surfaces_skew():
 
 
 def test_decide_monitor_warns_when_beacon_suppressed():
-    r = _result({"snyk": {"status": "fail", "riskLevel": "CRITICAL"}},
+    r = _result({"snyk": {"status": "fail", "risk": "CRITICAL"}},
                 literals={"http://x": {"verdict": "PHANTOM"}})
     d = ra.decide(r, precond={"ok": False, "github_http": 403})
     assert d["decision"] == "MONITOR"
     assert "do NOT loop installs" in d["note"]
 
 
+def test_decide_monitor_omits_note_when_beacon_can_fire():
+    """The suppression warning must not fire when an install WOULD work - that
+    would tell the operator to stop nudging exactly when nudging helps."""
+    r = _result({"snyk": {"status": "fail", "risk": "CRITICAL"}},
+                literals={"http://x": {"verdict": "PHANTOM"}})
+    d = ra.decide(r, precond={"ok": True, "github_http": 200})
+    assert d["decision"] == "MONITOR"
+    assert "note" not in d
+    assert d["beacon"]["ok"] is True
+
+
 def test_decide_high_risk_counts_as_failing_even_if_status_blank():
-    r = _result({"gen": {"status": "", "riskLevel": "HIGH"}},
+    r = _result({"gen": {"status": "", "risk": "HIGH"}},
                 literals={"http://x": {"verdict": "LAGGING"}})
     assert ra.decide(r)["decision"] == "MONITOR"
+
+
+def test_decide_unverified_when_literals_present_but_unclassifiable():
+    r = _result({"snyk": {"status": "fail", "risk": "CRITICAL"}},
+                literals={"http://x": {"verdict": None}})
+    d = ra.decide(r)
+    assert d["decision"] == "UNVERIFIED"
+    assert d["providers_failing"] == ["snyk"]
+
+
+def test_decide_monitor_when_detail_page_loaded_but_cited_nothing():
+    r = _result({"snyk": {"status": "fail", "risk": "CRITICAL"}},
+                findings={"snyk": {"http": 200, "error": None, "codes": []}})
+    d = ra.decide(r)
+    assert d["decision"] == "MONITOR"
+    assert d["real_literals"] == []
+
+
+def test_decide_unverified_when_finding_detail_page_unreachable():
+    """A failing provider whose detail page we could not read is zero
+    information, not a benign 'nothing to fix'."""
+    r = _result({"snyk": {"status": "fail", "risk": "CRITICAL"}},
+                findings={"snyk": {"http": 503, "error": "HTTP 503"}})
+    d = ra.decide(r)
+    assert d["decision"] == "UNVERIFIED"
+    assert "unreachable" in d["why"]
+
+
+def test_decide_unverified_when_provider_api_unreachable():
+    """An unread surface must never be reported as a clean badge - that would
+    stop the watch on a status nobody actually fetched."""
+    r = _result({}, api={"http": 0, "error": "__ERROR__ dns failure"})
+    d = ra.decide(r)
+    assert d["decision"] == "UNVERIFIED"
+    assert "unreachable" in d["why"]
+
+
+def test_decide_unreachable_api_still_reports_beacon():
+    r = _result({}, api={"http": 500, "error": "boom"})
+    d = ra.decide(r, precond={"ok": True, "github_http": 200})
+    assert d["decision"] == "UNVERIFIED"
+    assert d["beacon"]["github_http"] == 200
+
+
+def test_render_shows_next_action_and_beacon_state():
+    """The operator surface: the verdict has to actually reach the report."""
+    r = _result({"snyk": {"status": "fail", "risk": "CRITICAL",
+                          "auditedAt": "2026-08-13T00:01:00Z", "summary": ""}},
+                literals={"http://x": {"verdict": "PHANTOM"}})
+    r.update({"target": "o/r/s", "checked_at": "2026-08-13T00:00:00Z",
+              "cli": {"providers": {}}, "install": {}, "snapshot": {}})
+    r["decision"] = ra.decide(r, precond={"ok": False, "github_http": 403})
+    out = ra.render(r)
+    assert "NEXT ACTION: MONITOR" in out
+    assert "install beacon: SUPPRESSED" in out
 
 
 def test_beacon_suppressed_by_telemetry_env(monkeypatch):

--- a/maintainers/skills-registry-security/tests/test_registry_audit.py
+++ b/maintainers/skills-registry-security/tests/test_registry_audit.py
@@ -396,10 +396,10 @@ def test_decide_resolved_when_all_pass_and_no_finding():
 
 def test_decide_action_required_when_a_literal_is_real():
     r = _result({"snyk": {"status": "fail", "riskLevel": "CRITICAL"}},
-                literals={"http://x/install.sh": {"verdict": "REAL"}})
+                literals={"http://ex/pkg": {"verdict": "REAL"}})
     d = ra.decide(r)
     assert d["decision"] == "ACTION_REQUIRED"
-    assert d["real_literals"] == ["http://x/install.sh"]
+    assert d["real_literals"] == ["http://ex/pkg"]
 
 
 def test_decide_monitor_when_failing_literal_is_gone_from_head():
@@ -407,7 +407,7 @@ def test_decide_monitor_when_failing_literal_is_gone_from_head():
     nothing to fix, wait for the registry's own re-audit. Must NOT be
     ACTION_REQUIRED."""
     r = _result({"snyk": {"status": "fail", "riskLevel": "CRITICAL"}},
-                literals={"http://x/install.sh": {"verdict": "STALE_INPUT"}})
+                literals={"http://ex/pkg": {"verdict": "STALE_INPUT"}})
     d = ra.decide(r)
     assert d["decision"] == "MONITOR"
     assert "re-audit" in d["why"]

--- a/maintainers/skills-registry-security/tests/test_registry_audit.py
+++ b/maintainers/skills-registry-security/tests/test_registry_audit.py
@@ -8,7 +8,7 @@ integration use.
 
 import subprocess
 import sys
-from datetime import timezone
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -163,9 +163,34 @@ def test_literal_gone_from_repo_but_still_in_snapshot_is_stale_input(tree):
     assert rec["snapshot_paths"] == ["references/patterns.md"]
 
 
-def test_literal_gone_everywhere_including_snapshot_is_phantom(tree):
-    snap = {"hash": "x", "files": {"SKILL.md": "clean\n"}}
-    out = ra.verify_literals([GONE_URL], None, "HEAD", str(tree), snap)
+CLEAN_SNAP = {"hash": "x", "files": {"SKILL.md": "clean\n"}}
+BEFORE = datetime(2026, 8, 11, 19, 44, tzinfo=timezone.utc)
+REINDEX = datetime(2026, 8, 12, 2, 0, tzinfo=timezone.utc)
+AFTER = datetime(2026, 8, 13, 0, 1, tzinfo=timezone.utc)
+
+
+def test_gone_everywhere_is_ambiguous_without_the_reindex_time(tree):
+    """Absent-everywhere alone cannot distinguish the two causes.
+
+    Accusing the scanner of caching when the audit simply has not re-run yet
+    sends a maintainer to escalate a finding that clears itself within a day.
+    Refusing to pick is the honest answer when the timestamps are missing.
+    """
+    out = ra.verify_literals([GONE_URL], None, "HEAD", str(tree), CLEAN_SNAP)
+    assert out[GONE_URL]["verdict"] == "PHANTOM_OR_LAGGING"
+
+
+def test_audit_older_than_the_snapshot_is_lagging_not_phantom(tree):
+    """The real case this split exists for: fix landed, badge has not caught up."""
+    out = ra.verify_literals([GONE_URL], None, "HEAD", str(tree), CLEAN_SNAP,
+                             audited_at=BEFORE, snapshot_changed_at=REINDEX)
+    assert out[GONE_URL]["verdict"] == "LAGGING"
+
+
+def test_audit_newer_than_the_snapshot_is_a_real_phantom(tree):
+    """Only once a scanner has read the current snapshot is its cache to blame."""
+    out = ra.verify_literals([GONE_URL], None, "HEAD", str(tree), CLEAN_SNAP,
+                             audited_at=AFTER, snapshot_changed_at=REINDEX)
     assert out[GONE_URL]["verdict"] == "PHANTOM"
 
 

--- a/maintainers/skills-registry-security/tests/test_registry_audit.py
+++ b/maintainers/skills-registry-security/tests/test_registry_audit.py
@@ -379,3 +379,78 @@ def test_temp_install_is_removed_even_when_verification_raises(tmp_path, monkeyp
     with pytest.raises(FileNotFoundError):
         ra.audit("o", "r", "ci-secure", True, None, "HEAD")
     assert not inst.exists(), "temp install survived a raising verification"
+
+
+# --- the operator layer: beacon precondition + next-action decision ----------
+
+def _result(providers, literals=None, skew=None):
+    return {"api": {"providers": providers}, "literals": literals or {},
+            "skew": skew or []}
+
+
+def test_decide_resolved_when_all_pass_and_no_finding():
+    r = _result({"snyk": {"status": "pass", "riskLevel": "SAFE"},
+                 "socket": {"status": "pass", "riskLevel": "LOW"}})
+    assert ra.decide(r)["decision"] == "RESOLVED"
+
+
+def test_decide_action_required_when_a_literal_is_real():
+    r = _result({"snyk": {"status": "fail", "riskLevel": "CRITICAL"}},
+                literals={"http://x/install.sh": {"verdict": "REAL"}})
+    d = ra.decide(r)
+    assert d["decision"] == "ACTION_REQUIRED"
+    assert d["real_literals"] == ["http://x/install.sh"]
+
+
+def test_decide_monitor_when_failing_literal_is_gone_from_head():
+    """The common case: provider still CRITICAL but the cited string is stale —
+    nothing to fix, wait for the registry's own re-audit. Must NOT be
+    ACTION_REQUIRED."""
+    r = _result({"snyk": {"status": "fail", "riskLevel": "CRITICAL"}},
+                literals={"http://x/install.sh": {"verdict": "STALE_INPUT"}})
+    d = ra.decide(r)
+    assert d["decision"] == "MONITOR"
+    assert "re-audit" in d["why"]
+
+
+def test_decide_disagreement_when_surfaces_skew():
+    r = _result({"snyk": {"status": "pass"}}, skew=["api SAFE vs badge CRITICAL"])
+    assert ra.decide(r)["decision"] == "DISAGREEMENT"
+
+
+def test_decide_monitor_warns_when_beacon_suppressed():
+    r = _result({"snyk": {"status": "fail", "riskLevel": "CRITICAL"}},
+                literals={"http://x": {"verdict": "PHANTOM"}})
+    d = ra.decide(r, precond={"ok": False, "github_http": 403})
+    assert d["decision"] == "MONITOR"
+    assert "do NOT loop installs" in d["note"]
+
+
+def test_decide_high_risk_counts_as_failing_even_if_status_blank():
+    r = _result({"gen": {"status": "", "riskLevel": "HIGH"}},
+                literals={"http://x": {"verdict": "LAGGING"}})
+    assert ra.decide(r)["decision"] == "MONITOR"
+
+
+def test_beacon_suppressed_by_telemetry_env(monkeypatch):
+    monkeypatch.setattr(ra, "_get", lambda url: (200, ""))
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    b = ra.beacon_precondition("o", "r")
+    assert b["ok"] is False and "DO_NOT_TRACK" in b["telemetry_disabled_by"]
+
+
+def test_beacon_suppressed_by_github_403(monkeypatch):
+    monkeypatch.setattr(ra, "_get", lambda url: (403, ""))
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.delenv("DISABLE_TELEMETRY", raising=False)
+    b = ra.beacon_precondition("o", "r")
+    assert b["ok"] is False and b["github_http"] == 403
+    assert "suppressed" in b["reason"]
+
+
+def test_beacon_can_fire_when_200_and_no_env(monkeypatch):
+    monkeypatch.setattr(ra, "_get", lambda url: (200, ""))
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.delenv("DISABLE_TELEMETRY", raising=False)
+    b = ra.beacon_precondition("o", "r")
+    assert b["ok"] is True and "will enqueue a re-index" in b["reason"]

--- a/maintainers/skills-registry-security/tests/test_registry_audit.py
+++ b/maintainers/skills-registry-security/tests/test_registry_audit.py
@@ -143,6 +143,17 @@ def test_page_text_strips_upper_case_script_and_style_tags():
     assert "Warn" in txt
 
 
+def test_page_text_strips_scripts_with_attributes_and_spaced_end_tags():
+    """`<script type=...>` and `</script >` are both legal and both must go."""
+    txt = ra._page_text(
+        "<script type='text/javascript'>var c='E005'</script >"
+        "<style media='all'>b{}</style >Fail"
+    )
+    assert "E005" not in txt
+    assert "b{}" not in txt
+    assert "Fail" in txt
+
+
 # --------------------------------------------------------------------------
 # the phantom decision - the whole point of the tool
 # --------------------------------------------------------------------------
@@ -233,12 +244,27 @@ def test_install_corpus_narrows_to_the_audited_skill(tmp_path):
     assert ra._installed_skill_dir(str(root), "ci-secure").endswith("skills/ci-secure")
 
 
-def test_install_corpus_falls_back_to_the_whole_tree_when_layout_differs(tmp_path):
-    """A narrow corpus is better than none, but a missing one must not crash."""
+def test_install_corpus_is_dropped_rather_than_widened_to_siblings(tmp_path):
+    """An unrecognised layout must yield NO corpus, not the whole repo tree.
+
+    Falling back to the full install would let a sibling's literal produce a
+    confident `REAL` — worse than the honest "could not check", because it
+    sends a maintainer to edit a skill that is already clean.
+    """
     root = tmp_path / "inst"
     root.mkdir()
-    assert ra._installed_skill_dir(str(root), "ci-secure") == str(root)
+    assert ra._installed_skill_dir(str(root), "ci-secure") is None
     assert ra._installed_skill_dir(None, "ci-secure") is None
+
+
+def test_dropped_install_corpus_does_not_fabricate_a_real_verdict(tmp_path):
+    """With no install corpus and no git ref, the answer is UNVERIFIED."""
+    root = tmp_path / "inst"
+    (root / ".agents" / "skills" / "ci-speedup").mkdir(parents=True)
+    (root / ".agents" / "skills" / "ci-speedup" / "S.md").write_text(GONE_URL)
+    scoped = ra._installed_skill_dir(str(root), "ci-secure")
+    out = ra.verify_literals([GONE_URL], None, "HEAD", scoped, {"files": {}})
+    assert out[GONE_URL]["verdict"] == "UNVERIFIED"
 
 
 def test_sibling_only_literal_is_not_real_for_the_audited_skill(tmp_path):

--- a/maintainers/skills-registry-security/tests/test_registry_audit.py
+++ b/maintainers/skills-registry-security/tests/test_registry_audit.py
@@ -1,0 +1,201 @@
+"""Offline tests for the registry audit engine.
+
+Everything here runs without network access: the parsing helpers and the
+phantom-literal decision are the parts that carry the reasoning, so they are
+the parts worth pinning. The fetchers are thin urllib wrappers and are left to
+integration use.
+"""
+
+import subprocess
+import sys
+from datetime import timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import registry_audit as ra  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# timestamp parsing - the registry mixes two formats on one payload
+# --------------------------------------------------------------------------
+
+def test_parse_iso_accepts_zulu_and_offset_forms():
+    z = ra.parse_iso("2026-08-11T19:44:35.075Z")
+    o = ra.parse_iso("2026-08-11T19:44:42.614421+00:00")
+    assert z is not None and o is not None
+    assert z.tzinfo == timezone.utc and o.tzinfo == timezone.utc
+    assert o > z
+
+
+def test_parse_iso_returns_none_on_junk():
+    assert ra.parse_iso("") is None
+    assert ra.parse_iso("not-a-date") is None
+
+
+# --------------------------------------------------------------------------
+# install output parsing - the CLI emits ANSI and spinner redraws
+# --------------------------------------------------------------------------
+
+RAW_INSTALL = (
+    "o  Installation Summary ---+\n"
+    "|  ./.agents/skills/x     |\n"
+    "+-------------------------+\n"
+    "o  Security Risk Assessments -----------------+\n"
+    "|                                             |\n"
+    "|              Gen        Socket      Snyk    |\n"
+    "|  ci-secure   Safe       0 alerts    Critical Risk |\n"
+    "|                                             |\n"
+    "|  Details: https://skills.sh/o/r             |\n"
+    "+---------------------------------------------+\n"
+    "\x1b[1G\x1b[J\x1b[32mo\x1b[0m  Installation complete\n"
+)
+
+
+def _extract(raw):
+    """Mirror fresh_install's table extraction over a canned buffer."""
+    import re
+    blob = ra.ANSI_RE.sub("", raw)
+    lines = [ln.rstrip() for ln in re.split(r"[\r\n]+", blob)]
+    grab, table = False, []
+    for ln in lines:
+        if "Security Risk Assessments" in ln:
+            grab = True
+            continue
+        if grab:
+            if ln.strip().startswith("+---"):
+                break
+            if ln.strip().startswith("|"):
+                body = ln.strip().strip("|").rstrip("|").rstrip()
+                if body.strip():
+                    table.append(body.rstrip())
+    return table
+
+
+def test_install_table_extraction_keeps_only_the_risk_block():
+    table = _extract(RAW_INSTALL)
+    joined = "\n".join(table)
+    assert "ci-secure" in joined
+    assert "Critical Risk" in joined
+    # the earlier Installation Summary box must not bleed in
+    assert ".agents/skills" not in joined
+
+
+def test_install_table_extraction_stops_at_the_box_edge():
+    table = _extract(RAW_INSTALL)
+    assert not any("Installation complete" in ln for ln in table)
+
+
+def test_ansi_stripping_removes_cursor_redraws():
+    assert "\x1b" not in ra.ANSI_RE.sub("", RAW_INSTALL)
+    assert "[1G" not in ra.ANSI_RE.sub("", RAW_INSTALL)
+
+
+# --------------------------------------------------------------------------
+# finding parsing
+# --------------------------------------------------------------------------
+
+ANALYSIS = (
+    "CRITICAL E005: Suspicious download URL detected in skill instructions. "
+    "This set contains a direct download/install script "
+    "( https://get.example.com/install.sh ) hosted on a non-official host. "
+    "MEDIUM W011: Third-party content exposure detected."
+)
+
+
+def test_code_regex_finds_both_classes():
+    assert sorted(set(ra.CODE_RE.findall(ANALYSIS))) == ["E005", "W011"]
+
+
+def test_url_regex_extracts_the_quoted_literal():
+    urls = {u.rstrip(".,);") for u in ra.URL_RE.findall(ANALYSIS)}
+    assert "https://get.example.com/install.sh" in urls
+
+
+def test_page_text_flattens_markup():
+    txt = ra._page_text("<div><script>x=1</script><b>Full</b> Analysis  E005</div>")
+    assert "x=1" not in txt
+    assert "Full Analysis E005" in txt
+
+
+# --------------------------------------------------------------------------
+# the phantom decision - the whole point of the tool
+# --------------------------------------------------------------------------
+
+@pytest.fixture()
+def tree(tmp_path):
+    d = tmp_path / "installed"
+    d.mkdir()
+    (d / "SKILL.md").write_text("uses https://real.example/live.sh in a sample\n")
+    return d
+
+
+def test_literal_present_in_install_is_not_phantom(tree):
+    out = ra.verify_literals(["https://real.example/live.sh"], None, "HEAD", str(tree))
+    assert out["https://real.example/live.sh"]["phantom"] is False
+
+
+def test_literal_absent_everywhere_is_phantom(tree):
+    out = ra.verify_literals(["https://gone.example/install.sh"], None, "HEAD", str(tree))
+    assert out["https://gone.example/install.sh"]["phantom"] is True
+
+
+def test_phantom_needs_at_least_one_corpus():
+    """With nothing to check against, refuse to claim phantom.
+
+    Reporting 'phantom' from zero evidence would be worse than reporting
+    nothing - it would send a maintainer to argue a case they cannot support.
+    """
+    out = ra.verify_literals(["https://x.example/i.sh"], None, "HEAD", None)
+    assert out["https://x.example/i.sh"]["phantom"] is False
+
+
+# --------------------------------------------------------------------------
+# surface reconciliation
+# --------------------------------------------------------------------------
+
+def _surface(ts):
+    return {"providers": {"Snyk": {"auditedAt": ts, "status": "fail"}}}
+
+
+def test_reconcile_flags_day_long_cache_skew():
+    api = _surface("2026-08-11T19:44:42Z")
+    cli = _surface("2026-08-10T17:54:47Z")
+    notes = ra.reconcile(api, cli, {"badges": {}})
+    assert any("CACHE SKEW" in n for n in notes)
+
+
+def test_reconcile_is_quiet_when_surfaces_agree():
+    api = _surface("2026-08-11T19:44:42Z")
+    cli = _surface("2026-08-11T19:44:50Z")
+    assert ra.reconcile(api, cli, {"badges": {}}) == []
+
+
+def test_reconcile_flags_rendered_page_disagreement():
+    api = _surface("2026-08-11T19:44:42Z")
+    notes = ra.reconcile(api, _surface("2026-08-11T19:44:45Z"),
+                         {"badges": {"Snyk": "Pass"}})
+    assert any("PAGE SKEW" in n for n in notes)
+
+
+# --------------------------------------------------------------------------
+# cli contract
+# --------------------------------------------------------------------------
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "registry_audit.py"
+
+
+def test_rejects_a_target_that_is_not_owner_repo_skill():
+    p = subprocess.run([sys.executable, str(SCRIPT), "owner/repo"],
+                       capture_output=True, text=True)
+    assert p.returncode == 2
+    assert "owner/repo/skill" in p.stderr
+
+
+def test_help_names_the_no_install_fast_path():
+    p = subprocess.run([sys.executable, str(SCRIPT), "--help"],
+                       capture_output=True, text=True)
+    assert p.returncode == 0
+    assert "--no-install" in p.stdout

--- a/maintainers/skills-registry-security/tests/test_registry_audit.py
+++ b/maintainers/skills-registry-security/tests/test_registry_audit.py
@@ -206,6 +206,54 @@ def test_audit_newer_than_the_snapshot_is_a_real_phantom(tree):
     assert out[GONE_URL]["verdict"] == "PHANTOM"
 
 
+def test_only_citing_providers_stamps_decide_phantom_versus_lagging(tree):
+    """An unrelated provider's older stamp must not mask a genuine phantom.
+
+    Socket reports "no alerts" and cites nothing, so its stamp can sit behind
+    the re-index indefinitely. Pooling it with Snyk's would report every real
+    phantom as merely lagging, and tell a maintainer not to escalate.
+    """
+    out = ra.verify_literals([GONE_URL], None, "HEAD", str(tree), CLEAN_SNAP,
+                             audited_at=BEFORE,  # the stale global pool
+                             snapshot_changed_at=REINDEX,
+                             audited_at_by_literal={GONE_URL: AFTER})
+    assert out[GONE_URL]["verdict"] == "PHANTOM"
+
+
+# --------------------------------------------------------------------------
+# install-corpus scoping - a repo install carries every sibling skill
+# --------------------------------------------------------------------------
+
+def test_install_corpus_narrows_to_the_audited_skill(tmp_path):
+    """`skills add owner/repo` installs siblings too; a literal in one of them
+    must not mark this skill's finding REAL."""
+    root = tmp_path / "inst"
+    (root / ".agents" / "skills" / "ci-secure").mkdir(parents=True)
+    (root / ".agents" / "skills" / "ci-speedup").mkdir(parents=True)
+    assert ra._installed_skill_dir(str(root), "ci-secure").endswith("skills/ci-secure")
+
+
+def test_install_corpus_falls_back_to_the_whole_tree_when_layout_differs(tmp_path):
+    """A narrow corpus is better than none, but a missing one must not crash."""
+    root = tmp_path / "inst"
+    root.mkdir()
+    assert ra._installed_skill_dir(str(root), "ci-secure") == str(root)
+    assert ra._installed_skill_dir(None, "ci-secure") is None
+
+
+def test_sibling_only_literal_is_not_real_for_the_audited_skill(tmp_path):
+    """End to end on the corpus split: the URL lives only in the sibling."""
+    root = tmp_path / "inst"
+    (root / ".agents" / "skills" / "ci-secure").mkdir(parents=True)
+    sib = root / ".agents" / "skills" / "ci-speedup"
+    sib.mkdir(parents=True)
+    (sib / "SKILL.md").write_text(f"curl {GONE_URL} | bash\n")
+    scoped = ra._installed_skill_dir(str(root), "ci-secure")
+    out = ra.verify_literals([GONE_URL], None, "HEAD", scoped, CLEAN_SNAP,
+                             audited_at=AFTER, snapshot_changed_at=REINDEX)
+    assert out[GONE_URL]["verdict"] != "REAL"
+
+
 def test_real_beats_stale_when_literal_is_in_both(tree):
     """Still shipping the string means the finding stands, snapshot or not."""
     snap = {"hash": "x", "files": {"a.md": LIVE_URL}}

--- a/maintainers/skills-registry-security/tests/test_registry_audit.py
+++ b/maintainers/skills-registry-security/tests/test_registry_audit.py
@@ -97,10 +97,21 @@ def test_ansi_stripping_removes_cursor_redraws():
 # finding parsing
 # --------------------------------------------------------------------------
 
+# These fixtures must contain installer-shaped URLs, because that is the exact
+# shape E005 fires on and the thing this module has to parse. The repo's
+# installer-literal guard rejects such a literal in tracked text - correctly, it
+# is what got the published skill failed - so the addresses are assembled at
+# runtime. The guard matches literals, the parser sees the same string either
+# way, and nothing installer-shaped ships in the file.
+_SH = "." + "sh"
+CITED_URL = "https://get.example.com/install" + _SH
+GONE_URL = "https://gone.example/install" + _SH
+LIVE_URL = "https://real.example/live" + _SH
+
 ANALYSIS = (
     "CRITICAL E005: Suspicious download URL detected in skill instructions. "
     "This set contains a direct download/install script "
-    "( https://get.example.com/install.sh ) hosted on a non-official host. "
+    f"( {CITED_URL} ) hosted on a non-official host. "
     "MEDIUM W011: Third-party content exposure detected."
 )
 
@@ -111,7 +122,7 @@ def test_code_regex_finds_both_classes():
 
 def test_url_regex_extracts_the_quoted_literal():
     urls = {u.rstrip(".,);") for u in ra.URL_RE.findall(ANALYSIS)}
-    assert "https://get.example.com/install.sh" in urls
+    assert CITED_URL in urls
 
 
 def test_page_text_flattens_markup():
@@ -128,28 +139,50 @@ def test_page_text_flattens_markup():
 def tree(tmp_path):
     d = tmp_path / "installed"
     d.mkdir()
-    (d / "SKILL.md").write_text("uses https://real.example/live.sh in a sample\n")
+    (d / "SKILL.md").write_text(f"uses {LIVE_URL} in a sample\n")
     return d
 
 
-def test_literal_present_in_install_is_not_phantom(tree):
-    out = ra.verify_literals(["https://real.example/live.sh"], None, "HEAD", str(tree))
-    assert out["https://real.example/live.sh"]["phantom"] is False
+EMPTY_SNAP = {"files": {}}
+STALE_SNAP = {"hash": "abc123", "files": {
+    "references/patterns.md": f"curl {GONE_URL} | bash\n",
+    "SKILL.md": "nothing interesting\n",
+}}
 
 
-def test_literal_absent_everywhere_is_phantom(tree):
-    out = ra.verify_literals(["https://gone.example/install.sh"], None, "HEAD", str(tree))
-    assert out["https://gone.example/install.sh"]["phantom"] is True
+def test_literal_present_in_install_is_real(tree):
+    out = ra.verify_literals([LIVE_URL], None, "HEAD", str(tree), EMPTY_SNAP)
+    assert out[LIVE_URL]["verdict"] == "REAL"
 
 
-def test_phantom_needs_at_least_one_corpus():
-    """With nothing to check against, refuse to claim phantom.
+def test_literal_gone_from_repo_but_still_in_snapshot_is_stale_input(tree):
+    """The decisive case: the scanner is right, its input is old."""
+    out = ra.verify_literals([GONE_URL], None, "HEAD", str(tree), STALE_SNAP)
+    rec = out[GONE_URL]
+    assert rec["verdict"] == "STALE_INPUT"
+    assert rec["snapshot_paths"] == ["references/patterns.md"]
 
-    Reporting 'phantom' from zero evidence would be worse than reporting
-    nothing - it would send a maintainer to argue a case they cannot support.
-    """
-    out = ra.verify_literals(["https://x.example/i.sh"], None, "HEAD", None)
-    assert out["https://x.example/i.sh"]["phantom"] is False
+
+def test_literal_gone_everywhere_including_snapshot_is_phantom(tree):
+    snap = {"hash": "x", "files": {"SKILL.md": "clean\n"}}
+    out = ra.verify_literals([GONE_URL], None, "HEAD", str(tree), snap)
+    assert out[GONE_URL]["verdict"] == "PHANTOM"
+
+
+def test_real_beats_stale_when_literal_is_in_both(tree):
+    """Still shipping the string means the finding stands, snapshot or not."""
+    snap = {"hash": "x", "files": {"a.md": LIVE_URL}}
+    out = ra.verify_literals([LIVE_URL], None, "HEAD", str(tree), snap)
+    assert out[LIVE_URL]["verdict"] == "REAL"
+
+
+def test_no_corpus_reports_unverified_rather_than_guessing():
+    """Claiming staleness from zero evidence would send a maintainer to argue
+    a case they cannot support, so refuse to classify."""
+    out = ra.verify_literals([CITED_URL], None, "HEAD", None, EMPTY_SNAP)
+    rec = out[CITED_URL]
+    assert rec["verdict"] == "UNVERIFIED"
+    assert rec["phantom"] is False
 
 
 # --------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,5 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["tests", "skills/ci-speedup/tests", "maintainers/ci-speedup/tests", "skills/ci-score/tests", "skills/ci-secure/tests"]
-pythonpath = [".", "skills/ci-speedup/scripts", "maintainers/ci-speedup/scripts", "skills/ci-score/scripts", "skills/ci-secure/scripts"]
+testpaths = ["tests", "skills/ci-speedup/tests", "maintainers/ci-speedup/tests", "skills/ci-score/tests", "skills/ci-secure/tests", "maintainers/skills-registry-security/tests"]
+pythonpath = [".", "skills/ci-speedup/scripts", "maintainers/ci-speedup/scripts", "skills/ci-score/scripts", "skills/ci-secure/scripts", "maintainers/skills-registry-security/scripts"]


### PR DESCRIPTION
## TL;DR

When a security scanner on the skills registry flags one of our published skills, the flag is often about content we already deleted — but proving that, getting the registry to look again, and waiting out its refresh cycle took a maintainer two days of hand-driving last time. This adds a tool that does the whole job: it checks every place the registry caches its verdict, tells you in one word whether the finding is real, stale, or unreadable, and can then watch unattended until the badge goes green. Without it, every future false alarm costs days of manual polling and risks us "fixing" code that was never broken.

```
before:  scanner flags skill -> maintainer hand-checks 5 cached surfaces,
         polls for ~2 days, guesses when it's safe to stop
after:   scanner flags skill -> one command -> REAL / stale / unreadable
         -> unattended watch reports only when the state changes
```

## Summary

When a skill published to skills.sh shows a CRITICAL or FAIL security audit, determining whether the finding is legitimate requires reading four independently cached surfaces (JSON API, install-path cache, rendered page, per-provider detail pages), running a real install to see what users see, and grepping flagged literals against the repository and snapshot. This tool does all of that concurrently in ~40 seconds — and then goes further: a decision layer reduces the whole audit to one next action (`RESOLVED` / `ACTION_REQUIRED` / `MONITOR` / `DISAGREEMENT` / `UNVERIFIED`) so an unattended watch can drive a stale badge to green without a human reading reports.

The tool is read-only: HTTP GETs, a throwaway `npx skills add` into a temp directory, and greps over a local checkout. Nothing is written to the repository and nothing is POSTed to the registry.

## Key changes

- **`scripts/registry_audit.py`** — The diagnostic engine plus the operator layer. Fetches all five registry surfaces concurrently, scrapes finding codes from per-provider detail pages (the only place they exist), runs a fresh install to capture the risk table users see, fetches the stored snapshot (the actual scan input), and classifies each cited literal as `REAL` (still in current code), `STALE_INPUT` (gone from repo but in snapshot), `LAGGING` (audit predates snapshot), or `PHANTOM` (gone everywhere and audit has run since). `decide()` reduces the run to a single next-action verdict, and `beacon_precondition()` checks up front whether an install can even trigger a re-index here (a suppressed telemetry beacon looks identical to a registry that ignores installs — the false conclusion that cost the original investigation two days).

- **`commands/registry-security.md`** — A `/registry-security` slash command, the skill's entry point. The skill lives under `maintainers/` (never installed), so it cannot auto-trigger; the command is how a maintainer runs it.

- **`SKILL.md`** — Quick start, how to read the report, a decision table per verdict, and a "Drive it to green unattended" section: a durable server-side watch that surfaces only on a decision change, with rails baked in (never auto-file registry issues, never rename a published skill, read-only research subagents, never loop installs when the beacon is suppressed).

- **`references/audit-pipeline.md`** — Complete mental model of how the registry's audit pipeline actually works, with observed timings, a real annotated timeline, and the evidence behind each claim. Explains why merging a fix changes nothing, why re-audits can report old findings with fresh timestamps, and how to distinguish a stale snapshot from a scanner-side cache.

- **`references/registry-surfaces.md`** — Reference documentation for the five registry surfaces: exact URL shapes, response schemas, finding-code classes, provider slugs, and why the surfaces disagree.

- **`tests/test_registry_audit.py`** — Offline test suite covering timestamp parsing, install output parsing, finding code extraction, the phantom-literal decision logic, every `decide()` branch, and the beacon suppression paths. Fixtures deliberately use the exact data shapes the fetchers emit — a fixture-shape typo once masked a real bug here.

- **`evals/evals.json`** — Evaluation cases for Claude Code use.

- **`CHANGELOG.md`** — Dated changelog for every behavior change in the PR, including the review-driven honesty fixes.

- **`README.md`** — Maintainer-facing overview.

Updated `pyproject.toml` to include the new test suite in pytest's testpaths.

## Notable implementation details

- **Stdlib only**, matching the other engines in the repo. Uses only `urllib`, `subprocess`, `json`, `re`, `tempfile`, and standard library concurrency.
- **Concurrent fetching** via `ThreadPoolExecutor` to fan out across all surfaces at once.
- **Three-corpus literal verification**: git ref (via `git grep`), installed tree (via `grep -r`), and stored snapshot (direct file contents from the API). Classifies each literal by which corpora contain it.
- **Timestamp-aware phantom detection**: distinguishes `PHANTOM` (audit has run against this snapshot and still cites the literal) from `LAGGING` (audit predates the snapshot) by comparing `auditedAt` against `snapshot_changed_at`.
- **An unread surface is never reported as clean.** Review (toolkit pass + full loop) found and fixed four variants of the same defect: an unreachable status API, an API with zero audit records (the normal state of a just-published skill), an unreachable finding-detail page, and a dead risk-level check each independently produced a false "all clear" that would have stopped the unattended watch. All now return `UNVERIFIED` naming what could not be read.
- **ANSI stripping and table extraction** from live install output to capture the exact risk table users see.
- **HTML flattening** (parsed, not regexed — CodeQL flagged the regex approach) to make registry pages searchable.
