### PR TITLE
Mention @claude on a PR or issue to get Claude's help, answering as the Claude app

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -4,14 +4,16 @@
 #
 # Needs two one-time pieces of setup outside this file (repo admin):
 #   1. Install the Claude GitHub App on this repo: https://github.com/apps/claude
-#   2. Add the ANTHROPIC_API_KEY repository secret (Settings -> Secrets and
-#      variables -> Actions). A Claude subscription token works instead:
-#      run `claude setup-token` locally and store it as CLAUDE_CODE_OAUTH_TOKEN,
-#      then switch the input below to claude_code_oauth_token.
+#   2. ANTHROPIC_API_KEY is an org-wide secret on starslingdev, so there is no
+#      repository secret to create — confirm this repo is in that org secret's
+#      repository-access list (org secrets can be scoped to selected repos).
+#      A Claude subscription token works instead: run `claude setup-token`
+#      locally and store it as CLAUDE_CODE_OAUTH_TOKEN, then switch the input
+#      below to claude_code_oauth_token.
 #
 # Comment-triggered runs execute in base-repo context, so secrets are present
 # even when the comment is on a fork PR. The `if:` guard skips the job (and the
-# runner minutes) for comments that never mention @claude.
+# runner minutes) for every comment that does not clear both of its conditions.
 name: Claude Code
 
 on:
@@ -22,7 +24,16 @@ on:
 
 jobs:
   claude:
-    if: contains(github.event.comment.body, '@claude')
+    # Comment-triggered workflows get no first-time-contributor approval screen:
+    # GitHub's "require approval for first-time contributors" setting only gates
+    # pull_request events from forks, and this job runs on comments. This gate is
+    # the equivalent — an outsider's @claude mention does not start the job, and
+    # a maintainer re-mentioning @claude IS the approval. The action itself also
+    # independently requires the commenter to have write access, so this is
+    # defense in depth, not the only line.
+    if: >-
+      contains(github.event.comment.body, '@claude') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: starsling-ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,11 +31,14 @@ jobs:
       id-token: write
       actions: read
     steps:
-      - uses: actions/checkout@v6
+      # Actions are pinned to full commit SHAs, matching every other workflow in
+      # this repo: this job holds the API key and repo-write permissions, so a
+      # mutable tag would let an upstream retag run unreviewed code here.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
       # No github_token input on purpose: the action then authenticates its
       # pushes as the Claude App, which lets CI trigger on Claude's commits.
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@e63208cb983318a44e3f945e959ef894b707dcfa # v1.0.192
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,41 @@
+# Claude Code GitHub Action: mention @claude in a PR or issue comment and a
+# Claude instance runs in Actions, replying and pushing as the Claude GitHub
+# App (not as any maintainer's personal account).
+#
+# Needs two one-time pieces of setup outside this file (repo admin):
+#   1. Install the Claude GitHub App on this repo: https://github.com/apps/claude
+#   2. Add the ANTHROPIC_API_KEY repository secret (Settings -> Secrets and
+#      variables -> Actions). A Claude subscription token works instead:
+#      run `claude setup-token` locally and store it as CLAUDE_CODE_OAUTH_TOKEN,
+#      then switch the input below to claude_code_oauth_token.
+#
+# Comment-triggered runs execute in base-repo context, so secrets are present
+# even when the comment is on a fork PR. The `if:` guard skips the job (and the
+# runner minutes) for comments that never mention @claude.
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude:
+    if: contains(github.event.comment.body, '@claude')
+    runs-on: starsling-ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      # No github_token input on purpose: the action then authenticates its
+      # pushes as the Claude App, which lets CI trigger on Claude's commits.
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## TL;DR

This adds the standard Claude GitHub integration: anyone can mention @claude on a pull request or issue, and a Claude instance runs in this repo's CI, answers the question, and can push fixes — all under the Claude app's own identity, so it's always clear which feedback came from Claude. Nothing runs until two one-time admin steps are done (install the app, add the API-key secret), so merging this is safe on its own.

```
"@claude review this"  ->  GitHub Actions runs Claude  ->  replies / pushes as the Claude app
```

## What's in the PR

One file: `.github/workflows/claude.yml`, the canonical `anthropics/claude-code-action@v1` mention-triggered workflow, adapted to this repo:

- Triggers on `issue_comment` and `pull_request_review_comment`; an `if:` guard skips the job entirely (no runner spin-up) for comments that don't mention `@claude`.
- Only maintainers can trigger it: the guard also requires the commenter to be an org member, collaborator, or owner. Comment-triggered workflows have no "approve first-time contributor" screen (that GitHub setting only gates fork PRs), so this gate is the equivalent — an outsider's `@claude` does nothing, and a maintainer re-mentioning `@claude` on their behalf is the approval. The action independently refuses commenters without write access, so this is defense in depth.
- Runs on `starsling-ubuntu-24.04`, matching this repo's runner convention.
- No `github_token` override, deliberately: the action then authenticates pushes as the Claude App, so CI still triggers on Claude's commits (passing the default token would silently suppress CI on them).
- Comment events run in base-repo context, so this works on fork PRs too — secrets are available because the workflow runs from `main`, not from the fork.

## Requirements (one-time, repo admin — nothing runs until both are done)

1. Install the Claude GitHub App on this repo: https://github.com/apps/claude
2. The workflow uses the existing org-wide `ANTHROPIC_API_KEY` secret — just confirm this repo is in that secret's repository-access list (org Settings → Secrets and variables → Actions), since org secrets can be scoped to selected repos. Alternative: a subscription token via `claude setup-token`, stored as `CLAUDE_CODE_OAUTH_TOKEN`, switching the workflow's one input accordingly.

Optional knobs, not set here: `claude_args: "--max-turns N"` to cap a run's iterations, `--model` to pin a model, `trigger_phrase` to change the mention word.
