### PR TITLE
ci-secure checks our own workflows on every PR, and the @claude workflow returns hardened

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,9 @@
 # fork/self-hosted split, the escaping, the @claude hardening. Deleting an
 # assertion weakens the gate as much as editing the code it guards.
 /tests/ @yonasb
+
+# The off-switch for all of the above. `testpaths` here is what makes those
+# suites run at all, so dropping an entry disables them wholesale without
+# touching a single owned path -- a shorter route to a forged pass than editing
+# any test.
+/pyproject.toml @yonasb

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Workflow changes carry CI-security consequences; route them to an owner.
+/.github/ @yonasb

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,8 @@
 # Workflow changes carry CI-security consequences; route them to an owner.
 /.github/ @yonasb
+
+# The engine the CI-security gate executes. A pull request can edit the code
+# that judges it, so the gate's honesty rests on someone reading that diff --
+# owning the workflow but not the scanner it runs would leave the shorter path
+# to a forged pass unwatched.
+/skills/ci-secure/scripts/ @yonasb

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,12 @@
 # The engine the CI-security gate executes. A pull request can edit the code
 # that judges it, so the gate's honesty rests on someone reading that diff --
 # owning the workflow but not the scanner it runs would leave the shorter path
-# to a forged pass unwatched.
-/skills/ci-secure/scripts/ @yonasb
+# to a forged pass unwatched. The whole directory, not just scripts/: the engine
+# loads its detector catalog from references/security-patterns.md, and deleting a
+# section there silences a detector as effectively as editing the code.
+/skills/ci-secure/ @yonasb
+
+# The tests are the only thing pinning the gate's rules -- the verdict logic, the
+# fork/self-hosted split, the escaping, the @claude hardening. Deleting an
+# assertion weakens the gate as much as editing the code it guards.
+/tests/ @yonasb

--- a/.github/scripts/ci_secure_gate.py
+++ b/.github/scripts/ci_secure_gate.py
@@ -8,8 +8,25 @@ Runs the ci-secure engine against the repository root, then applies the gate:
               each one becomes a ::warning:: annotation and a summary row,
               so accepting one is a visible decision, not silence.
 
-Stdlib only, like the engine itself. Portable: point ENGINE at any checkout
-of starslingdev/skills (this repo uses its in-tree copy).
+Green here means a scan ran and returned a verdict. That is a stronger claim
+than "the engine exited 0", and the difference is the whole job of this file:
+the engine is deliberately crash-tolerant, so its facts layer degrades to an
+empty `facts` list with a null score rather than taking the scan down, and an
+empty list contains no failures. Left unchecked, "the scoring layer crashed"
+would render as "0/0 facts pass" and go green - a scan that measured nothing,
+reported as clean. Every degraded shape is therefore named and turned red
+below. A check that did not run is not a check that passed.
+
+This file is stdlib only. The engine it runs is NOT: `scan.py` imports PyYAML
+and exits 1 with an install hint without it, so the job needs `pip install
+pyyaml` (or an image that already has it) as well as a checkout and python3.
+
+Portability. This file must live at `.github/scripts/` (it takes the scan root
+from GITHUB_WORKSPACE, falling back to two directories up). The engine defaults
+to an in-tree checkout of starslingdev/skills, which is what this repo has; any
+repo that vendors the gate without vendoring the engine points CI_SECURE_ENGINE
+at a fetched `scan.py` instead. A missing engine is a red build naming the path
+it looked in, never a silent pass.
 """
 import json
 import os
@@ -17,34 +34,96 @@ import subprocess
 import sys
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-ENGINE = REPO_ROOT / "skills" / "ci-secure" / "scripts" / "scan.py"
+REPO_ROOT = Path(os.environ.get("GITHUB_WORKSPACE")
+                 or Path(__file__).resolve().parents[2])
+ENGINE = Path(os.environ.get("CI_SECURE_ENGINE")
+              or REPO_ROOT / "skills" / "ci-secure" / "scripts" / "scan.py")
+
+# The job's own timeout-minutes would eventually catch a hung engine, but only
+# as an unexplained cancellation; failing here names the cause on the check run.
+ENGINE_TIMEOUT_S = 600
+
+# The outcomes the engine's config-facts layer is known to emit. Anything else
+# is a contract change between engine and gate, and must not be quietly bucketed
+# as "not a fail" - that is how a new failure state ships green.
+KNOWN_OUTCOMES = {"pass", "fail", "unmeasured"}
+
+# P14.11 (impostor action SHA) is the one detector that needs network + a GitHub
+# token. Neither job here has one, so it is turned off explicitly rather than
+# left on `auto`: otherwise whether a security check runs would depend on
+# whichever runner image happened to ship an authenticated `gh`. The engine
+# records the decision in `gh_checks`, which this gate renders.
+ENGINE_ARGS = ["--gh-impostor", "off"]
+
+
+def fail(message: str) -> int:
+    """Annotate the check run with a red reason. Returns 1, the gate's exit code."""
+    print(f"::error::{message}")
+    return 1
 
 
 def main() -> int:
-    result = subprocess.run(
-        [sys.executable, str(ENGINE), "--root", str(REPO_ROOT)],
-        capture_output=True, text=True)
+    if not ENGINE.is_file():
+        return fail(
+            f"ci-secure engine not found at {ENGINE} - point CI_SECURE_ENGINE at a "
+            "checkout's skills/ci-secure/scripts/scan.py. The gate cannot pass "
+            "without a verdict (a scan that did not run is not a scan that passed)")
+
+    try:
+        result = subprocess.run(
+            [sys.executable, str(ENGINE), "--root", str(REPO_ROOT), *ENGINE_ARGS],
+            capture_output=True, text=True, timeout=ENGINE_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        return fail(f"ci-secure engine did not finish within {ENGINE_TIMEOUT_S}s - "
+                    "the gate cannot pass without a verdict")
+
     if result.returncode != 0:
         print(result.stderr, file=sys.stderr)
-        print("::error::ci-secure engine failed to run - the gate cannot pass "
-              "without a verdict (a scan that did not run is not a scan that "
-              "passed)")
-        return 1
-    scan = json.loads(result.stdout)
+        return fail("ci-secure engine failed to run - the gate cannot pass without "
+                    "a verdict (a scan that did not run is not a scan that passed)")
 
-    facts = scan["security_score"]["facts"]
+    # Every key read below is one the engine always emits. Indexing rather than
+    # .get()-with-a-default is deliberate: if the schema ever drops `findings` or
+    # `scan_incomplete`, the gate must go red on the KeyError, not quietly report
+    # zero coverage gaps - which is the exact false negative it exists to prevent.
+    try:
+        scan = json.loads(result.stdout)
+        score = scan["security_score"]
+        facts = score["facts"]
+        findings = scan["findings"]
+        incomplete = scan["scan_incomplete"]
+    except (ValueError, KeyError, TypeError) as exc:
+        sys.stderr.write(result.stdout[:2000])
+        return fail(f"ci-secure engine produced no readable verdict ({exc!r}) - "
+                    "the gate cannot pass without one")
+
+    degraded = []
+    if not scan.get("scanned_workflows"):
+        degraded.append("no workflow files were scanned")
+    if not facts or not score.get("scored_count"):
+        degraded.append("the config-facts layer evaluated nothing")
+    if score.get("score") is None:
+        degraded.append("the engine returned no score")
+    if score.get("reason"):
+        degraded.append(str(score["reason"]))
+    unknown = sorted(str(o) for o in {f.get("outcome") for f in facts} - KNOWN_OUTCOMES)
+    if unknown:
+        degraded.append(f"unrecognised fact outcome(s) {unknown} - this gate cannot "
+                        "tell whether they are failures")
+
     failed = [f for f in facts if f["outcome"] == "fail"]
-    findings = scan.get("findings", [])
-    incomplete = scan.get("scan_incomplete", [])
+    unmeasured = [f for f in facts if f["outcome"] == "unmeasured"]
 
     lines = ["## ci-secure", "",
-             f"score: **{scan['security_score']['score']}** "
-             f"({scan['security_score']['passed']}/{scan['security_score']['scored_count']} facts pass, "
-             f"{scan['scanned_workflows']} workflow file(s) scanned)", ""]
+             f"score: **{score.get('score')}** "
+             f"({score.get('passed')}/{score.get('scored_count')} facts pass, "
+             f"{scan.get('scanned_workflows')} workflow file(s) scanned)", ""]
 
+    # An unrecognised outcome renders as itself rather than folding into FAIL:
+    # the summary a human reads must never disagree with the exit code.
+    marks = {"pass": "PASS", "fail": "**FAIL**", "unmeasured": "UNMEASURED"}
     for f in facts:
-        mark = "PASS" if f["outcome"] == "pass" else "**FAIL**"
+        mark = marks.get(f["outcome"], f"**{str(f['outcome']).upper()}**")
         lines.append(f"- {mark} `{f['fact_id']}` - {f['evidence']}")
     if findings:
         lines += ["", "### Findings (surfaced, non-blocking)", ""]
@@ -53,10 +132,19 @@ def main() -> int:
             lines.append(f"- {f.get('severity', '?')} `{f.get('pattern', '?')}` {f.get('title', '')} ({loc})")
             print(f"::warning file={f.get('workflow_file', '')},line={f.get('line', 1)}::"
                   f"ci-secure {f.get('severity', '?')} {f.get('pattern', '?')}: {f.get('title', '')}")
+    # A detector that did not run is reported, not omitted: "no findings from
+    # P14.11" and "P14.11 never ran" must not look the same to a reader.
+    gh_checks = scan.get("gh_checks") or {}
+    if gh_checks:
+        lines += ["", "### Network-gated detectors", ""]
+        lines += [f"- `{k}`: {v}" for k, v in sorted(gh_checks.items())]
+    # Individually unmeasured facts do not block - several have honest causes
+    # that would otherwise leave the gate permanently red - but they are never
+    # silent, and a run where NOTHING was measured is caught by `degraded` above.
+    for f in unmeasured:
+        print(f"::warning::ci-secure fact unmeasured: {f['fact_id']} - {f['evidence']}")
     if incomplete:
         lines += ["", f"### Coverage gaps: {incomplete}"]
-        print(f"::error::ci-secure scan incomplete: {incomplete} - a skipped "
-              "workflow shown as clean is a false negative")
 
     summary = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary:
@@ -64,11 +152,15 @@ def main() -> int:
             fh.write("\n".join(lines) + "\n")
     print("\n".join(lines))
 
+    red = False
+    for reason in degraded:
+        red = bool(fail(f"ci-secure produced no usable verdict: {reason}"))
+    if incomplete:
+        red = bool(fail(f"ci-secure scan incomplete: {incomplete} - a skipped "
+                        "workflow shown as clean is a false negative"))
     for f in failed:
-        print(f"::error::ci-secure fact failed: {f['fact_id']} - {f['evidence']}")
-    if failed or incomplete:
-        return 1
-    return 0
+        red = bool(fail(f"ci-secure fact failed: {f['fact_id']} - {f['evidence']}"))
+    return 1 if red else 0
 
 
 if __name__ == "__main__":

--- a/.github/scripts/ci_secure_gate.py
+++ b/.github/scripts/ci_secure_gate.py
@@ -94,12 +94,31 @@ CONFIG, CONFIG_PATH = load_config()
 # unreachable, because checkout and pip had already spent a minute of that clock.
 ENGINE_TIMEOUT_S = 420
 
-# P14.11 (impostor action SHA) is the one detector that needs network + a GitHub
-# token. Neither job here has one, so it is turned off explicitly rather than
-# left on `auto`: otherwise whether a security check runs would depend on
-# whichever runner image happened to ship an authenticated `gh`. The engine
-# records the decision in `gh_checks`, which this gate renders.
-ENGINE_ARGS = ["--gh-impostor", "off"]
+# P14.11 (impostor action SHA) is the one detector that needs network and a
+# GitHub token, so whether it runs is a property of the JOB, not of this script:
+# a job holding a read-only token turns it on, a job running fork-authored code
+# does not get one. CI_SECURE_GH_IMPOSTOR carries that decision.
+#
+# The value is always passed through explicitly and `auto` is not accepted.
+# `auto` (and simply omitting the flag, which lands on it) runs the check iff an
+# authenticated `gh` happens to be present, which makes "did this security check
+# run?" a property of the runner image - one rebuild away from silently
+# stopping. A typo is red for the same reason: a check that quietly turned
+# itself off looks exactly like a check that passed.
+IMPOSTOR = os.environ.get("CI_SECURE_GH_IMPOSTOR", "off").strip().lower()
+ENGINE_ARGS = ["--gh-impostor", IMPOSTOR]
+
+# Anything short of a completed network check is disclosed everywhere; whether
+# it also BLOCKS depends on the run. A pull request must not be held hostage to
+# someone else's rate limit, so there it warns. The scheduled run against the
+# default branch has no deadline and nothing to race, so there it is red - and
+# it is the run that catches a pin that rots after merge.
+STRICT_GH = os.environ.get("CI_SECURE_GH_STRICT", "").strip() == "1"
+
+# The engine's own vocabulary for a completed network check. `partial:` (some
+# pins unverified) and `skipped:` (never ran) are the two it uses for anything
+# less, and both are held to be short of "ran".
+GH_CHECK_COMPLETE_PREFIX = "ran:"
 
 
 # GitHub rejects a step summary over 1 MiB, so an oversized one is not a big
@@ -210,6 +229,13 @@ def main() -> int:
         return fail(f"ci-secure rule at {CONFIG_PATH} is incoherent: an outcome that "
                     "blocks or is recognised has no display mark")
 
+    if IMPOSTOR not in ("on", "off"):
+        return fail(
+            f"CI_SECURE_GH_IMPOSTOR must be 'on' or 'off', not {IMPOSTOR!r} - "
+            "'auto' and an unset value are refused on purpose, because they make "
+            "whether the network-gated check runs depend on the runner image "
+            "rather than on this job")
+
     try:
         result = subprocess.run(
             [sys.executable, str(ENGINE), "--root", str(REPO_ROOT), *ENGINE_ARGS],
@@ -299,6 +325,18 @@ def main() -> int:
     if score.get("caveat"):
         lines += [f"> {flat(score['caveat'])}", ""]
 
+    # A network-gated check that did not complete is disclosed HERE, in the
+    # summary's opening lines, not only in the detector section far below. A
+    # reader who stops after the headline must not come away with a coverage
+    # claim the run cannot support: "no findings from P14.11" and "P14.11 never
+    # ran" are different statements, and the reassuring one is false.
+    incomplete_gh = {k: v for k, v in gh_checks.items()
+                     if not str(v).startswith(GH_CHECK_COMPLETE_PREFIX)}
+    if incomplete_gh:
+        lines += [f"> **Network-gated check(s) did NOT run to completion:** "
+                  f"{', '.join(flat(k) for k in sorted(incomplete_gh))}. "
+                  "This scan does not cover what they would have checked.", ""]
+
     # An unrecognised outcome renders as itself rather than folding into FAIL:
     # the summary a human reads must never disagree with the exit code.
     for f in facts:
@@ -329,6 +367,12 @@ def main() -> int:
     # silent, and a run where NOTHING was measured is caught by `degraded` above.
     for f in unmeasured:
         print(f"::warning::ci-secure fact unmeasured: {esc(f['fact_id'])} - {esc(f['evidence'])}")
+    # The second surface for the same disclosure. On a strict run this is
+    # promoted to a verdict below rather than repeated as a warning.
+    if not STRICT_GH:
+        for name, status in sorted(incomplete_gh.items()):
+            print(f"::warning::ci-secure network-gated check {esc(name)} did not "
+                  f"complete: {esc(status)} - this scan does not cover it")
     if incomplete:
         lines += ["", f"### Coverage gaps: {flat(incomplete)}"]
 
@@ -355,6 +399,12 @@ def main() -> int:
     for f in failed:
         fail(f"ci-secure fact failed: {f['fact_id']} - {f['evidence']}")
         red = True
+    if STRICT_GH:
+        for name, status in sorted(incomplete_gh.items()):
+            fail(f"ci-secure network-gated check {name} did not complete: {status} "
+                 "- this run requires complete coverage, and a check that could "
+                 "not finish is not a check that passed")
+            red = True
 
     summary = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary:

--- a/.github/scripts/ci_secure_gate.py
+++ b/.github/scripts/ci_secure_gate.py
@@ -32,6 +32,7 @@ import json
 import os
 import subprocess
 import sys
+import traceback
 from pathlib import Path
 
 REPO_ROOT = Path(os.environ.get("GITHUB_WORKSPACE")
@@ -41,7 +42,9 @@ ENGINE = Path(os.environ.get("CI_SECURE_ENGINE")
 
 # The job's own timeout-minutes would eventually catch a hung engine, but only
 # as an unexplained cancellation; failing here names the cause on the check run.
-ENGINE_TIMEOUT_S = 600
+# It must therefore fire FIRST: at parity with the job's 10 minutes this path was
+# unreachable, because checkout and pip had already spent a minute of that clock.
+ENGINE_TIMEOUT_S = 420
 
 # The outcomes the engine's config-facts layer is known to emit. Anything else
 # is a contract change between engine and gate, and must not be quietly bucketed
@@ -56,9 +59,13 @@ KNOWN_OUTCOMES = {"pass", "fail", "unmeasured"}
 ENGINE_ARGS = ["--gh-impostor", "off"]
 
 
-# A job summary over this many characters is rejected by GitHub, which would
-# throw away the whole thing - including the failures. Truncate instead.
-SUMMARY_LIMIT = 900_000
+# GitHub rejects a step summary over 1 MiB, so an oversized one is not a big
+# summary - it is no summary. The budget is in BYTES because that is what GitHub
+# counts: a character budget passes a scan whose evidence strings are non-ASCII
+# (em dashes are 3 bytes, and on a fork PR the filenames in them are attacker
+# chosen) while the upload is several times over the real limit. Headroom is left
+# for whatever another step in the same job already appended to the same file.
+SUMMARY_LIMIT_BYTES = 900_000
 
 
 def esc(value: object, *, prop: bool = False) -> str:
@@ -95,6 +102,30 @@ def flat(value: object) -> str:
     return " ".join(str(value).split())
 
 
+def budget(body: str) -> str:
+    """Trim the summary to GitHub's byte limit, cutting on a line boundary."""
+    if len(body.encode("utf-8")) <= SUMMARY_LIMIT_BYTES:
+        return body
+    clipped = body.encode("utf-8")[:SUMMARY_LIMIT_BYTES].decode("utf-8", "ignore")
+    # Cut back to the last complete line so the final row is not half-rendered.
+    head, sep, _ = clipped.rpartition("\n")
+    return (head if sep else clipped) + "\n\n_(summary truncated; see the step log)_"
+
+
+def quote(text: str) -> None:
+    """Echo untrusted engine output to the log, readably, without running it.
+
+    Percent-encoding this would be wrong: GitHub decodes `%0A` only inside a
+    workflow command, never in an ordinary log line, so escaping an engine
+    traceback turns the thing a maintainer reads when the gate goes red for a
+    NON-security reason into one unreadable blob. Prefixing each line keeps it
+    legible while guaranteeing no line can begin with `::`, which is the only
+    property that matters here.
+    """
+    for line in text.splitlines():
+        print(f"engine| {line}", file=sys.stderr)
+
+
 def fail(message: str) -> int:
     """Annotate the check run with a red reason. Returns 1, the gate's exit code."""
     print(f"::error::{esc(message)}")
@@ -111,15 +142,14 @@ def main() -> int:
     try:
         result = subprocess.run(
             [sys.executable, str(ENGINE), "--root", str(REPO_ROOT), *ENGINE_ARGS],
-            capture_output=True, text=True, timeout=ENGINE_TIMEOUT_S)
+            capture_output=True, text=True, errors="replace",
+            timeout=ENGINE_TIMEOUT_S)
     except subprocess.TimeoutExpired:
         return fail(f"ci-secure engine did not finish within {ENGINE_TIMEOUT_S}s - "
                     "the gate cannot pass without a verdict")
 
     if result.returncode != 0:
-        # Escaped like everything else: on a fork PR the engine is attacker code,
-        # and Actions parses workflow commands out of stderr too.
-        print(esc(result.stderr[:4000]), file=sys.stderr)
+        quote(result.stderr[:4000])
         return fail("ci-secure engine failed to run - the gate cannot pass without "
                     "a verdict (a scan that did not run is not a scan that passed)")
 
@@ -127,14 +157,28 @@ def main() -> int:
     # .get()-with-a-default is deliberate: if the schema ever drops `findings` or
     # `scan_incomplete`, the gate must go red on the KeyError, not quietly report
     # zero coverage gaps - which is the exact false negative it exists to prevent.
+    # (Fields the gate only renders, never decides on, are read with .get().)
     try:
         scan = json.loads(result.stdout)
         score = scan["security_score"]
         facts = score["facts"]
         findings = scan["findings"]
         incomplete = scan["scan_incomplete"]
+        # A match the engine FOUND and then could not anchor to a line, so did not
+        # report. The engine ranks this the same as an unreadable file, and its own
+        # coverage predicate requires both to be empty - so a gate that blocks on
+        # `scan_incomplete` and ignores this one is inconsistent about the same
+        # class of hole. A finding produced and discarded is a false negative.
+        dropped = scan["dropped_matches"]
+        gh_checks = scan["gh_checks"]
+        if not isinstance(facts, list) or not all(isinstance(f, dict) for f in facts):
+            raise TypeError(f"facts is not a list of objects: {type(facts).__name__}")
+        for f in facts:
+            # Read now, inside the guarded block, so a malformed fact renders as
+            # "no readable verdict" instead of an unannotated traceback later.
+            f["outcome"], f["fact_id"], f["evidence"]
     except (ValueError, KeyError, TypeError) as exc:
-        sys.stderr.write(esc(result.stdout[:2000]))
+        quote(result.stdout[:2000])
         return fail(f"ci-secure engine produced no readable verdict ({exc!r}) - "
                     "the gate cannot pass without one")
 
@@ -147,7 +191,9 @@ def main() -> int:
         degraded.append("the engine returned no score")
     if score.get("reason"):
         degraded.append(str(score["reason"]))
-    unknown = sorted(str(o) for o in {f.get("outcome") for f in facts} - KNOWN_OUTCOMES)
+    if not gh_checks:
+        degraded.append("the engine reported no network-gated detector status")
+    unknown = sorted(str(o) for o in {f["outcome"] for f in facts} - KNOWN_OUTCOMES)
     if unknown:
         degraded.append(f"unrecognised fact outcome(s) {unknown} - this gate cannot "
                         "tell whether they are failures")
@@ -155,10 +201,24 @@ def main() -> int:
     failed = [f for f in facts if f["outcome"] == "fail"]
     unmeasured = [f for f in facts if f["outcome"] == "unmeasured"]
 
+    # `applicable_count` is in the headline, not just `scored_count`: when a fact
+    # cannot be measured the engine drops it from BOTH sides of the ratio, so a
+    # repo with one measurable fact and eleven unmeasurable ones still reads
+    # "1/1 facts pass" at a score of 100. True, and rhetorically false - the
+    # denominator shrank to hide the gap. The engine states the gap in `caveat`,
+    # which is rendered below.
+    #
+    # Every interpolation here is flattened. These four fields come out of the
+    # engine's JSON, and on a fork pull request the engine is attacker code: a
+    # newline in any of them would start a new line in `body`, which is printed
+    # to stdout where Actions parses `::workflow commands::`.
     lines = ["## ci-secure", "",
-             f"score: **{score.get('score')}** "
-             f"({score.get('passed')}/{score.get('scored_count')} facts pass, "
-             f"{scan.get('scanned_workflows')} workflow file(s) scanned)", ""]
+             f"score: **{flat(score.get('score'))}** "
+             f"({flat(score.get('passed'))}/{flat(score.get('scored_count'))} facts pass"
+             f" of {flat(score.get('applicable_count'))} applicable, "
+             f"{flat(scan.get('scanned_workflows'))} workflow file(s) scanned)", ""]
+    if score.get("caveat"):
+        lines += [f"> {flat(score['caveat'])}", ""]
 
     # An unrecognised outcome renders as itself rather than folding into FAIL:
     # the summary a human reads must never disagree with the exit code.
@@ -172,16 +232,19 @@ def main() -> int:
             loc = f"{flat(f.get('workflow_file', '?'))}:{flat(f.get('line', '?'))}"
             lines.append(f"- {flat(f.get('severity', '?'))} `{flat(f.get('pattern', '?'))}` "
                          f"{flat(f.get('title', ''))} ({loc})")
-            print(f"::warning file={esc(f.get('workflow_file', ''), prop=True)},"
-                  f"line={esc(f.get('line', 1), prop=True)}::"
+            props = [f"file={esc(f.get('workflow_file', ''), prop=True)}"]
+            if f.get("line") is not None:
+                props.append(f"line={esc(f['line'], prop=True)}")
+            print(f"::warning {','.join(props)}::"
                   f"ci-secure {esc(f.get('severity', '?'))} {esc(f.get('pattern', '?'))}: "
                   f"{esc(f.get('title', ''))}")
     # A detector that did not run is reported, not omitted: "no findings from
-    # P14.11" and "P14.11 never ran" must not look the same to a reader.
-    gh_checks = scan.get("gh_checks") or {}
-    if gh_checks:
-        lines += ["", "### Network-gated detectors", ""]
-        lines += [f"- `{flat(k)}`: {flat(v)}" for k, v in sorted(gh_checks.items())]
+    # P14.11" and "P14.11 never ran" must not look the same to a reader. Indexed,
+    # not `.get(... ) or {}`: this gate always passes `--gh-impostor off`, so the
+    # engine always has a status to report, and an absent key is schema drift -
+    # which would make those two cases look identical again.
+    lines += ["", "### Network-gated detectors", ""]
+    lines += [f"- `{flat(k)}`: {flat(v)}" for k, v in sorted(gh_checks.items())]
     # Individually unmeasured facts do not block - several have honest causes
     # that would otherwise leave the gate permanently red - but they are never
     # silent, and a run where NOTHING was measured is caught by `degraded` above.
@@ -191,26 +254,51 @@ def main() -> int:
         lines += ["", f"### Coverage gaps: {flat(incomplete)}"]
 
     body = "\n".join(lines)
-    summary = os.environ.get("GITHUB_STEP_SUMMARY")
-    if summary:
-        # A scan can legitimately produce thousands of findings, and an oversized
-        # summary is rejected wholesale - taking the failures down with it.
-        text = body if len(body) <= SUMMARY_LIMIT else (
-            body[:SUMMARY_LIMIT] + "\n\n_(summary truncated; see the step log)_")
-        with open(summary, "a", encoding="utf-8") as fh:
-            fh.write(text + "\n")
     print(body)
 
+    # The verdict is emitted BEFORE the summary is written. The summary is a
+    # cosmetic sink on a file GitHub provisions, and an OSError writing it used to
+    # take the whole failure list down with it - the operator got a traceback
+    # about a summary file instead of the security failure that caused the red.
     red = False
     for reason in degraded:
-        red = bool(fail(f"ci-secure produced no usable verdict: {reason}"))
+        fail(f"ci-secure produced no usable verdict: {reason}")
+        red = True
     if incomplete:
-        red = bool(fail(f"ci-secure scan incomplete: {incomplete} - a skipped "
-                        "workflow shown as clean is a false negative"))
+        fail(f"ci-secure scan incomplete: {incomplete} - a skipped workflow shown "
+             "as clean is a false negative")
+        red = True
+    if dropped:
+        fail(f"ci-secure dropped {len(dropped)} match(es) it could not anchor to a "
+             f"line: {dropped} - a finding the detector produced and discarded is a "
+             "false negative")
+        red = True
     for f in failed:
-        red = bool(fail(f"ci-secure fact failed: {f['fact_id']} - {f['evidence']}"))
+        fail(f"ci-secure fact failed: {f['fact_id']} - {f['evidence']}")
+        red = True
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        try:
+            with open(summary, "a", encoding="utf-8") as fh:
+                fh.write(budget(body) + "\n")
+        except OSError as exc:
+            # Never fatal: the verdict above is already on the check run.
+            print(f"::warning::could not write the job summary ({exc!r}); the "
+                  "findings above are in the step log")
     return 1 if red else 0
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except SystemExit:
+        raise
+    except BaseException as exc:                              # noqa: BLE001
+        # Fail closed AND fail legibly. An uncaught traceback already exits
+        # non-zero, so the build was never at risk - but it reaches the check run
+        # as a red with no stated cause, which is the same "unexplained red" this
+        # gate argues against everywhere else.
+        traceback.print_exc()
+        sys.exit(fail(f"ci-secure gate crashed ({exc!r}) - the gate cannot pass "
+                      "without a verdict"))

--- a/.github/scripts/ci_secure_gate.py
+++ b/.github/scripts/ci_secure_gate.py
@@ -21,13 +21,29 @@ This file is stdlib only. The engine it runs is NOT: `scan.py` imports PyYAML
 and exits 1 with an install hint without it, so the job needs `pip install
 pyyaml` (or an image that already has it) as well as a checkout and python3.
 
-Portability. This file must live at `.github/scripts/` (it takes the scan root
-from GITHUB_WORKSPACE, falling back to two directories up). The engine defaults
-to an in-tree checkout of starslingdev/skills, which is what this repo has; any
-repo that vendors the gate without vendoring the engine points CI_SECURE_ENGINE
-at a fetched `scan.py` instead. A missing engine is a red build naming the path
-it looked in, never a silent pass.
+Two trees, and the difference between them is the whole security argument. The
+SCAN ROOT is the repository under examination, taken from GITHUB_WORKSPACE; on
+a fork pull request an attacker writes every byte of it. The ENGINE and the
+RULE are the code this gate executes, and they are resolved relative to THIS
+FILE - never from the scan root. A gate that loaded its engine from the tree it
+was auditing would be running the code it is supposed to be judging, and would
+print whatever verdict that code returned.
+
+CI_SECURE_ENGINE is the one deliberate redirect, for a repository that vendors
+ci-secure into a directory of its own instead of checking out this whole tree.
+It is safe only while the workflow that sets it is pinned to the base
+repository's definition - a fork that can edit the workflow `env:` can point it
+back into the workspace and reopen the hole this resolution closes.
+
+`config.py` follows the ENGINE, not this file: it is loaded from the directory
+of whichever engine was resolved, falling back to this tree's copy. One rule
+serves both layouts - here the gate sits at `.github/scripts/` and the engine
+under `skills/ci-secure/scripts/`, while a vendored install puts engine and
+config in one directory - and the redirect travels with CI_SECURE_ENGINE, so
+the rule is always in the same trust class as the engine it configures rather
+than a third thing that can be aimed somewhere else on its own.
 """
+import importlib.util
 import json
 import os
 import subprocess
@@ -35,21 +51,48 @@ import sys
 import traceback
 from pathlib import Path
 
+# The tree being AUDITED. Attacker-writable on a fork PR; only ever scan input.
 REPO_ROOT = Path(os.environ.get("GITHUB_WORKSPACE")
                  or Path(__file__).resolve().parents[2])
-ENGINE = Path(os.environ.get("CI_SECURE_ENGINE")
-              or REPO_ROOT / "skills" / "ci-secure" / "scripts" / "scan.py")
+
+# The tree the gate EXECUTES from, relative to this file: `.github/scripts/` ->
+# repo root -> the in-tree skill. Deliberately not REPO_ROOT-relative.
+_GATE_TREE = Path(__file__).resolve().parents[2]
+_ENGINE_DEFAULT = _GATE_TREE / "skills" / "ci-secure" / "scripts" / "scan.py"
+_CONFIG_FALLBACK = _ENGINE_DEFAULT.parent / "config.py"
+
+ENGINE = Path(os.environ.get("CI_SECURE_ENGINE") or _ENGINE_DEFAULT)
+
+
+def load_config():
+    """Load `config.py` from beside the resolved engine, else from this tree.
+
+    By file location, through importlib, rather than by package import: a
+    vendored install carries the engine and this gate and nothing else - no
+    test helpers, no conftest, no `skills.ci_secure` package on sys.path.
+    Anything that works here only because the repository's test tree happens
+    to be importable would fail on every adopter.
+    """
+    for candidate in (ENGINE.resolve().parent / "config.py", _CONFIG_FALLBACK):
+        if not candidate.is_file():
+            continue
+        spec = importlib.util.spec_from_file_location(
+            "ci_secure_gate_config", candidate)
+        if spec is None or spec.loader is None:      # pragma: no cover - defensive
+            continue
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module, candidate
+    return None, None
+
+
+CONFIG, CONFIG_PATH = load_config()
 
 # The job's own timeout-minutes would eventually catch a hung engine, but only
 # as an unexplained cancellation; failing here names the cause on the check run.
 # It must therefore fire FIRST: at parity with the job's 10 minutes this path was
 # unreachable, because checkout and pip had already spent a minute of that clock.
 ENGINE_TIMEOUT_S = 420
-
-# The outcomes the engine's config-facts layer is known to emit. Anything else
-# is a contract change between engine and gate, and must not be quietly bucketed
-# as "not a fail" - that is how a new failure state ships green.
-KNOWN_OUTCOMES = {"pass", "fail", "unmeasured"}
 
 # P14.11 (impostor action SHA) is the one detector that needs network + a GitHub
 # token. Neither job here has one, so it is turned off explicitly rather than
@@ -139,6 +182,26 @@ def main() -> int:
             "checkout's skills/ci-secure/scripts/scan.py. The gate cannot pass "
             "without a verdict (a scan that did not run is not a scan that passed)")
 
+    # No rule, no verdict. The gate could fall back to a hardcoded copy of the
+    # outcome tables, and that is exactly the failure this indirection exists to
+    # prevent: a second definition of "which outcomes block" that drifts from
+    # the engine's and is never noticed, because a build that finds it goes
+    # green either way.
+    if CONFIG is None:
+        return fail(
+            f"ci-secure rule (config.py) not found beside the engine at "
+            f"{ENGINE.parent} nor at {_CONFIG_FALLBACK} - the gate cannot decide "
+            "what blocks without one")
+    missing = [name for name in
+               ("BLOCKING_OUTCOMES", "KNOWN_OUTCOMES", "OUTCOME_MARKS")
+               if not hasattr(CONFIG, name)]
+    if missing:
+        return fail(f"ci-secure rule at {CONFIG_PATH} defines no {', '.join(missing)} "
+                    "- engine and gate disagree about what an outcome means")
+    if not CONFIG.coverage_is_complete():
+        return fail(f"ci-secure rule at {CONFIG_PATH} is incoherent: an outcome that "
+                    "blocks or is recognised has no display mark")
+
     try:
         result = subprocess.run(
             [sys.executable, str(ENGINE), "--root", str(REPO_ROOT), *ENGINE_ARGS],
@@ -193,12 +256,16 @@ def main() -> int:
         degraded.append(str(score["reason"]))
     if not gh_checks:
         degraded.append("the engine reported no network-gated detector status")
-    unknown = sorted(str(o) for o in {f["outcome"] for f in facts} - KNOWN_OUTCOMES)
+    unknown = sorted(str(o) for o in
+                     {f["outcome"] for f in facts} - set(CONFIG.KNOWN_OUTCOMES))
     if unknown:
         degraded.append(f"unrecognised fact outcome(s) {unknown} - this gate cannot "
                         "tell whether they are failures")
 
-    failed = [f for f in facts if f["outcome"] == "fail"]
+    # Which outcomes block is the rule's call, not a string literal here: a
+    # hardcoded "fail" filter means a newly-added failure outcome is neither
+    # blocked nor unrecognised, and ships green.
+    failed = [f for f in facts if f["outcome"] in CONFIG.BLOCKING_OUTCOMES]
     unmeasured = [f for f in facts if f["outcome"] == "unmeasured"]
 
     # `applicable_count` is in the headline, not just `scored_count`: when a fact
@@ -222,9 +289,9 @@ def main() -> int:
 
     # An unrecognised outcome renders as itself rather than folding into FAIL:
     # the summary a human reads must never disagree with the exit code.
-    marks = {"pass": "PASS", "fail": "**FAIL**", "unmeasured": "UNMEASURED"}
     for f in facts:
-        mark = marks.get(f["outcome"], f"**{flat(f['outcome']).upper()}**")
+        mark = CONFIG.OUTCOME_MARKS.get(
+            f["outcome"], f"**{flat(f['outcome']).upper()}**")
         lines.append(f"- {mark} `{flat(f['fact_id'])}` - {flat(f['evidence'])}")
     if findings:
         lines += ["", "### Findings (surfaced, non-blocking)", ""]

--- a/.github/scripts/ci_secure_gate.py
+++ b/.github/scripts/ci_secure_gate.py
@@ -86,13 +86,42 @@ def load_config():
     return None, None
 
 
-CONFIG, CONFIG_PATH = load_config()
+# Loading the rule EXECUTES code - `spec.loader.exec_module` - and in a vendored
+# layout that code sits beside the engine rather than in this tree, which makes
+# this the likeliest line in the file to raise, not the least. It runs at module
+# scope, OUTSIDE main()'s handler, so a config.py with a syntax error or an
+# import-time raise used to exit non-zero with a bare traceback and no
+# `::error::`. The build was never at risk; the operator just got the
+# "unexplained red" this file argues against everywhere else. The failure is
+# captured here and re-reported as a stated verdict inside main().
+#
+# Deliberately unannotated: a PEP 604 `BaseException | None` here would be
+# evaluated at module scope, and this file is vendored into adopters' repos
+# where python3 is whatever they have. That is the same break this PR fixed in
+# the skill's own config.py.
+try:
+    CONFIG, CONFIG_PATH = load_config()
+    CONFIG_ERROR = None
+except BaseException as _exc:                                 # noqa: BLE001
+    CONFIG, CONFIG_PATH, CONFIG_ERROR = None, None, _exc
 
 # The job's own timeout-minutes would eventually catch a hung engine, but only
 # as an unexplained cancellation; failing here names the cause on the check run.
 # It must therefore fire FIRST: at parity with the job's 10 minutes this path was
 # unreachable, because checkout and pip had already spent a minute of that clock.
-ENGINE_TIMEOUT_S = 420
+#
+# Overridable by env so the timeout can be exercised for real in a test rather
+# than trusted. A test that has to sleep 420s does not get written, and an
+# untested timeout is how this constant sat at parity with the job clock -
+# unreachable - in the first place. The override only ever SHORTENS the wait in
+# a test; no workflow sets it, and a bad value falls back to the default rather
+# than disabling the timeout, since "no timeout" is the failure being prevented.
+try:
+    ENGINE_TIMEOUT_S = int(os.environ.get("CI_SECURE_ENGINE_TIMEOUT_S", "") or 420)
+except ValueError:
+    ENGINE_TIMEOUT_S = 420
+if ENGINE_TIMEOUT_S <= 0:
+    ENGINE_TIMEOUT_S = 420
 
 # P14.11 (impostor action SHA) is the one detector that needs network and a
 # GitHub token, so whether it runs is a property of the JOB, not of this script:
@@ -105,7 +134,12 @@ ENGINE_TIMEOUT_S = 420
 # run?" a property of the runner image - one rebuild away from silently
 # stopping. A typo is red for the same reason: a check that quietly turned
 # itself off looks exactly like a check that passed.
-IMPOSTOR = os.environ.get("CI_SECURE_GH_IMPOSTOR", "off").strip().lower()
+# No default. Defaulting to "off" made UNSET the one value that skipped the
+# refusal below - so deleting the `env:` block from a scan job would quietly
+# turn the network-gated check off, which is exactly the outcome this variable
+# exists to make impossible, and the refusal message right below claimed was
+# already impossible.
+IMPOSTOR = os.environ.get("CI_SECURE_GH_IMPOSTOR", "").strip().lower()
 ENGINE_ARGS = ["--gh-impostor", IMPOSTOR]
 
 # Anything short of a completed network check is disclosed everywhere; whether
@@ -113,7 +147,15 @@ ENGINE_ARGS = ["--gh-impostor", IMPOSTOR]
 # someone else's rate limit, so there it warns. The scheduled run against the
 # default branch has no deadline and nothing to race, so there it is red - and
 # it is the run that catches a pin that rots after merge.
-STRICT_GH = os.environ.get("CI_SECURE_GH_STRICT", "").strip() == "1"
+#
+# Unset is allowed and means lax, because the fork job deliberately does not set
+# it and lax still DISCLOSES on both surfaces - the dial changes severity, not
+# coverage. An unrecognised value is refused, though: `true`, `yes` and
+# `schedule` all read as "strict is on" to a human editing the YAML and all
+# silently meant lax, which would have muted the one run whose whole purpose is
+# catching a pin that rots after merge.
+STRICT_RAW = os.environ.get("CI_SECURE_GH_STRICT", "0").strip()
+STRICT_GH = STRICT_RAW == "1"
 
 # The engine's own vocabulary for a completed network check. `partial:` (some
 # pins unverified) and `skipped:` (never ran) are the two it uses for anything
@@ -213,14 +255,23 @@ def main() -> int:
     # prevent: a second definition of "which outcomes block" that drifts from
     # the engine's and is never noticed, because a build that finds it goes
     # green either way.
+    if CONFIG_ERROR is not None:
+        quote("".join(traceback.format_exception(
+            type(CONFIG_ERROR), CONFIG_ERROR, CONFIG_ERROR.__traceback__)))
+        return fail(
+            f"ci-secure rule (config.py) could not be loaded ({CONFIG_ERROR!r}) "
+            "- the gate cannot decide what blocks without one")
     if CONFIG is None:
         return fail(
             f"ci-secure rule (config.py) not found beside the engine at "
             f"{ENGINE.parent} nor at {_CONFIG_FALLBACK} - the gate cannot decide "
             "what blocks without one")
+    # `coverage_is_complete` is in this list because it is CALLED below: left
+    # out, a vendored rule missing only that name reached the crash handler and
+    # reported an AttributeError instead of the specific disagreement.
     missing = [name for name in
                ("BLOCKING_OUTCOMES", "KNOWN_OUTCOMES", "OUTCOME_MARKS",
-                "flatten_scanned")
+                "flatten_scanned", "coverage_is_complete")
                if not hasattr(CONFIG, name)]
     if missing:
         return fail(f"ci-secure rule at {CONFIG_PATH} defines no {', '.join(missing)} "
@@ -235,6 +286,12 @@ def main() -> int:
             "'auto' and an unset value are refused on purpose, because they make "
             "whether the network-gated check runs depend on the runner image "
             "rather than on this job")
+
+    if STRICT_RAW not in ("0", "1"):
+        return fail(
+            f"CI_SECURE_GH_STRICT must be '0' or '1', not {STRICT_RAW!r} - a "
+            "value like 'true' reads as strict and meant lax, which would mute "
+            "the run whose purpose is catching a pin that rots after merge")
 
     try:
         result = subprocess.run(
@@ -357,9 +414,9 @@ def main() -> int:
                   f"{esc(f.get('title', ''))}")
     # A detector that did not run is reported, not omitted: "no findings from
     # P14.11" and "P14.11 never ran" must not look the same to a reader. Indexed,
-    # not `.get(... ) or {}`: this gate always passes `--gh-impostor off`, so the
-    # engine always has a status to report, and an absent key is schema drift -
-    # which would make those two cases look identical again.
+    # not `.get(... ) or {}`: this gate always passes `--gh-impostor` explicitly,
+    # on or off, so the engine always has a status to report, and an absent key
+    # is schema drift - which would make those two cases look identical again.
     lines += ["", "### Network-gated detectors", ""]
     lines += [f"- `{flat(k)}`: {flat(v)}" for k, v in sorted(gh_checks.items())]
     # Individually unmeasured facts do not block - several have honest causes

--- a/.github/scripts/ci_secure_gate.py
+++ b/.github/scripts/ci_secure_gate.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""The ci-secure CI gate: red on any failed security fact, loud on findings.
+
+Runs the ci-secure engine against the repository root, then applies the gate:
+
+  facts    -> deterministic pass/fail security checks; ANY fail exits 1.
+  findings -> severity-rated pattern matches; they never exit non-zero, but
+              each one becomes a ::warning:: annotation and a summary row,
+              so accepting one is a visible decision, not silence.
+
+Stdlib only, like the engine itself. Portable: point ENGINE at any checkout
+of starslingdev/skills (this repo uses its in-tree copy).
+"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENGINE = REPO_ROOT / "skills" / "ci-secure" / "scripts" / "scan.py"
+
+
+def main() -> int:
+    result = subprocess.run(
+        [sys.executable, str(ENGINE), "--root", str(REPO_ROOT)],
+        capture_output=True, text=True)
+    if result.returncode != 0:
+        print(result.stderr, file=sys.stderr)
+        print("::error::ci-secure engine failed to run - the gate cannot pass "
+              "without a verdict (a scan that did not run is not a scan that "
+              "passed)")
+        return 1
+    scan = json.loads(result.stdout)
+
+    facts = scan["security_score"]["facts"]
+    failed = [f for f in facts if f["outcome"] == "fail"]
+    findings = scan.get("findings", [])
+    incomplete = scan.get("scan_incomplete", [])
+
+    lines = ["## ci-secure", "",
+             f"score: **{scan['security_score']['score']}** "
+             f"({scan['security_score']['passed']}/{scan['security_score']['scored_count']} facts pass, "
+             f"{scan['scanned_workflows']} workflow file(s) scanned)", ""]
+
+    for f in facts:
+        mark = "PASS" if f["outcome"] == "pass" else "**FAIL**"
+        lines.append(f"- {mark} `{f['fact_id']}` - {f['evidence']}")
+    if findings:
+        lines += ["", "### Findings (surfaced, non-blocking)", ""]
+        for f in findings:
+            loc = f"{f.get('workflow_file', '?')}:{f.get('line', '?')}"
+            lines.append(f"- {f.get('severity', '?')} `{f.get('pattern', '?')}` {f.get('title', '')} ({loc})")
+            print(f"::warning file={f.get('workflow_file', '')},line={f.get('line', 1)}::"
+                  f"ci-secure {f.get('severity', '?')} {f.get('pattern', '?')}: {f.get('title', '')}")
+    if incomplete:
+        lines += ["", f"### Coverage gaps: {incomplete}"]
+        print(f"::error::ci-secure scan incomplete: {incomplete} - a skipped "
+              "workflow shown as clean is a false negative")
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as fh:
+            fh.write("\n".join(lines) + "\n")
+    print("\n".join(lines))
+
+    for f in failed:
+        print(f"::error::ci-secure fact failed: {f['fact_id']} - {f['evidence']}")
+    if failed or incomplete:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/ci_secure_gate.py
+++ b/.github/scripts/ci_secure_gate.py
@@ -91,9 +91,15 @@ def load_config():
 # this the likeliest line in the file to raise, not the least. It runs at module
 # scope, OUTSIDE main()'s handler, so a config.py with a syntax error or an
 # import-time raise used to exit non-zero with a bare traceback and no
-# `::error::`. The build was never at risk; the operator just got the
-# "unexplained red" this file argues against everywhere else. The failure is
-# captured here and re-reported as a stated verdict inside main().
+# `::error::` - the "unexplained red" this file argues against everywhere else.
+# The failure is captured here and re-reported as a stated verdict in main().
+#
+# `BaseException`, not `Exception`, and that is the load-bearing part rather
+# than defensive habit: `SystemExit` is not an `Exception`, so a config.py whose
+# module body called `sys.exit(0)` ENDED THIS PROCESS RIGHT HERE with status 0
+# and no output - a green gate over a scan that never ran. Narrowing this clause
+# is a natural-looking tidy-up that brings that forged pass straight back, which
+# is why `test_a_rule_that_exits_cleanly_on_load_cannot_forge_a_pass` pins it.
 #
 # Deliberately unannotated: a PEP 604 `BaseException | None` here would be
 # evaluated at module scope, and this file is vendored into adopters' repos
@@ -113,15 +119,23 @@ except BaseException as _exc:                                 # noqa: BLE001
 # Overridable by env so the timeout can be exercised for real in a test rather
 # than trusted. A test that has to sleep 420s does not get written, and an
 # untested timeout is how this constant sat at parity with the job clock -
-# unreachable - in the first place. The override only ever SHORTENS the wait in
-# a test; no workflow sets it, and a bad value falls back to the default rather
-# than disabling the timeout, since "no timeout" is the failure being prevented.
+# unreachable - in the first place.
+#
+# The override can only ever SHORTEN the wait, and the clamp is what makes that
+# true rather than a comment hoping it is. Without it a workflow could set the
+# variable high enough to put the timeout back out of reach, which is exactly
+# the regression this constant exists to prevent - and the invariant test reads
+# the source literal, so it would not notice. A zero, a negative or a
+# non-numeric falls back to the default, since "no timeout at all" is the
+# failure being prevented, not a way to ask for one.
+_TIMEOUT_CEILING = 420
 try:
-    ENGINE_TIMEOUT_S = int(os.environ.get("CI_SECURE_ENGINE_TIMEOUT_S", "") or 420)
+    ENGINE_TIMEOUT_S = int(os.environ.get("CI_SECURE_ENGINE_TIMEOUT_S", "")
+                           or _TIMEOUT_CEILING)
 except ValueError:
-    ENGINE_TIMEOUT_S = 420
-if ENGINE_TIMEOUT_S <= 0:
-    ENGINE_TIMEOUT_S = 420
+    ENGINE_TIMEOUT_S = _TIMEOUT_CEILING
+if not 0 < ENGINE_TIMEOUT_S <= _TIMEOUT_CEILING:
+    ENGINE_TIMEOUT_S = _TIMEOUT_CEILING
 
 # P14.11 (impostor action SHA) is the one detector that needs network and a
 # GitHub token, so whether it runs is a property of the JOB, not of this script:

--- a/.github/scripts/ci_secure_gate.py
+++ b/.github/scripts/ci_secure_gate.py
@@ -136,13 +136,20 @@ def esc(value: object, *, prop: bool = False) -> str:
 
 
 def flat(value: object) -> str:
-    """Collapse untrusted text to one line for the Markdown job summary.
+    """Neutralize untrusted text for the Markdown job summary.
 
     Same attacker-controlled source as `esc`, different sink: a newline here does
     not run a command, it breaks out of the list item and lets a crafted filename
-    render its own Markdown - a summary that reads as a clean pass.
+    render its own Markdown - a summary that reads as a clean pass. A backtick
+    does the same thing without a newline, by closing one of the inline code
+    spans this summary wraps ids in, and a pipe splits a table row.
+
+    The rule comes from the skill's config.py rather than being spelled out
+    here, because the engine's report renderer neutralizes the same strings for
+    the same reason: two copies would drift, and the weaker one is the surface
+    an attacker aims at.
     """
-    return " ".join(str(value).split())
+    return CONFIG.flatten_scanned(value)
 
 
 def budget(body: str) -> str:
@@ -193,7 +200,8 @@ def main() -> int:
             f"{ENGINE.parent} nor at {_CONFIG_FALLBACK} - the gate cannot decide "
             "what blocks without one")
     missing = [name for name in
-               ("BLOCKING_OUTCOMES", "KNOWN_OUTCOMES", "OUTCOME_MARKS")
+               ("BLOCKING_OUTCOMES", "KNOWN_OUTCOMES", "OUTCOME_MARKS",
+                "flatten_scanned")
                if not hasattr(CONFIG, name)]
     if missing:
         return fail(f"ci-secure rule at {CONFIG_PATH} defines no {', '.join(missing)} "
@@ -268,22 +276,26 @@ def main() -> int:
     failed = [f for f in facts if f["outcome"] in CONFIG.BLOCKING_OUTCOMES]
     unmeasured = [f for f in facts if f["outcome"] == "unmeasured"]
 
+    # Counts, never the bare aggregate. `config_facts.py` registers the score as
+    # machine-only - it exists so several engines' scores can be blended, and the
+    # report renderer is forbidden from showing it, because one number invites a
+    # reader to manage the number rather than the findings. This is a second
+    # reader-facing surface and it was quietly exempt.
+    #
     # `applicable_count` is in the headline, not just `scored_count`: when a fact
     # cannot be measured the engine drops it from BOTH sides of the ratio, so a
     # repo with one measurable fact and eleven unmeasurable ones still reads
-    # "1/1 facts pass" at a score of 100. True, and rhetorically false - the
-    # denominator shrank to hide the gap. The engine states the gap in `caveat`,
-    # which is rendered below.
+    # "1/1 facts pass". True, and rhetorically false - the denominator shrank to
+    # hide the gap. The engine states the gap in `caveat`, rendered below.
     #
-    # Every interpolation here is flattened. These four fields come out of the
+    # Every interpolation here is flattened. These fields come out of the
     # engine's JSON, and on a fork pull request the engine is attacker code: a
     # newline in any of them would start a new line in `body`, which is printed
     # to stdout where Actions parses `::workflow commands::`.
     lines = ["## ci-secure", "",
-             f"score: **{flat(score.get('score'))}** "
-             f"({flat(score.get('passed'))}/{flat(score.get('scored_count'))} facts pass"
+             f"{flat(score.get('passed'))}/{flat(score.get('scored_count'))} facts pass"
              f" of {flat(score.get('applicable_count'))} applicable, "
-             f"{flat(scan.get('scanned_workflows'))} workflow file(s) scanned)", ""]
+             f"{flat(scan.get('scanned_workflows'))} workflow file(s) scanned", ""]
     if score.get("caveat"):
         lines += [f"> {flat(score['caveat'])}", ""]
 

--- a/.github/scripts/ci_secure_gate.py
+++ b/.github/scripts/ci_secure_gate.py
@@ -56,9 +56,48 @@ KNOWN_OUTCOMES = {"pass", "fail", "unmeasured"}
 ENGINE_ARGS = ["--gh-impostor", "off"]
 
 
+# A job summary over this many characters is rejected by GitHub, which would
+# throw away the whole thing - including the failures. Truncate instead.
+SUMMARY_LIMIT = 900_000
+
+
+def esc(value: object, *, prop: bool = False) -> str:
+    """Escape untrusted text before it goes into a ::workflow command::.
+
+    Everything this gate reports about is read out of scanned workflow files, and
+    on a fork pull request an attacker writes those files - including their NAMES,
+    which the engine reports verbatim. GitHub parses `::command::` sequences out
+    of a step's stdout line by line, so an unescaped newline in a filename lets
+    that filename emit commands of its own. `::stop-commands::` is the one that
+    matters: it switches off command parsing for the rest of the step, which
+    would silence the `::error::` annotations this gate emits for real failures.
+    The exit code is computed in Python and cannot be touched this way, so a
+    build still goes red - but "the finding does not block" must not decay into
+    "the finding does not appear", which is this gate's whole premise.
+
+    Escapes are the ones GitHub decodes: %25 first (or it would double-encode the
+    others), then CR and LF. Property values additionally escape `:` and `,`,
+    which terminate the property list.
+    """
+    text = str(value).replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+    if prop:
+        text = text.replace(":", "%3A").replace(",", "%2C")
+    return text
+
+
+def flat(value: object) -> str:
+    """Collapse untrusted text to one line for the Markdown job summary.
+
+    Same attacker-controlled source as `esc`, different sink: a newline here does
+    not run a command, it breaks out of the list item and lets a crafted filename
+    render its own Markdown - a summary that reads as a clean pass.
+    """
+    return " ".join(str(value).split())
+
+
 def fail(message: str) -> int:
     """Annotate the check run with a red reason. Returns 1, the gate's exit code."""
-    print(f"::error::{message}")
+    print(f"::error::{esc(message)}")
     return 1
 
 
@@ -78,7 +117,9 @@ def main() -> int:
                     "the gate cannot pass without a verdict")
 
     if result.returncode != 0:
-        print(result.stderr, file=sys.stderr)
+        # Escaped like everything else: on a fork PR the engine is attacker code,
+        # and Actions parses workflow commands out of stderr too.
+        print(esc(result.stderr[:4000]), file=sys.stderr)
         return fail("ci-secure engine failed to run - the gate cannot pass without "
                     "a verdict (a scan that did not run is not a scan that passed)")
 
@@ -93,7 +134,7 @@ def main() -> int:
         findings = scan["findings"]
         incomplete = scan["scan_incomplete"]
     except (ValueError, KeyError, TypeError) as exc:
-        sys.stderr.write(result.stdout[:2000])
+        sys.stderr.write(esc(result.stdout[:2000]))
         return fail(f"ci-secure engine produced no readable verdict ({exc!r}) - "
                     "the gate cannot pass without one")
 
@@ -123,34 +164,42 @@ def main() -> int:
     # the summary a human reads must never disagree with the exit code.
     marks = {"pass": "PASS", "fail": "**FAIL**", "unmeasured": "UNMEASURED"}
     for f in facts:
-        mark = marks.get(f["outcome"], f"**{str(f['outcome']).upper()}**")
-        lines.append(f"- {mark} `{f['fact_id']}` - {f['evidence']}")
+        mark = marks.get(f["outcome"], f"**{flat(f['outcome']).upper()}**")
+        lines.append(f"- {mark} `{flat(f['fact_id'])}` - {flat(f['evidence'])}")
     if findings:
         lines += ["", "### Findings (surfaced, non-blocking)", ""]
         for f in findings:
-            loc = f"{f.get('workflow_file', '?')}:{f.get('line', '?')}"
-            lines.append(f"- {f.get('severity', '?')} `{f.get('pattern', '?')}` {f.get('title', '')} ({loc})")
-            print(f"::warning file={f.get('workflow_file', '')},line={f.get('line', 1)}::"
-                  f"ci-secure {f.get('severity', '?')} {f.get('pattern', '?')}: {f.get('title', '')}")
+            loc = f"{flat(f.get('workflow_file', '?'))}:{flat(f.get('line', '?'))}"
+            lines.append(f"- {flat(f.get('severity', '?'))} `{flat(f.get('pattern', '?'))}` "
+                         f"{flat(f.get('title', ''))} ({loc})")
+            print(f"::warning file={esc(f.get('workflow_file', ''), prop=True)},"
+                  f"line={esc(f.get('line', 1), prop=True)}::"
+                  f"ci-secure {esc(f.get('severity', '?'))} {esc(f.get('pattern', '?'))}: "
+                  f"{esc(f.get('title', ''))}")
     # A detector that did not run is reported, not omitted: "no findings from
     # P14.11" and "P14.11 never ran" must not look the same to a reader.
     gh_checks = scan.get("gh_checks") or {}
     if gh_checks:
         lines += ["", "### Network-gated detectors", ""]
-        lines += [f"- `{k}`: {v}" for k, v in sorted(gh_checks.items())]
+        lines += [f"- `{flat(k)}`: {flat(v)}" for k, v in sorted(gh_checks.items())]
     # Individually unmeasured facts do not block - several have honest causes
     # that would otherwise leave the gate permanently red - but they are never
     # silent, and a run where NOTHING was measured is caught by `degraded` above.
     for f in unmeasured:
-        print(f"::warning::ci-secure fact unmeasured: {f['fact_id']} - {f['evidence']}")
+        print(f"::warning::ci-secure fact unmeasured: {esc(f['fact_id'])} - {esc(f['evidence'])}")
     if incomplete:
-        lines += ["", f"### Coverage gaps: {incomplete}"]
+        lines += ["", f"### Coverage gaps: {flat(incomplete)}"]
 
+    body = "\n".join(lines)
     summary = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary:
+        # A scan can legitimately produce thousands of findings, and an oversized
+        # summary is rejected wholesale - taking the failures down with it.
+        text = body if len(body) <= SUMMARY_LIMIT else (
+            body[:SUMMARY_LIMIT] + "\n\n_(summary truncated; see the step log)_")
         with open(summary, "a", encoding="utf-8") as fh:
-            fh.write("\n".join(lines) + "\n")
-    print("\n".join(lines))
+            fh.write(text + "\n")
+    print(body)
 
     red = False
     for reason in degraded:

--- a/.github/workflows/ci-secure-check.yml
+++ b/.github/workflows/ci-secure-check.yml
@@ -8,13 +8,28 @@
 #     every one is surfaced as a ::warning:: annotation and in the job summary.
 #     "Does not block" must not decay into "does not appear".
 #
-# Reuse in any other repo: ci-secure is stdlib-only Python, so this file needs
-# nothing but a checkout and python3. This repo runs the in-tree engine; any
-# other repo replaces the "Run ci-secure" step's SCAN_ROOT setup with a
-# SHA-pinned fetch of the engine, e.g.:
-#   git clone --depth 1 https://github.com/starslingdev/skills /tmp/ci-secure-engine
-#   git -C /tmp/ci-secure-engine checkout <pinned-sha>
-#   python3 /tmp/ci-secure-engine/skills/ci-secure/scripts/scan.py --root .
+# Reuse in any other repo: copy this file and .github/scripts/ci_secure_gate.py
+# (the gate script must keep that exact location - it derives the scan root from
+# it). This repo runs the engine from its own tree; a repo that does not vendor
+# the engine fetches it and points CI_SECURE_ENGINE at the fetched scan.py,
+# replacing the "Run ci-secure" step with:
+#   - run: |
+#       git init /tmp/ci-secure-engine
+#       git -C /tmp/ci-secure-engine fetch --depth 1 \
+#         https://github.com/starslingdev/skills <pinned-sha>
+#       git -C /tmp/ci-secure-engine checkout FETCH_HEAD
+#     # `git clone --depth 1` cannot be followed by `checkout <sha>`: a depth-1
+#     # clone fetches only the default-branch tip, so the pin would never resolve.
+#   - run: python3 .github/scripts/ci_secure_gate.py
+#     env:
+#       CI_SECURE_ENGINE: /tmp/ci-secure-engine/skills/ci-secure/scripts/scan.py
+#
+# Run the GATE, never scan.py directly: scan.py prints its JSON and exits 0 no
+# matter what it found, so a step that calls it is a green-forever check. The
+# pass/fail rule above lives entirely in ci_secure_gate.py.
+#
+# Expect the first run on a new repo to be red on sec.codeowners.workflows until
+# a CODEOWNERS file exists - that is the gate working, not the gate broken.
 name: CI security
 
 on:
@@ -32,26 +47,40 @@ permissions:
   contents: read
 
 jobs:
-  ci-secure:
-    name: ci-secure
+  scan:
+    name: ci-secure (self-hosted)
     # Dogfoods StarSling runners like ci.yml; fork PRs are excluded from the
     # self-hosted runner and get the hosted twin below instead.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: starsling-ubuntu-24.04
     timeout-minutes: 10
     steps:
+      # fetch-depth: 1 — the scan only reads the tree at this commit; unlike
+      # ci.yml it verifies no ancestry, so history would be dead weight.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
           persist-credentials: false
+      # Pinned rather than inherited from the runner image: this is a security
+      # gate, and which interpreter it runs under should not drift with an image
+      # rebuild. The engine needs PyYAML — it is not a stdlib-only program.
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.12"
+      - run: pip install pyyaml
       - name: Run ci-secure against this repo's workflows
         run: python3 .github/scripts/ci_secure_gate.py
 
-  # Fork PRs run the identical scan on a GitHub-hosted runner: the scan needs
-  # no secrets, so hosted execution of fork code is the standard ci-fork model.
-  ci-secure-fork:
+  # Fork PRs run the same scan on a GitHub-hosted runner: the scan needs no
+  # secrets, so hosted execution of fork code is the standard ci-fork model.
+  # It is the same command over the same tree, but it is NOT an equivalent
+  # assurance: on a fork PR the gate script and the engine both come from the
+  # head ref, so a fork can weaken its own scan in the same pull request. What
+  # stops that is human review of a `.github/` diff (CODEOWNERS routes it), not
+  # this job. Treat a green fork scan as "nothing obvious", not as cleared.
+  scan-fork:
     name: ci-secure (fork)
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -59,5 +88,48 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: false
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.12"
+      - run: pip install pyyaml
       - name: Run ci-secure against this repo's workflows
         run: python3 .github/scripts/ci_secure_gate.py
+
+  # ONE check name carries the verdict for fork and non-fork alike. The two scan
+  # jobs are mutually exclusive, so a branch protection rule naming either of
+  # them directly would be satisfiable by never running it: a fork PR skips the
+  # self-hosted job, and a required check that is absent does not block a merge.
+  # This job always runs, so the required check is always reported, and it passes
+  # only when the one scan that was supposed to run actually ran and passed.
+  #
+  # GitHub-hosted on purpose: this job runs on fork PRs too, and its `run:` block
+  # travels with the head ref, so a self-hosted runner here would execute
+  # fork-authored shell on StarSling infrastructure. It checks out nothing.
+  verdict:
+    name: ci-secure
+    needs: [scan, scan-fork]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require the scan that should have run to have passed
+        env:
+          SELF_HOSTED: ${{ needs.scan.result }}
+          FORK: ${{ needs.scan-fork.result }}
+        run: |
+          set -euo pipefail
+          echo "self-hosted scan: ${SELF_HOSTED}"
+          echo "fork scan:        ${FORK}"
+          # Exactly one of the two is meant to run; the other reports "skipped".
+          # Anything else - both skipped, either failed, either cancelled - is
+          # not a pass: a scan that did not run is not a scan that passed.
+          if [ "${SELF_HOSTED}" = "success" ] && [ "${FORK}" = "skipped" ]; then
+            echo "ci-secure passed (self-hosted scan)."
+            exit 0
+          fi
+          if [ "${FORK}" = "success" ] && [ "${SELF_HOSTED}" = "skipped" ]; then
+            echo "ci-secure passed (fork scan)."
+            exit 0
+          fi
+          echo "::error::ci-secure has no passing verdict (self-hosted=${SELF_HOSTED}, fork=${FORK}) - a scan that did not run, was cancelled, or failed is not a pass"
+          exit 1

--- a/.github/workflows/ci-secure-check.yml
+++ b/.github/workflows/ci-secure-check.yml
@@ -1,0 +1,63 @@
+# ci-secure as a CI check: scans this repo's own .github/workflows with the
+# ci-secure engine and FAILS the build when any security fact fails, so a
+# workflow change that weakens CI security cannot merge green.
+#
+# Gate rule (mirrors registry-scan.yml's philosophy):
+#   - security_score FACTS are deterministic pass/fail checks -> any fail is RED.
+#   - pattern-layer FINDINGS (severity-rated, e.g. P14.18) do not block, but
+#     every one is surfaced as a ::warning:: annotation and in the job summary.
+#     "Does not block" must not decay into "does not appear".
+#
+# Reuse in any other repo: ci-secure is stdlib-only Python, so this file needs
+# nothing but a checkout and python3. This repo runs the in-tree engine; any
+# other repo replaces the "Run ci-secure" step's SCAN_ROOT setup with a
+# SHA-pinned fetch of the engine, e.g.:
+#   git clone --depth 1 https://github.com/starslingdev/skills /tmp/ci-secure-engine
+#   git -C /tmp/ci-secure-engine checkout <pinned-sha>
+#   python3 /tmp/ci-secure-engine/skills/ci-secure/scripts/scan.py --root .
+name: CI security
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-secure-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# The gate only reads the checked-out tree.
+permissions:
+  contents: read
+
+jobs:
+  ci-secure:
+    name: ci-secure
+    # Dogfoods StarSling runners like ci.yml; fork PRs are excluded from the
+    # self-hosted runner and get the hosted twin below instead.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    runs-on: starsling-ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Run ci-secure against this repo's workflows
+        run: python3 .github/scripts/ci_secure_gate.py
+
+  # Fork PRs run the identical scan on a GitHub-hosted runner: the scan needs
+  # no secrets, so hosted execution of fork code is the standard ci-fork model.
+  ci-secure-fork:
+    name: ci-secure (fork)
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Run ci-secure against this repo's workflows
+        run: python3 .github/scripts/ci_secure_gate.py

--- a/.github/workflows/ci-secure-check.yml
+++ b/.github/workflows/ci-secure-check.yml
@@ -8,23 +8,27 @@
 #     every one is surfaced as a ::warning:: annotation and in the job summary.
 #     "Does not block" must not decay into "does not appear".
 #
-# Reuse in any other repo: copy this file and .github/scripts/ci_secure_gate.py.
-# Under Actions the gate takes its scan root from GITHUB_WORKSPACE, so the path
-# is free; off Actions it falls back to two directories up, which is why the
-# in-repo location is `.github/scripts/`. This repo runs the engine from its own
-# tree; a repo that does not vendor
-# the engine fetches it and points CI_SECURE_ENGINE at the fetched scan.py,
-# replacing the "Run ci-secure" step with:
-#   - run: |
-#       git init /tmp/ci-secure-engine
-#       git -C /tmp/ci-secure-engine fetch --depth 1 \
-#         https://github.com/starslingdev/skills <pinned-sha>
-#       git -C /tmp/ci-secure-engine checkout FETCH_HEAD
-#     # `git clone --depth 1` cannot be followed by `checkout <sha>`: a depth-1
-#     # clone fetches only the default-branch tip, so the pin would never resolve.
-#   - run: python3 .github/scripts/ci_secure_gate.py
-#     env:
-#       CI_SECURE_ENGINE: /tmp/ci-secure-engine/skills/ci-secure/scripts/scan.py
+# Reuse in another repo: ask ci-secure to install itself. It VENDORS the engine
+# and the gate into your repository - copied in, reviewed as a pull request,
+# refreshed when you ask - so nothing is fetched and executed at CI time. The
+# gate resolves the engine relative to its own file, with CI_SECURE_ENGINE as
+# the redirect for a vendored layout; the scan root stays GITHUB_WORKSPACE,
+# which is the tree being judged and is never where executable code comes from.
+#
+# There is deliberately no fetch-a-pinned-sha-and-run-it recipe here any more.
+# We ship a detector for that shape (P14.24, unverified remote code execution):
+# a pin can be moved or deleted in a repository you do not control, so a CI job
+# that fetches and executes code is one upstream compromise away from running
+# whatever arrives. Recommending it in the header of our own security gate was
+# advice this scanner would flag in anyone else's workflow.
+#
+# A note for whoever adds a merge queue here. `ci-secure` is produced by the
+# verdict job below, whose predicate reasons about two mutually exclusive scans,
+# and neither scan's condition was written with `merge_group` in mind. If
+# `ci-secure` is required in the queue while this workflow does not trigger on
+# `merge_group`, the check never reports and the queue waits forever; and if the
+# verdict job greens while the scan it needs was SKIPPED for that event, the
+# skipped-check bypass reopens one event over. Trace both before adding it.
 #
 # Run the GATE, never scan.py directly: scan.py exits non-zero only on
 # OPERATIONAL errors (no workflows to scan, unreadable catalog, bad arguments)
@@ -39,6 +43,13 @@ on:
   pull_request:
   push:
     branches: [main]
+  # Every other trigger judges a proposed change. This one re-judges what
+  # already merged, which is the only way a pin that ROTS is ever noticed: an
+  # action SHA that is legitimate today can be deleted or orphaned tomorrow in
+  # a repository nobody here controls, and no pull request of ours would see
+  # it. Mondays, early UTC.
+  schedule:
+    - cron: "17 6 * * 1"
   workflow_dispatch:
 
 concurrency:
@@ -73,6 +84,28 @@ jobs:
       - run: pip install pyyaml
       - name: Run ci-secure against this repo's workflows
         run: python3 .github/scripts/ci_secure_gate.py
+        env:
+          # P14.11 verifies that every pinned action SHA actually exists in the
+          # action's canonical repository — the check that catches a pin aimed
+          # at a fork-only or dangling commit. It needs an authenticated `gh`,
+          # so it runs HERE, in the job whose code we control, and nowhere else.
+          #
+          # Turned on explicitly rather than by omission: the engine's default
+          # is `auto`, which runs the check iff an authenticated gh happens to
+          # be on the runner. That makes "did this security check run?" a
+          # property of the runner image, one rebuild away from silently
+          # stopping.
+          CI_SECURE_GH_IMPOSTOR: "on"
+          # The job's own read-only token: the least privilege that can read
+          # public commit metadata. It never reaches the fork twin below.
+          GH_TOKEN: ${{ github.token }}
+          # Anything short of a completed network check is red on the weekly
+          # run and a warning everywhere else. A pull request must not be
+          # blocked by somebody else's rate limit; the weekly run has no
+          # deadline and nothing to race, and it is the one run whose whole
+          # purpose is catching rot — so it is the one that must not be mutable
+          # by exhausting API quota.
+          CI_SECURE_GH_STRICT: ${{ github.event_name == 'schedule' && '1' || '0' }}
 
   # Fork PRs run the same scan on a GitHub-hosted runner: the scan needs no
   # secrets, so hosted execution of fork code is the standard ci-fork model.
@@ -102,6 +135,14 @@ jobs:
       - run: pip install pyyaml
       - name: Run ci-secure against this repo's workflows
         run: python3 .github/scripts/ci_secure_gate.py
+        env:
+          # OFF here, and off explicitly. This job executes code the pull
+          # request author wrote; handing it a token variable would hand
+          # attacker-authored steps a credential, which costs far more than the
+          # coverage it buys. The gate says the check did not run on both
+          # surfaces — the annotations and the summary's opening lines —
+          # because a check that did not run is never a pass.
+          CI_SECURE_GH_IMPOSTOR: "off"
 
   # ONE check name carries the verdict for fork and non-fork alike. The two scan
   # jobs are mutually exclusive, so a branch protection rule naming either of

--- a/.github/workflows/ci-secure-check.yml
+++ b/.github/workflows/ci-secure-check.yml
@@ -74,10 +74,14 @@ jobs:
   # Fork PRs run the same scan on a GitHub-hosted runner: the scan needs no
   # secrets, so hosted execution of fork code is the standard ci-fork model.
   # It is the same command over the same tree, but it is NOT an equivalent
-  # assurance: on a fork PR the gate script and the engine both come from the
-  # head ref, so a fork can weaken its own scan in the same pull request. What
-  # stops that is human review of a `.github/` diff (CODEOWNERS routes it), not
-  # this job. Treat a green fork scan as "nothing obvious", not as cleared.
+  # assurance: on a fork PR this workflow, the gate script, and the engine all
+  # come from the head ref, so a fork can weaken its own scan in the same pull
+  # request. Nothing inside CI can close that - a check whose code the pull
+  # request edits cannot vouch for itself. What closes it is a human reading the
+  # diff. CODEOWNERS routes both paths that matter (`.github/` and the engine
+  # under skills/ci-secure/scripts/), and that routing only blocks a merge if
+  # branch protection has "Require review from Code Owners" turned on.
+  # Treat a green fork scan as "nothing obvious", not as cleared.
   scan-fork:
     name: ci-secure (fork)
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
@@ -98,13 +102,25 @@ jobs:
   # ONE check name carries the verdict for fork and non-fork alike. The two scan
   # jobs are mutually exclusive, so a branch protection rule naming either of
   # them directly would be satisfiable by never running it: a fork PR skips the
-  # self-hosted job, and a required check that is absent does not block a merge.
-  # This job always runs, so the required check is always reported, and it passes
-  # only when the one scan that was supposed to run actually ran and passed.
+  # self-hosted job, and GitHub counts a skipped required check as a pass. This
+  # job always runs, so the required check is always reported, and it passes only
+  # when the one scan that was supposed to run actually ran and passed. Point
+  # branch protection at `ci-secure` - this job - and at nothing else here.
+  #
+  # The same caveat as the fork scan above applies to this comparison: on a fork
+  # PR this script travels with the head ref too, so what it guarantees is a
+  # consistent verdict over jobs that ran, not that the jobs were honest. The
+  # `.github/` diff review is the thing that guarantees the latter.
   #
   # GitHub-hosted on purpose: this job runs on fork PRs too, and its `run:` block
   # travels with the head ref, so a self-hosted runner here would execute
   # fork-authored shell on StarSling infrastructure. It checks out nothing.
+  #
+  # `always()`, not `!cancelled()`: a cancelled run reports this job as skipped,
+  # and GitHub reads a skipped required check as green. Rather than hand anyone a
+  # one-click way to turn the gate green, a superseded run is left to report a
+  # red `ci-secure` - branch protection reads the newest run, so the cost is a
+  # stale red in the history and the alternative is a bypass.
   verdict:
     name: ci-secure
     needs: [scan, scan-fork]

--- a/.github/workflows/ci-secure-check.yml
+++ b/.github/workflows/ci-secure-check.yml
@@ -8,12 +8,14 @@
 #     every one is surfaced as a ::warning:: annotation and in the job summary.
 #     "Does not block" must not decay into "does not appear".
 #
-# Reuse in another repo: ask ci-secure to install itself. It VENDORS the engine
-# and the gate into your repository - copied in, reviewed as a pull request,
-# refreshed when you ask - so nothing is fetched and executed at CI time. The
-# gate resolves the engine relative to its own file, with CI_SECURE_ENGINE as
-# the redirect for a vendored layout; the scan root stays GITHUB_WORKSPACE,
-# which is the tree being judged and is never where executable code comes from.
+# Reuse in another repo: copy this workflow and the gate in, alongside a
+# checkout of the engine. Nothing is fetched and executed at CI time - the code
+# that runs is code that arrived through a reviewed pull request. The gate
+# resolves the engine relative to its own file, with CI_SECURE_ENGINE as the
+# redirect for a vendored layout; the scan root stays GITHUB_WORKSPACE, which is
+# the tree being judged and is never where executable code comes from.
+# (An `install itself` flow that does the copying for you is proposed, not
+# shipped - do not read this comment as describing a command that exists.)
 #
 # There is deliberately no fetch-a-pinned-sha-and-run-it recipe here any more.
 # We ship a detector for that shape (P14.24, unverified remote code execution):

--- a/.github/workflows/ci-secure-check.yml
+++ b/.github/workflows/ci-secure-check.yml
@@ -8,9 +8,11 @@
 #     every one is surfaced as a ::warning:: annotation and in the job summary.
 #     "Does not block" must not decay into "does not appear".
 #
-# Reuse in any other repo: copy this file and .github/scripts/ci_secure_gate.py
-# (the gate script must keep that exact location - it derives the scan root from
-# it). This repo runs the engine from its own tree; a repo that does not vendor
+# Reuse in any other repo: copy this file and .github/scripts/ci_secure_gate.py.
+# Under Actions the gate takes its scan root from GITHUB_WORKSPACE, so the path
+# is free; off Actions it falls back to two directories up, which is why the
+# in-repo location is `.github/scripts/`. This repo runs the engine from its own
+# tree; a repo that does not vendor
 # the engine fetches it and points CI_SECURE_ENGINE at the fetched scan.py,
 # replacing the "Run ci-secure" step with:
 #   - run: |
@@ -24,9 +26,10 @@
 #     env:
 #       CI_SECURE_ENGINE: /tmp/ci-secure-engine/skills/ci-secure/scripts/scan.py
 #
-# Run the GATE, never scan.py directly: scan.py prints its JSON and exits 0 no
-# matter what it found, so a step that calls it is a green-forever check. The
-# pass/fail rule above lives entirely in ci_secure_gate.py.
+# Run the GATE, never scan.py directly: scan.py exits non-zero only on
+# OPERATIONAL errors (no workflows to scan, unreadable catalog, bad arguments)
+# and exits 0 for every security outcome it reports, so a step that calls it
+# directly is a green-forever check. The pass/fail rule above lives in the gate.
 #
 # Expect the first run on a new repo to be red on sec.codeowners.workflows until
 # a CODEOWNERS file exists - that is the gate working, not the gate broken.
@@ -78,9 +81,10 @@ jobs:
   # come from the head ref, so a fork can weaken its own scan in the same pull
   # request. Nothing inside CI can close that - a check whose code the pull
   # request edits cannot vouch for itself. What closes it is a human reading the
-  # diff. CODEOWNERS routes both paths that matter (`.github/` and the engine
-  # under skills/ci-secure/scripts/), and that routing only blocks a merge if
-  # branch protection has "Require review from Code Owners" turned on.
+  # diff. CODEOWNERS routes every path that could forge a pass (`.github/`, the
+  # engine under skills/ci-secure/, and the tests that pin the rules), and that
+  # routing only blocks a merge if branch protection has "Require review from
+  # Code Owners" turned on.
   # Treat a green fork scan as "nothing obvious", not as cleared.
   scan-fork:
     name: ci-secure (fork)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,55 @@
+# Claude Code GitHub Action: mention @claude in a PR or issue comment and a
+# Claude instance runs in Actions, replying and pushing as the Claude GitHub
+# App (not as any maintainer's personal account).
+#
+# Needs two one-time pieces of setup outside this file (repo admin):
+#   1. Install the Claude GitHub App on this repo: https://github.com/apps/claude
+#   2. ANTHROPIC_API_KEY is an org-wide secret on starslingdev, so there is no
+#      repository secret to create — confirm this repo is in that org secret's
+#      repository-access list (org secrets can be scoped to selected repos).
+#      A Claude subscription token works instead: run `claude setup-token`
+#      locally and store it as CLAUDE_CODE_OAUTH_TOKEN, then switch the input
+#      below to claude_code_oauth_token.
+#
+# Comment-triggered runs execute in base-repo context, so secrets are present
+# even when the comment is on a fork PR. The `if:` guard skips the job (and the
+# runner minutes) for every comment that does not clear both of its conditions.
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude:
+    # Comment-triggered workflows get no first-time-contributor approval screen:
+    # GitHub's "require approval for first-time contributors" setting only gates
+    # pull_request events from forks, and this job runs on comments. This gate is
+    # the equivalent — an outsider's @claude mention does not start the job, and
+    # a maintainer re-mentioning @claude IS the approval. The action itself also
+    # independently requires the commenter to have write access, so this is
+    # defense in depth, not the only line.
+    if: >-
+      contains(github.event.comment.body, '@claude') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: starsling-ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      # Actions are pinned to full commit SHAs, matching every other workflow in
+      # this repo: this job holds the API key and repo-write permissions, so a
+      # mutable tag would let an upstream retag run unreviewed code here.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+      # No github_token input on purpose: the action then authenticates its
+      # pushes as the Claude App, which lets CI trigger on Claude's commits.
+      - uses: anthropics/claude-code-action@e63208cb983318a44e3f945e959ef894b707dcfa # v1.0.192
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,15 +12,16 @@
 #      below to claude_code_oauth_token.
 #
 # Comment-triggered runs execute in base-repo context, so secrets are present
-# even when the comment is on a fork PR. The `if:` guard skips the job (and the
-# runner minutes) for every comment that does not clear both of its conditions,
-# and the action itself refuses to run for any commenter without write access to
-# this repo, so an outside commenter never reaches the secrets.
+# even when the comment is on a fork PR. The `if:` guard below is what keeps an
+# outsider away from them: it skips the job — and the runner minutes — for every
+# comment that does not clear both of its conditions, before anything starts. The
+# action ALSO refuses to proceed for a commenter without write access, but that
+# check runs inside the job, after the secrets are on the runner and the App
+# token has been minted, so it is a second line and not the boundary.
 #
 # Comment events always run the workflow file from the DEFAULT branch, so this
 # file does nothing until it merges — @claude cannot be smoke-tested on the PR
-# that adds it, and the action logs an expected "not found on default branch"
-# skip if you try.
+# that adds it. No run is created at all, so there is no log to inspect either.
 name: Claude Code
 
 on:
@@ -75,15 +76,19 @@ jobs:
     # GITHUB_TOKEN can do, not what Claude can do. Verified against the pinned
     # action: with no github_token input, its token setup takes the OIDC ->
     # app-token-exchange path and hands that App token to every write-capable
-    # tool it installs; the job's own GITHUB_TOKEN reaches the action only as
-    # DEFAULT_WORKFLOW_TOKEN, consumed by the read-only CI-status tool that needs
-    # the `actions: read` below. Dropping the three write grants would therefore
-    # silence a scanner finding without taking one capability away from a run a
-    # maintainer has already started. These grants match upstream's own published
-    # example workflow for this action, at the same pinned version. All of that
-    # describes the path where the App token exchange SUCCEEDS; if it ever fails
-    # (app uninstalled, OIDC unavailable) the action's fallback decides whether
-    # these three grants become live credentials rather than inert ones.
+    # tool it installs. Dropping the write grants would therefore silence a
+    # scanner finding without taking one of Claude's own capabilities away. These
+    # grants match upstream's published example for this action, at this pin.
+    #
+    # Two qualifications, so this does not read as a blanket "the block is inert".
+    # `contents: write` and `issues: write` are the inert ones. The job token also
+    # backs the action's fallback path for posting buffered inline review
+    # comments, so `pull-requests: write` is load-bearing — removing it would
+    # break a real feature, not just quiet a detector — and `actions: read` is
+    # equally real: the job token reaches the action as DEFAULT_WORKFLOW_TOKEN for
+    # its read-only CI-status tool. And all of this describes the path where the
+    # App token exchange SUCCEEDS; if it fails, the action raises and the step
+    # fails rather than quietly falling back to the job token.
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -58,7 +58,15 @@ jobs:
     # push as the app instead of as a maintainer. Removing it breaks the
     # workflow. Note that Claude's own write scope comes from that App token and
     # is fixed by the app, so trimming the grants below changes what this job's
-    # GITHUB_TOKEN can do, not what Claude can do.
+    # GITHUB_TOKEN can do, not what Claude can do. Verified against the pinned
+    # action: with no github_token input, its token setup takes the OIDC ->
+    # app-token-exchange path and hands that App token to every write-capable
+    # tool it installs; the job's own GITHUB_TOKEN reaches the action only as
+    # DEFAULT_WORKFLOW_TOKEN, consumed by the read-only CI-status tool that needs
+    # the `actions: read` below. Dropping the three write grants would therefore
+    # silence a scanner finding without taking one capability away from a run a
+    # maintainer has already started. These grants match upstream's own published
+    # example workflow for this action, at the same pinned version.
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,7 +13,14 @@
 #
 # Comment-triggered runs execute in base-repo context, so secrets are present
 # even when the comment is on a fork PR. The `if:` guard skips the job (and the
-# runner minutes) for every comment that does not clear both of its conditions.
+# runner minutes) for every comment that does not clear both of its conditions,
+# and the action itself refuses to run for any commenter without write access to
+# this repo, so an outside commenter never reaches the secrets.
+#
+# Comment events always run the workflow file from the DEFAULT branch, so this
+# file does nothing until it merges — @claude cannot be smoke-tested on the PR
+# that adds it, and the action logs an expected "not found on default branch"
+# skip if you try.
 name: Claude Code
 
 on:
@@ -35,6 +42,23 @@ jobs:
       contains(github.event.comment.body, '@claude') &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: starsling-ubuntu-24.04
+    # An agent turn has no natural bound, and a stalled one would otherwise hold
+    # a self-hosted runner for the six-hour GitHub default with no signal — the
+    # same reason registry-scan.yml sets a timeout.
+    timeout-minutes: 30
+    # One Claude at a time per issue/PR. Two mentions in quick succession would
+    # otherwise run two agents that both push to the same branch. Not
+    # cancel-in-progress: cancelling would kill a Claude mid-push and orphan the
+    # tracking comment it already posted.
+    concurrency:
+      group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: false
+    # id-token: write is required, not over-broad — the action exchanges the
+    # job's OIDC token for the Claude App installation token that lets Claude
+    # push as the app instead of as a maintainer. Removing it breaks the
+    # workflow. Note that Claude's own write scope comes from that App token and
+    # is fixed by the app, so trimming the grants below changes what this job's
+    # GITHUB_TOKEN can do, not what Claude can do.
     permissions:
       contents: write
       pull-requests: write
@@ -45,11 +69,17 @@ jobs:
       # Actions are pinned to full commit SHAs, matching every other workflow in
       # this repo: this job holds the API key and repo-write permissions, so a
       # mutable tag would let an upstream retag run unreviewed code here.
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
+          # Don't leave the job token in .git/config: Claude's own tools run
+          # inside this working tree. The action swaps in its App token for
+          # pushes regardless, so this costs nothing and closes the window.
+          persist-credentials: false
       # No github_token input on purpose: the action then authenticates its
       # pushes as the Claude App, which lets CI trigger on Claude's commits.
-      - uses: anthropics/claude-code-action@e63208cb983318a44e3f945e959ef894b707dcfa # v1.0.192
+      - name: Run Claude
+        uses: anthropics/claude-code-action@e63208cb983318a44e3f945e959ef894b707dcfa # v1.0.192
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,9 +35,23 @@ jobs:
     # GitHub's "require approval for first-time contributors" setting only gates
     # pull_request events from forks, and this job runs on comments. This gate is
     # the equivalent — an outsider's @claude mention does not start the job, and
-    # a maintainer re-mentioning @claude IS the approval. The action itself also
-    # independently requires the commenter to have write access, so this is
-    # defense in depth, not the only line.
+    # someone with standing re-mentioning @claude IS the approval. The action
+    # itself also independently requires the commenter to have write access, so
+    # this is defense in depth, not the only line.
+    #
+    # Be precise about what this allowlist admits: MEMBER is any starslingdev org
+    # member and COLLABORATOR is anyone invited to this repo at any level, so
+    # neither implies write access. A read-only org member can therefore burn a
+    # self-hosted runner slot with a mention, and the action's write-access check
+    # is what stops them — after the job starts, not before. That is the accepted
+    # trade: the alternative is an allowlist of usernames to maintain by hand.
+    #
+    # Note also what this gate does NOT cover. It approves the COMMENTER, never
+    # the content. A maintainer mentioning @claude on a fork PR starts a job that
+    # holds the App's write credentials and then reads fork-authored diff, PR
+    # body, and comments — attacker-controlled text on the privileged side of the
+    # boundary. That residue is the action's prompt handling to manage, and it is
+    # the reason to think before mentioning @claude on an outside contribution.
     if: >-
       contains(github.event.comment.body, '@claude') &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
@@ -66,7 +80,10 @@ jobs:
     # the `actions: read` below. Dropping the three write grants would therefore
     # silence a scanner finding without taking one capability away from a run a
     # maintainer has already started. These grants match upstream's own published
-    # example workflow for this action, at the same pinned version.
+    # example workflow for this action, at the same pinned version. All of that
+    # describes the path where the App token exchange SUCCEEDS; if it ever fails
+    # (app uninstalled, OIDC unavailable) the action's fallback decides whether
+    # these three grants become live credentials rather than inert ones.
     permissions:
       contents: write
       pull-requests: write

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -55,8 +55,6 @@ entries are dated (UTC). Format loosely follows
   titles for the identical defect; the pattern id, the severity and the fix
   anchor are unchanged, so anything keyed on those still matches.
 
-### Fixed
-
 - **2026-08-14** — **A single-star branch filter (`branches: ['*']`) no longer
   certifies a required check.** GitHub's filter glob `*` matches a run of
   characters that does NOT include a slash, so `feature/x`, `dependabot/…` and

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -11,6 +11,18 @@ entries are dated (UTC). Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- **2026-08-15** — **The blocking rule is now part of the skill, as three
+  independent names in `config.py`.** `BLOCKING_OUTCOMES` (which fact outcomes
+  fail a build), `KNOWN_OUTCOMES` (which are recognised at all) and
+  `OUTCOME_MARKS` (how each is displayed), plus `coverage_is_complete()`, which
+  says whether the three agree. None is derived from another — in particular
+  the first two are never computed from the display table, because that
+  coupling lets a cosmetic edit widen the set of accepted outcomes and ship a
+  new failure state as a pass. Anything running ci-secure as a CI gate imports
+  these instead of hardcoding a copy that can drift from the engine's.
+
 ### Changed
 
 - **2026-08-14** — **P14.24's rendered finding title is now "Unverified remote

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -23,6 +23,14 @@ entries are dated (UTC). Format loosely follows
   new failure state as a pass. Anything running ci-secure as a CI gate imports
   these instead of hardcoding a copy that can drift from the engine's.
 
+- **2026-08-15** — **`config.py` now owns the one definition of how a scanned
+  string is neutralized.** `flatten_scanned()` collapses whitespace, replaces
+  the backtick and escapes the pipe — the rule the report renderer already
+  applied, moved somewhere a stdlib-only CI gate can import it too. The
+  renderer delegates to it rather than keeping a copy: two copies of an
+  escaping rule eventually differ, and the surface with the weaker copy is the
+  one an attacker aims at.
+
 ### Changed
 
 - **2026-08-14** — **P14.24's rendered finding title is now "Unverified remote

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -31,7 +31,22 @@ entries are dated (UTC). Format loosely follows
   escaping rule eventually differ, and the surface with the weaker copy is the
   one an attacker aims at.
 
+### Fixed
+
+- **2026-08-15** — **The skill imports again on Python 3.9**, the floor
+  `pyproject.toml` declares. `config.py` was the only module under `scripts/`
+  without `from __future__ import annotations`, so the PEP 604 (`X | Y`)
+  annotations added alongside the outcome tables were evaluated at definition
+  time and raised `TypeError` on import — taking `scan.py`, `report.py` and any
+  CI gate down with it for every 3.9 user. Every workflow in this repository
+  pins 3.12, so CI could not see the break. A test now asserts the rule for
+  every module under `scripts/` rather than leaving it to habit.
+
 ### Changed
+
+- **2026-08-15** — **`__version__` / `VERSION` bumped to 0.2.0** for the
+  changes in this entry. The constant is stamped into the report's Scanner row,
+  so an installed skill carries it as its provenance marker.
 
 - **2026-08-14** — **P14.24's rendered finding title is now "Unverified remote
   code execution", not "Unverified remote script execution".** The entry covers

--- a/skills/ci-secure/scripts/config.py
+++ b/skills/ci-secure/scripts/config.py
@@ -11,7 +11,7 @@ from typing import Final
 # Skill version. Stamped into the report's Scanner row so an INSTALLED skill
 # (no .git checkout, so no commit sha to record) still carries a provenance
 # marker instead of a bare "(unknown)". Bump this on every shipped change.
-__version__: Final[str] = "0.1.0"
+__version__: Final[str] = "0.2.0"
 
 
 # Default log level resolved from STARSLING_LOG_LEVEL env var
@@ -140,7 +140,62 @@ def setup_logging(
 
 
 # =============================================================================
+# CONFIG-FACT OUTCOMES — the blocking rule
+# =============================================================================
+#
+# `config_facts.py` gives every check an OUTCOME. Three separate questions are
+# asked about one, and each gets its own name here, because collapsing any two
+# of them is how a new failure state ships green:
+#
+#   BLOCKING_OUTCOMES  which outcomes fail a build
+#   KNOWN_OUTCOMES     which outcomes anything here recognises at all
+#   OUTCOME_MARKS      how each one is displayed to a reader
+#
+# NONE of these is derived from another, and in particular the first two are
+# never computed from the third. Deriving the allowlist from the display table
+# reads as tidy and is a security hole: adding a display style for a new
+# outcome would silently widen the set of outcomes accepted as recognised, so
+# the "outcome I cannot classify" red never fires — while the new outcome is
+# still not in BLOCKING_OUTCOMES, so it does not fail either. A one-line
+# cosmetic edit would then be enough to ship a failure state as a pass.
+#
+# The CI gate (`.github/scripts/ci_secure_gate.py`) imports all three by name.
+# Adding an outcome to `config_facts.py` means editing all three deliberately;
+# the census test in `tests/test_ci_secure_gate_resolution.py` fails until you do.
+
+BLOCKING_OUTCOMES: Final[frozenset[str]] = frozenset({"fail"})
+
+KNOWN_OUTCOMES: Final[frozenset[str]] = frozenset({"pass", "fail", "unmeasured"})
+
+OUTCOME_MARKS: Final[dict[str, str]] = {
+    "pass": "PASS",
+    "fail": "**FAIL**",
+    "unmeasured": "UNMEASURED",
+}
+
+
+def coverage_is_complete(
+    blocking: frozenset[str] | set[str] = BLOCKING_OUTCOMES,
+    known: frozenset[str] | set[str] = KNOWN_OUTCOMES,
+    marks: dict[str, str] | None = None,
+) -> bool:
+    """True when the three tables above are mutually coherent.
+
+    Coherent means: everything that blocks is recognised, and everything
+    recognised can be displayed. It is NOT a claim about `config_facts.py` —
+    that the engine's actual vocabulary fits inside these tables is a census
+    the test suite runs against the source, since this module cannot import
+    the engine without dragging PyYAML into a stdlib-only gate.
+
+    The parameters exist so the predicate can be exercised against tables
+    other than the live ones; production callers pass nothing.
+    """
+    marks = OUTCOME_MARKS if marks is None else marks
+    return set(blocking) <= set(known) <= set(marks)
+
+
+# =============================================================================
 # VERSION
 # =============================================================================
 
-VERSION: Final[str] = "0.1.0"
+VERSION: Final[str] = "0.2.0"

--- a/skills/ci-secure/scripts/config.py
+++ b/skills/ci-secure/scripts/config.py
@@ -2,6 +2,14 @@
 
 Centralizes the constants used by gh_utils, scan, and report.
 """
+# Defers annotation evaluation, which is what makes PEP 604 (`X | Y`) safe on
+# Python 3.9 - the floor `pyproject.toml` declares. Without it, an annotation on
+# a parameter that carries a default is evaluated when the `def` runs, so 3.9
+# raises TypeError at IMPORT time and takes the whole scanner down with it. This
+# is an INSTALLED skill: it runs under whatever python3 a user has, while every
+# workflow here pins 3.12, so CI cannot catch that break for you. Every other
+# module under scripts/ carries this line for the same reason.
+from __future__ import annotations
 
 import logging
 import os

--- a/skills/ci-secure/scripts/config.py
+++ b/skills/ci-secure/scripts/config.py
@@ -194,6 +194,29 @@ def coverage_is_complete(
     return set(blocking) <= set(known) <= set(marks)
 
 
+def flatten_scanned(value: object) -> str:
+    """Flatten and neutralize an ATTACKER-CONTROLLED scanned string.
+
+    Everything ci-secure reports about is read out of the repository under
+    audit — workflow file names, job names, fact evidence — and on a fork pull
+    request an attacker writes all of it. Three characters carry structure in
+    the Markdown these values land in:
+
+      newline   starts a row the tool did not write, which can read as a pass
+      backtick  closes an inline code span (or a fence) early, so whatever
+                follows renders as live Markdown on the same line
+      pipe      splits a table row into phantom columns
+
+    Collapsing all whitespace kills the first, replacing the backtick kills the
+    second, escaping the pipe kills the third. This is the single definition of
+    that rule: the report renderer and the CI gate both use it, so a value that
+    is safe in one surface cannot be unsafe in the other.
+    """
+    if value is None:
+        return ""
+    return " ".join(str(value).split()).replace("`", "'").replace("|", "\\|")
+
+
 # =============================================================================
 # VERSION
 # =============================================================================

--- a/skills/ci-secure/scripts/config.py
+++ b/skills/ci-secure/scripts/config.py
@@ -3,12 +3,12 @@
 Centralizes the constants used by gh_utils, scan, and report.
 """
 # Defers annotation evaluation, which is what makes PEP 604 (`X | Y`) safe on
-# Python 3.9 - the floor `pyproject.toml` declares. Without it, an annotation on
-# a parameter that carries a default is evaluated when the `def` runs, so 3.9
-# raises TypeError at IMPORT time and takes the whole scanner down with it. This
-# is an INSTALLED skill: it runs under whatever python3 a user has, while every
-# workflow here pins 3.12, so CI cannot catch that break for you. Every other
-# module under scripts/ carries this line for the same reason.
+# Python 3.9 - the floor `pyproject.toml` declares. Without it, a parameter or
+# return annotation is evaluated when the `def` runs, so 3.9 raises TypeError at
+# IMPORT time and takes the whole scanner down with it. This is an INSTALLED
+# skill: it runs under whatever python3 a user has, while every workflow here
+# pins 3.12, so CI cannot catch that break for you. Every other module under
+# scripts/ carries this line for the same reason.
 from __future__ import annotations
 
 import logging

--- a/skills/ci-secure/scripts/report.py
+++ b/skills/ci-secure/scripts/report.py
@@ -59,6 +59,7 @@ from config import (  # noqa: E402
     ACTIVITY_RUN_LIMIT,
     DORMANT_DAYS,
     __version__ as SKILL_VERSION,
+    flatten_scanned as _flatten_rule,
     setup_logging,
 )
 
@@ -1647,11 +1648,13 @@ def _flatten_scanned(value: Any) -> str:
     heading/fence-break injection; replacing the backtick kills inline-code and
     fence-character breakout. Pipes are escaped too, so the result is also
     table-cell safe.
+
+    The rule itself lives in ``config.py`` so that the CI gate — which cannot
+    import this module, being stdlib-only — neutralizes scanned strings the
+    same way. Two copies of this rule would eventually differ, and the surface
+    with the weaker copy is the one an attacker would aim at.
     """
-    if value is None:
-        return ""
-    flat = " ".join(str(value).split())
-    return flat.replace("`", "'").replace("|", "\\|")
+    return _flatten_rule(value)
 
 
 def _fence_safe(text: str) -> str:

--- a/skills/ci-secure/tests/test_python_compat.py
+++ b/skills/ci-secure/tests/test_python_compat.py
@@ -1,0 +1,102 @@
+"""The skill must import on the oldest Python this repo says it supports.
+
+`pyproject.toml` declares `requires-python = ">=3.9"`, and ci-secure is a
+PUBLICLY INSTALLED skill: it runs against whatever `python3` an end user
+happens to have, not against the 3.12 every workflow in this repo pins. That
+asymmetry is the whole reason this file exists — CI cannot see the break,
+because CI never runs the version that breaks.
+
+The specific hazard is PEP 604 (`X | Y`) in an annotation that is EVALUATED at
+definition time. Annotations on a parameter that carries a default, and any
+annotation outside a `from __future__ import annotations` module, are evaluated
+when the `def` executes — so on 3.9 they raise `TypeError: unsupported operand
+type(s) for |` at IMPORT time and take the entire module down. Not a subtle
+degradation: `import config` fails, so `scan.py`, `report.py` and the CI gate
+all fail, for every 3.9 user, silently as far as this repo's CI is concerned.
+
+`from __future__ import annotations` defers annotation evaluation to a string,
+which makes PEP 604 safe on 3.9. Every other module under `scripts/` already
+carries it; this test makes that a rule instead of a habit.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _modules() -> list[Path]:
+    return sorted(p for p in SCRIPTS.glob("*.py"))
+
+
+def _has_future_annotations(tree: ast.Module) -> bool:
+    return any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "__future__"
+        and any(alias.name == "annotations" for alias in node.names)
+        for node in tree.body
+    )
+
+
+def _pep604_annotations(tree: ast.Module) -> list[str]:
+    """Every annotation in the module that uses a PEP 604 `X | Y` union."""
+    found: list[str] = []
+
+    def walk_annotation(annotation: ast.expr | None, where: str) -> None:
+        if annotation is None:
+            return
+        for node in ast.walk(annotation):
+            if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+                found.append(f"{where} (line {annotation.lineno})")
+                return
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            args = node.args
+            for arg in (*args.posonlyargs, *args.args, *args.kwonlyargs,
+                        args.vararg, args.kwarg):
+                if arg is not None:
+                    walk_annotation(arg.annotation, f"{node.name}({arg.arg})")
+            walk_annotation(node.returns, f"{node.name}() -> ...")
+        elif isinstance(node, ast.AnnAssign):
+            target = getattr(node.target, "id", "<target>")
+            walk_annotation(node.annotation, f"{target}")
+    return found
+
+
+@pytest.mark.parametrize("module", _modules(), ids=lambda p: p.name)
+def test_pep604_annotations_are_deferred(module: Path) -> None:
+    """A `X | Y` annotation without the future import breaks the skill on 3.9.
+
+    Red on the unfixed tree: `config.py` grew `frozenset[str] | set[str]` on a
+    parameter WITH a default, which 3.9 evaluates at `def` time and refuses.
+    """
+    tree = ast.parse(module.read_text(encoding="utf-8"))
+    unions = _pep604_annotations(tree)
+    if not unions:
+        return
+    assert _has_future_annotations(tree), (
+        f"{module.name} uses PEP 604 unions in {unions} but has no "
+        "`from __future__ import annotations`. On Python 3.9 — which "
+        "pyproject.toml declares as supported, and which an installed skill "
+        "may well run under — importing this module raises TypeError and "
+        "takes the whole scanner down. Every workflow here pins 3.12, so CI "
+        "cannot catch this for you."
+    )
+
+
+def test_the_guard_can_actually_fail(tmp_path: Path) -> None:
+    """The check above is not vacuous: it reds on a module shaped like the bug."""
+    broken = ast.parse("def f(x: int | None = None) -> None: ...\n")
+    assert _pep604_annotations(broken)
+    assert not _has_future_annotations(broken)
+
+    fixed = ast.parse(
+        "from __future__ import annotations\n"
+        "def f(x: int | None = None) -> None: ...\n"
+    )
+    assert _pep604_annotations(fixed)
+    assert _has_future_annotations(fixed)

--- a/skills/ci-secure/tests/test_python_compat.py
+++ b/skills/ci-secure/tests/test_python_compat.py
@@ -6,17 +6,22 @@ happens to have, not against the 3.12 every workflow in this repo pins. That
 asymmetry is the whole reason this file exists — CI cannot see the break,
 because CI never runs the version that breaks.
 
-The specific hazard is PEP 604 (`X | Y`) in an annotation that is EVALUATED at
-definition time. Annotations on a parameter that carries a default, and any
-annotation outside a `from __future__ import annotations` module, are evaluated
-when the `def` executes — so on 3.9 they raise `TypeError: unsupported operand
-type(s) for |` at IMPORT time and take the entire module down. Not a subtle
-degradation: `import config` fails, so `scan.py`, `report.py` and the CI gate
-all fail, for every 3.9 user, silently as far as this repo's CI is concerned.
+Two hazards, and they need different guards.
 
-`from __future__ import annotations` defers annotation evaluation to a string,
-which makes PEP 604 safe on 3.9. Every other module under `scripts/` already
-carries it; this test makes that a rule instead of a habit.
+1. PEP 604 (`X | Y`) in an ANNOTATION. Parameter and return annotations are
+   evaluated when the `def` executes, so on 3.9 they raise `TypeError:
+   unsupported operand type(s) for |` at IMPORT time and take the whole module
+   down. `from __future__ import annotations` defers them to strings, which
+   makes the syntax safe — so for this hazard the future import IS the fix.
+
+2. Anything 3.9 cannot even PARSE (`match` statements, and PEP 604 outside an
+   annotation — a type alias, an `isinstance` argument — where the future
+   import does not help because the expression is evaluated for real). Only
+   compiling against 3.9's grammar catches these.
+
+Not a subtle degradation either way: `import config` fails, so `scan.py`,
+`report.py` and the CI gate all fail together, for every 3.9 user, and silently
+as far as this repository's CI is concerned — every workflow here pins 3.12.
 """
 from __future__ import annotations
 
@@ -71,8 +76,8 @@ def _pep604_annotations(tree: ast.Module) -> list[str]:
 def test_pep604_annotations_are_deferred(module: Path) -> None:
     """A `X | Y` annotation without the future import breaks the skill on 3.9.
 
-    Red on the unfixed tree: `config.py` grew `frozenset[str] | set[str]` on a
-    parameter WITH a default, which 3.9 evaluates at `def` time and refuses.
+    Red on the unfixed tree: `config.py` grew `frozenset[str] | set[str]`
+    parameter annotations, which 3.9 evaluates at `def` time and refuses.
     """
     tree = ast.parse(module.read_text(encoding="utf-8"))
     unions = _pep604_annotations(tree)
@@ -86,6 +91,35 @@ def test_pep604_annotations_are_deferred(module: Path) -> None:
         "takes the whole scanner down. Every workflow here pins 3.12, so CI "
         "cannot catch this for you."
     )
+
+
+@pytest.mark.parametrize("module", _modules(), ids=lambda p: p.name)
+def test_the_module_parses_under_the_oldest_supported_grammar(module: Path) -> None:
+    """Syntax 3.9 cannot compile at all, which no future import can defer.
+
+    `feature_version` makes CPython's own parser refuse anything newer than the
+    target, so this covers `match` statements and every other post-3.9 form in
+    one line — including the PEP 604 unions that live OUTSIDE an annotation
+    (a module-level type alias, an `isinstance` argument), where the future
+    import genuinely does not help because the expression is evaluated for real.
+    """
+    try:
+        ast.parse(module.read_text(encoding="utf-8"), feature_version=(3, 9))
+    except SyntaxError as exc:
+        raise AssertionError(
+            f"{module.name} uses syntax Python 3.9 cannot parse (line "
+            f"{exc.lineno}): {exc.msg}. pyproject.toml declares 3.9 as the "
+            "floor, and this is an installed skill — CI pins 3.12 and cannot "
+            "catch this for you."
+        ) from None
+
+
+def test_the_grammar_guard_can_actually_fail() -> None:
+    """The 3.9 parse check is not a no-op that accepts everything."""
+    newer = "def f(v):\n    match v:\n        case 1:\n            return 2\n"
+    ast.parse(newer)                                   # fine on this interpreter
+    with pytest.raises(SyntaxError):
+        ast.parse(newer, feature_version=(3, 9))
 
 
 def test_the_guard_can_actually_fail(tmp_path: Path) -> None:

--- a/skills/ci-secure/tests/test_report.py
+++ b/skills/ci-secure/tests/test_report.py
@@ -2296,7 +2296,12 @@ def test_the_renderer_does_not_keep_its_own_copy_of_the_rule() -> None:
             f"the renderer and the gate disagree about {probe!r}; the rule has "
             "been copied instead of shared")
 
-    body = inspect.getsource(report._flatten_scanned)
-    assert "replace" not in body, (
-        "report._flatten_scanned has re-inlined the escaping rule instead of "
-        "delegating to config.flatten_scanned")
+    # Either it IS the shared rule, or its body calls it. Asserting the
+    # absence of `replace` was both evadable (a re-inline via `translate` or
+    # `re.sub` passed) and prone to a false red (a direct alias makes
+    # `getsource` return config's own body, which contains `replace`).
+    if report._flatten_scanned is not config.flatten_scanned:
+        body = inspect.getsource(report._flatten_scanned)
+        assert "_flatten_rule" in body or "config.flatten_scanned" in body, (
+            "report._flatten_scanned has re-inlined the escaping rule instead "
+            f"of delegating to config.flatten_scanned:\n{body}")

--- a/skills/ci-secure/tests/test_report.py
+++ b/skills/ci-secure/tests/test_report.py
@@ -2250,3 +2250,53 @@ def test_a_pin_suppression_alone_leaves_the_report_complete():
     as the fix recipe says gets no banner and no incomplete-coverage flag."""
     assert report._coverage_is_complete([], [], []) is True
     assert report._coverage_gap_banner([], [], []) == ""
+
+
+# ---------------------------------------------------------------------------
+# The renderer half of the shared neutralization rule
+# ---------------------------------------------------------------------------
+# `flatten_scanned` moved into config.py so the stdlib-only CI gate and this
+# renderer neutralize scanned strings identically — "two copies of an escaping
+# rule eventually differ, and the surface with the weaker copy is the one an
+# attacker aims at." The gate's half is covered by tests/test_ci_secure_gate.py.
+# This half had no coverage at all, so re-inlining a WEAKER rule here — the
+# precise drift the refactor exists to prevent — was green across the whole
+# repository suite.
+
+def test_the_renderer_neutralizes_scanned_strings_via_the_shared_rule() -> None:
+    """Newline, backtick and pipe all lose their structural meaning."""
+    hostile = "a`b|c\nd  e"
+    flat = report._flatten_scanned(hostile)
+
+    assert "\n" not in flat, "a newline lets a scanned name start a row of its own"
+    assert "`" not in flat, "a backtick closes the inline code span this lands in"
+    assert "|" not in flat.replace("\\|", ""), "an unescaped pipe forges a table column"
+    assert flat == "a'b\\|c d e"
+
+
+def test_the_renderer_does_not_keep_its_own_copy_of_the_rule() -> None:
+    """It must DELEGATE, so the two surfaces cannot drift apart.
+
+    Asserting on behaviour alone would let a re-inlined identical copy pass and
+    then rot independently. This asserts the single definition itself.
+    """
+    import inspect
+
+    sys.path.insert(0, _SCRIPTS)
+    try:
+        import config  # noqa: PLC0415
+    finally:
+        try:
+            sys.path.remove(_SCRIPTS)
+        except ValueError:
+            pass
+
+    for probe in ("x`y|z\n w", "", "  ", "a\tb", None, 12, "ünïcode`|"):
+        assert report._flatten_scanned(probe) == config.flatten_scanned(probe), (
+            f"the renderer and the gate disagree about {probe!r}; the rule has "
+            "been copied instead of shared")
+
+    body = inspect.getsource(report._flatten_scanned)
+    assert "replace" not in body, (
+        "report._flatten_scanned has re-inlined the escaping rule instead of "
+        "delegating to config.flatten_scanned")

--- a/tests/test_ci_secure_gate.py
+++ b/tests/test_ci_secure_gate.py
@@ -863,3 +863,33 @@ def test_every_failure_reason_is_reported_not_just_the_first(tmp_path: Path) -> 
     assert "no workflow files were scanned" in proc.stdout
     assert "scan incomplete" in proc.stdout
     assert "ci-secure fact failed: sec.actions.pinned" in proc.stdout
+
+
+def test_a_rule_that_exits_cleanly_on_load_cannot_forge_a_pass(tmp_path: Path) -> None:
+    """`sys.exit(0)` in a rule file must not become a green gate.
+
+    This is why the handler around the config load catches `BaseException` and
+    not `Exception`: `SystemExit` inherits from the former, so a `config.py`
+    whose module body calls `sys.exit(0)` used to end the gate process right
+    there — before any scan, with exit status 0 and no output at all. A scan
+    that never ran, reported as a pass, which is the one outcome this whole
+    file exists to make impossible.
+
+    Loading the rule EXECUTES it, and in a vendored layout that file sits
+    beside the engine rather than in this tree, so this is reachable by anyone
+    who can write there. Narrowing the clause to `Exception` — a natural-looking
+    tidy-up — brings the forged pass straight back.
+    """
+    engine_dir = tmp_path / "vendored_exit"
+    engine_dir.mkdir()
+    (engine_dir / "config.py").write_text(
+        "import sys\nsys.exit(0)\n", encoding="utf-8")
+    engine = engine_dir / "scan.py"
+    engine.write_text("import sys\nsys.stdout.write('{}')\n", encoding="utf-8")
+
+    proc = run_scan(tmp_path, _CLEAN, engine=str(engine))
+
+    assert proc.returncode == 1, (
+        "a rule file that called sys.exit(0) produced a GREEN gate with no scan")
+    assert "::error::" in proc.stdout, "the forged pass was turned red with no stated cause"
+    assert "could not be loaded" in proc.stdout

--- a/tests/test_ci_secure_gate.py
+++ b/tests/test_ci_secure_gate.py
@@ -446,6 +446,56 @@ def _engine_argv(tmp_path: Path, env_extra: dict[str, str] | None = None):
     return proc
 
 
+def test_the_summary_header_is_escaped_like_every_other_row(tmp_path: Path) -> None:
+    """The headline interpolates engine fields too, and they are not trustworthy.
+
+    On a fork pull request the engine IS attacker code, so the counts it
+    reports are attacker-chosen strings, not integers. The header was the one
+    line where that was easy to forget — it renders numbers, and numbers feel
+    safe — but a newline in `passed` starts a row of its own, above every real
+    result, where a reader is most likely to stop.
+    """
+    scan = _scan()
+    scan["security_score"].update(passed="2\n- PASS `everything is fine`")
+    scan["security_score"]["facts"][0].update(outcome="fail")
+
+    proc = run_scan(tmp_path, scan)
+
+    assert proc.returncode == 1
+    # Anchored at the START of a line, not compared whole: the payload lands
+    # mid-sentence, with the rest of the header trailing after it, so an
+    # equality check would pass while the forged row rendered perfectly well.
+    forged = [ln for ln in proc.summary.splitlines()
+              if ln.strip().startswith("- PASS `everything is fine`")]
+    assert not forged, (
+        f"the header forged a summary row above the real results:\n{proc.summary}")
+
+
+def test_a_summary_that_cannot_be_written_still_leaves_a_verdict(tmp_path: Path) -> None:
+    """The verdict is emitted BEFORE the summary, so a cosmetic sink cannot eat it.
+
+    GITHUB_STEP_SUMMARY is a file GitHub provisions and occasionally cannot be
+    written. If the summary were written first, an OSError there would take the
+    whole failure list down with it and the operator would get a traceback
+    about a summary file instead of the security failure that caused the red.
+    The build still fails either way — but "the gate went red for an unstated
+    reason" is how a real finding gets waved through as flakiness.
+    """
+    scan = _scan()
+    scan["security_score"]["facts"][0].update(
+        outcome="fail", evidence="no CODEOWNERS entry covers .github/")
+
+    # A directory where a file is expected: writing to it raises OSError.
+    unwritable = tmp_path / "summary_dir"
+    unwritable.mkdir()
+    proc = run_scan(tmp_path, scan, env_extra={"GITHUB_STEP_SUMMARY": str(unwritable)})
+
+    assert proc.returncode == 1
+    assert "::error::ci-secure fact failed: sec.codeowners.workflows" in proc.stdout, (
+        "the verdict was lost when the summary could not be written")
+    assert "could not write the job summary" in proc.stdout
+
+
 def test_the_scan_root_defaults_to_the_gates_own_tree_off_actions(tmp_path: Path) -> None:
     """With no GITHUB_WORKSPACE, the scan root is the repository the gate is in.
 

--- a/tests/test_ci_secure_gate.py
+++ b/tests/test_ci_secure_gate.py
@@ -1,0 +1,246 @@
+"""The gate's verdict rule, exercised against every shape the engine can return.
+
+`.github/scripts/ci_secure_gate.py` is the only thing standing between "the scan
+process exited 0" and "this repo passed its security scan", and those are very
+different claims. The engine is deliberately crash-tolerant: its config-facts
+layer is wrapped in a catch-all that returns an empty `facts` list with a null
+score rather than killing the scan, and a scan with incomplete coverage still
+exits 0. An empty list of facts contains no failures, so the naive reading of the
+engine's output turns "the scoring layer crashed" into "0/0 facts pass" and ships
+it green — a scan that measured nothing, reported as clean.
+
+Every test below drives the real gate script as a subprocess against a stub
+engine (via `CI_SECURE_ENGINE`), because the gate's contract IS its exit code.
+The stub lets us produce shapes the real engine only reaches when something has
+gone wrong, which is exactly where a gate earns its keep.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+_GATE = _REPO / ".github" / "scripts" / "ci_secure_gate.py"
+
+# A scan of a repo with nothing wrong with it: the only shape that may exit 0.
+_CLEAN = {
+    "scanned_workflows": 3,
+    "findings": [],
+    "scan_incomplete": [],
+    "gh_checks": {"P14.11": "skipped: disabled via --gh-impostor=off"},
+    "security_score": {
+        "facts": [
+            {"fact_id": "sec.codeowners.workflows", "outcome": "pass",
+             "evidence": "CODEOWNERS covers .github/"},
+            {"fact_id": "sec.actions.pinned", "outcome": "pass",
+             "evidence": "every action is pinned to a commit SHA"},
+        ],
+        "score": 100, "passed": 2, "scored_count": 2,
+        "applicable_count": 2, "unmeasured": [],
+    },
+}
+
+
+def _scan(**overrides) -> dict:
+    """A copy of the clean scan with top-level keys replaced."""
+    scan = json.loads(json.dumps(_CLEAN))
+    for key, value in overrides.items():
+        if key == "security_score":
+            scan["security_score"].update(value)
+        else:
+            scan[key] = value
+    return scan
+
+
+def run_gate(tmp_path: Path, *, stdout: str, returncode: int = 0, engine: str | None = None):
+    """Run the real gate against a stub engine that prints `stdout` and exits `returncode`."""
+    stub = tmp_path / "stub_engine.py"
+    stub.write_text(
+        "import sys\n"
+        f"sys.stdout.write({stdout!r})\n"
+        f"sys.exit({returncode})\n",
+        encoding="utf-8",
+    )
+    summary = tmp_path / "summary.md"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(exist_ok=True)
+
+    proc = subprocess.run(
+        [sys.executable, str(_GATE)],
+        capture_output=True, text=True,
+        env={
+            "PATH": "/usr/bin:/bin",
+            "GITHUB_WORKSPACE": str(workspace),
+            "CI_SECURE_ENGINE": engine if engine is not None else str(stub),
+            "GITHUB_STEP_SUMMARY": str(summary),
+        },
+    )
+    proc.summary = summary.read_text(encoding="utf-8") if summary.exists() else ""
+    return proc
+
+
+def run_scan(tmp_path: Path, scan: dict, **kwargs):
+    return run_gate(tmp_path, stdout=json.dumps(scan), **kwargs)
+
+
+# --------------------------------------------------------------------------
+# The one green path
+# --------------------------------------------------------------------------
+
+def test_a_clean_scan_passes(tmp_path: Path) -> None:
+    proc = run_scan(tmp_path, _CLEAN)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "::error::" not in proc.stdout
+    assert "sec.actions.pinned" in proc.summary, "the summary must show what was checked"
+    assert "P14.11" in proc.summary, (
+        "a detector that did not run must be reported: 'no findings from it' and "
+        "'it never ran' cannot look the same to a reader"
+    )
+
+
+# --------------------------------------------------------------------------
+# Real failures
+# --------------------------------------------------------------------------
+
+def test_a_failed_fact_is_red_and_named(tmp_path: Path) -> None:
+    scan = _scan()
+    scan["security_score"]["facts"][0].update(
+        outcome="fail", evidence="no CODEOWNERS entry covers .github/")
+    scan["security_score"].update(score=50, passed=1)
+    proc = run_scan(tmp_path, scan)
+    assert proc.returncode == 1
+    assert "::error::ci-secure fact failed: sec.codeowners.workflows" in proc.stdout
+    assert "**FAIL**" in proc.summary
+
+
+def test_incomplete_coverage_is_red(tmp_path: Path) -> None:
+    """A workflow the engine could not read is a false negative, not a pass."""
+    proc = run_scan(tmp_path, _scan(scan_incomplete=[
+        {"workflow_file": ".github/workflows/x.yml", "reason": "unparseable YAML"}]))
+    assert proc.returncode == 1
+    assert "scan incomplete" in proc.stdout
+
+
+# --------------------------------------------------------------------------
+# Degraded shapes: the engine exits 0, but there is no verdict in what it said
+# --------------------------------------------------------------------------
+
+def test_engine_crash_is_red(tmp_path: Path) -> None:
+    proc = run_gate(tmp_path, stdout="", returncode=2)
+    assert proc.returncode == 1
+    assert "engine failed to run" in proc.stdout
+
+
+def test_a_missing_engine_is_red_and_names_the_path(tmp_path: Path) -> None:
+    """The portability escape hatch must not turn a typo into a silent pass."""
+    missing = tmp_path / "nowhere" / "scan.py"
+    proc = run_gate(tmp_path, stdout="", engine=str(missing))
+    assert proc.returncode == 1
+    assert "engine not found" in proc.stdout and str(missing) in proc.stdout
+
+
+@pytest.mark.parametrize("payload", ["", "not json at all", "null", "[]", "{}"])
+def test_unreadable_output_is_red(tmp_path: Path, payload: str) -> None:
+    proc = run_gate(tmp_path, stdout=payload)
+    assert proc.returncode == 1, f"{payload!r} exited {proc.returncode}"
+    assert "no readable verdict" in proc.stdout
+
+
+@pytest.mark.parametrize("missing_key", ["findings", "scan_incomplete"])
+def test_a_dropped_schema_key_is_red_not_assumed_empty(tmp_path: Path, missing_key: str) -> None:
+    """If the engine stops reporting coverage gaps, the gate must not read that as zero gaps."""
+    scan = _scan()
+    del scan[missing_key]
+    proc = run_scan(tmp_path, scan)
+    assert proc.returncode == 1
+    assert "no readable verdict" in proc.stdout
+
+
+def test_the_facts_layer_degrading_to_empty_is_red(tmp_path: Path) -> None:
+    """The engine's own catch-all shape: facts=[], score=None, still exit 0.
+
+    This is the headline case. Nothing here is a "fail", so a gate that only
+    looks for failures reports `0/0 facts pass` and goes green on a scan that
+    measured nothing.
+    """
+    proc = run_scan(tmp_path, _scan(security_score={
+        "facts": [], "score": None, "passed": 0, "scored_count": 0,
+        "applicable_count": 0, "unmeasured": [],
+        "reason": "config-facts layer failed: ImportError(...)",
+    }))
+    assert proc.returncode == 1
+    assert "no usable verdict" in proc.stdout
+    assert "config-facts layer failed" in proc.stdout, "the engine's own reason must reach the log"
+
+
+def test_scanning_nothing_is_red(tmp_path: Path) -> None:
+    """Zero workflow files scanned is an unpointed gate, not a clean repo."""
+    proc = run_scan(tmp_path, _scan(scanned_workflows=0))
+    assert proc.returncode == 1
+    assert "no workflow files were scanned" in proc.stdout
+
+
+def test_a_null_score_is_red(tmp_path: Path) -> None:
+    proc = run_scan(tmp_path, _scan(security_score={"score": None}))
+    assert proc.returncode == 1
+    assert "no usable verdict" in proc.stdout
+
+
+def test_an_unrecognised_outcome_is_red(tmp_path: Path) -> None:
+    """A new outcome the gate has never seen must not be bucketed as "not a fail".
+
+    Treating unknown values as passing is how a future engine release that adds,
+    say, an "error" outcome would ship silently green.
+    """
+    scan = _scan()
+    scan["security_score"]["facts"][0]["outcome"] = "error"
+    proc = run_scan(tmp_path, scan)
+    assert proc.returncode == 1
+    assert "unrecognised fact outcome" in proc.stdout
+    assert "**ERROR**" in proc.summary, (
+        "the summary a human reads must not disagree with the exit code: an unknown "
+        "outcome may not be rendered as PASS"
+    )
+
+
+# --------------------------------------------------------------------------
+# Loud but non-blocking
+# --------------------------------------------------------------------------
+
+def test_findings_warn_without_blocking(tmp_path: Path) -> None:
+    """Severity-rated findings are accepted decisions, but never silent ones."""
+    proc = run_scan(tmp_path, _scan(findings=[{
+        "severity": "MEDIUM", "pattern": "P14.18", "title": "write token on comment trigger",
+        "workflow_file": ".github/workflows/claude.yml", "line": 62}]))
+    assert proc.returncode == 0, proc.stdout
+    assert "::warning file=.github/workflows/claude.yml,line=62::" in proc.stdout
+    assert "P14.18" in proc.summary
+
+
+def test_an_unmeasured_fact_warns_without_blocking(tmp_path: Path) -> None:
+    """Unmeasured is neither a pass nor a fail, and must render as neither."""
+    scan = _scan()
+    scan["security_score"]["facts"][0].update(
+        outcome="unmeasured", evidence="no CODEOWNERS file to evaluate")
+    scan["security_score"].update(scored_count=1, passed=1, score=100)
+    proc = run_scan(tmp_path, scan)
+    assert proc.returncode == 0, proc.stdout
+    assert "::warning::ci-secure fact unmeasured: sec.codeowners.workflows" in proc.stdout
+    assert "UNMEASURED `sec.codeowners.workflows`" in proc.summary
+    assert "PASS `sec.codeowners.workflows`" not in proc.summary
+
+
+def test_every_failure_reason_is_reported_not_just_the_first(tmp_path: Path) -> None:
+    """A red build must list all of its causes, so one fix does not reveal the next."""
+    scan = _scan(scanned_workflows=0, scan_incomplete=[
+        {"workflow_file": "a.yml", "reason": "unreadable"}])
+    scan["security_score"]["facts"][1].update(outcome="fail", evidence="an unpinned action")
+    proc = run_scan(tmp_path, scan)
+    assert proc.returncode == 1
+    assert "no workflow files were scanned" in proc.stdout
+    assert "scan incomplete" in proc.stdout
+    assert "ci-secure fact failed: sec.actions.pinned" in proc.stdout

--- a/tests/test_ci_secure_gate.py
+++ b/tests/test_ci_secure_gate.py
@@ -403,9 +403,96 @@ def test_a_crafted_filename_cannot_break_out_of_the_summary(tmp_path: Path) -> N
     # gate did not author exists at all.
     forged = [ln for ln in proc.summary.splitlines() if ln.strip() == "- PASS `all good`"]
     assert not forged, "a crafted filename rendered its own summary row"
-    assert any("evil - PASS `all good` foo.yml" in ln for ln in proc.summary.splitlines()), (
+    # The backticks in the payload are neutralized as well as flattened: they
+    # would otherwise close the code span the gate wraps values in, which is a
+    # second breakout that needs no newline at all.
+    assert any("evil - PASS 'all good' foo.yml" in ln for ln in proc.summary.splitlines()), (
         "the filename should still be readable in the row the gate wrote, just flattened"
     )
+
+
+def test_the_summary_reports_counts_and_never_the_bare_aggregate(tmp_path: Path) -> None:
+    """The CI surface obeys the same rule as the report: no bare score.
+
+    `config_facts.py` registers the aggregate as machine-only — it exists so
+    the scores of several engines can be blended, and the report renderer is
+    forbidden from showing it, because a single number invites a reader to
+    manage the number instead of the findings. "94" says nothing about which
+    check failed; "13/14 facts pass of 14 applicable" says what to go fix.
+
+    The gate is a second reader-facing surface and was quietly exempt. The
+    assertion keys on the rendered CONSTRUCT rather than the digits: a bare
+    numeral collides with line numbers and byte counts that legitimately
+    appear in evidence text, so it could never fail honestly.
+    """
+    proc = run_scan(tmp_path, _CLEAN)
+
+    assert proc.returncode == 0
+    assert "score: **" not in proc.summary, (
+        "the machine-only aggregate is rendered on the CI surface")
+    assert "score: **" not in proc.stdout, (
+        "the summary is printed to the step log as well as written to the "
+        "summary file; the ban has to hold on both")
+    assert "2/2 facts pass of 2 applicable" in proc.summary, (
+        "dropping the number must not drop the counts that replace it")
+    assert "3 workflow file(s) scanned" in proc.summary
+
+
+def test_a_backtick_cannot_break_out_of_an_inline_code_span(tmp_path: Path) -> None:
+    """Flattening newlines is not enough: the backtick is its own breakout.
+
+    Three summary sinks wrap a value in an inline code span — the fact id, the
+    finding's pattern, the network-detector name. A value carrying a backtick
+    closes that span early and renders whatever follows as live Markdown, on
+    the SAME line, which the newline-flattening rule never touches. The forgery
+    that matters is a row reading like a passing check the gate did not write,
+    on a run that is going red.
+    """
+    scan = _scan()
+    scan["security_score"]["facts"][0].update(
+        fact_id="sec.a` — **PASS** `sec.b",
+        outcome="fail",
+        evidence="`` broken out ``")
+    scan["gh_checks"] = {"P14.11` — **ran** `x": "skipped"}
+    scan["findings"] = [{"severity": "LOW", "pattern": "P1` — **clean** `P2",
+                         "title": "t", "workflow_file": "w.yml", "line": 1}]
+
+    proc = run_scan(tmp_path, scan)
+
+    assert proc.returncode == 1
+
+    # The invariant is span integrity, not the absence of the payload's text:
+    # inside a code span `**PASS**` renders as those nine literal characters,
+    # which is honest. It is the ESCAPE from the span that turns it into a
+    # forged verdict, and an unbalanced backtick count is exactly that escape.
+    for line in proc.summary.splitlines():
+        assert line.count("`") % 2 == 0, (
+            f"an odd number of backticks leaves a code span open: {line!r}")
+
+    # Every crafted value keeps its own backticks neutralized, so none of them
+    # can close the span the gate opened around it.
+    assert "`sec.a' — **PASS** 'sec.b`" in proc.summary
+    assert "`P1' — **clean** 'P2`" in proc.summary
+    assert "`P14.11' — **ran** 'x`" in proc.summary
+
+
+def test_a_pipe_cannot_forge_table_columns(tmp_path: Path) -> None:
+    """The same values are copied into contexts where `|` splits a row.
+
+    The gate's summary is a list today, but these values come from the same
+    flattening rule the report's tables use, and a summary that grows a table
+    later must not quietly reopen this. Escaping where the untrusted value
+    enters keeps the guarantee independent of where it lands.
+    """
+    scan = _scan()
+    scan["security_score"]["facts"][0].update(
+        fact_id="sec.a|b", outcome="fail", evidence="ev|il")
+
+    proc = run_scan(tmp_path, scan)
+
+    assert proc.returncode == 1
+    assert "sec.a\\|b" in proc.summary, "an unescaped pipe can split a row"
+    assert "ev\\|il" in proc.summary
 
 
 GITHUB_SUMMARY_LIMIT_BYTES = 1024 * 1024  # 1 MiB, GitHub's documented cap

--- a/tests/test_ci_secure_gate.py
+++ b/tests/test_ci_secure_gate.py
@@ -57,7 +57,8 @@ def _scan(**overrides) -> dict:
     return scan
 
 
-def run_gate(tmp_path: Path, *, stdout: str, returncode: int = 0, engine: str | None = None):
+def run_gate(tmp_path: Path, *, stdout: str, returncode: int = 0,
+             engine: str | None = None, env_extra: dict[str, str] | None = None):
     """Run the real gate against a stub engine that prints `stdout` and exits `returncode`."""
     stub = tmp_path / "stub_engine.py"
     stub.write_text(
@@ -70,15 +71,16 @@ def run_gate(tmp_path: Path, *, stdout: str, returncode: int = 0, engine: str | 
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
 
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "GITHUB_WORKSPACE": str(workspace),
+        "CI_SECURE_ENGINE": engine if engine is not None else str(stub),
+        "GITHUB_STEP_SUMMARY": str(summary),
+    }
+    env.update(env_extra or {})
     proc = subprocess.run(
         [sys.executable, str(_GATE)],
-        capture_output=True, text=True,
-        env={
-            "PATH": "/usr/bin:/bin",
-            "GITHUB_WORKSPACE": str(workspace),
-            "CI_SECURE_ENGINE": engine if engine is not None else str(stub),
-            "GITHUB_STEP_SUMMARY": str(summary),
-        },
+        capture_output=True, text=True, env=env,
     )
     proc.summary = summary.read_text(encoding="utf-8") if summary.exists() else ""
     return proc
@@ -328,11 +330,14 @@ def test_a_crafted_filename_cannot_emit_its_own_workflow_commands(
     # invariant is per-line. Counting, not prefix-matching: a forged `::error::`
     # would satisfy "starts with ::error", so the assertion has to be that the
     # gate emitted EXACTLY the commands it meant to — one warning for the one
-    # finding, one error for the one failed fact — and nothing else.
+    # finding, one warning for the network-gated check this fixture reports as
+    # incomplete, one error for the one failed fact — and nothing else.
     emitted = [ln.strip() for ln in (proc.stdout + proc.stderr).splitlines()
                if ln.strip().startswith("::")]
-    assert len(emitted) == 2, f"expected exactly 2 workflow commands, got {emitted}"
+    assert len(emitted) == 3, f"expected exactly 3 workflow commands, got {emitted}"
     assert sum(ln.startswith("::warning file=") for ln in emitted) == 1
+    assert sum(ln.startswith("::warning::ci-secure network-gated check")
+               for ln in emitted) == 1
     assert sum(ln.startswith("::error::ci-secure fact failed") for ln in emitted) == 1
     # Escaped rather than dropped: the payload survives mid-line, percent-encoded,
     # so the evidence a reviewer needs is still legible.
@@ -409,6 +414,139 @@ def test_a_crafted_filename_cannot_break_out_of_the_summary(tmp_path: Path) -> N
     assert any("evil - PASS 'all good' foo.yml" in ln for ln in proc.summary.splitlines()), (
         "the filename should still be readable in the row the gate wrote, just flattened"
     )
+
+
+# --------------------------------------------------------------------------
+# The network-gated check: on or off, never "whatever the runner happened to have"
+# --------------------------------------------------------------------------
+
+def _engine_argv(tmp_path: Path, env_extra: dict[str, str] | None = None):
+    """Run a stub engine that reports the argv the gate invoked it with."""
+    stub = tmp_path / "argv_engine.py"
+    argv_file = tmp_path / "argv.json"
+    # Written to a file, not to stderr: the gate captures the engine's stderr
+    # and only echoes it on a failing run, so a stub that reported there would
+    # be invisible on exactly the green path this asserts about.
+    stub.write_text(
+        "import json, sys\n"
+        f"open({str(argv_file)!r}, 'w').write(json.dumps(sys.argv[1:]))\n"
+        f"sys.stdout.write({json.dumps(_CLEAN)!r})\n",
+        encoding="utf-8")
+    summary = tmp_path / "summary.md"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(exist_ok=True)
+    env = {"PATH": "/usr/bin:/bin", "GITHUB_WORKSPACE": str(workspace),
+           "CI_SECURE_ENGINE": str(stub), "GITHUB_STEP_SUMMARY": str(summary)}
+    env.update(env_extra or {})
+    proc = subprocess.run([sys.executable, str(_GATE)],
+                          capture_output=True, text=True, env=env)
+    proc.summary = summary.read_text(encoding="utf-8") if summary.exists() else ""
+    proc.argv = (json.loads(argv_file.read_text(encoding="utf-8"))
+                 if argv_file.exists() else [])
+    return proc
+
+
+def test_the_scan_root_defaults_to_the_gates_own_tree_off_actions(tmp_path: Path) -> None:
+    """With no GITHUB_WORKSPACE, the scan root is the repository the gate is in.
+
+    Two paths matter and only one of them is exercised by CI. Under Actions
+    GITHUB_WORKSPACE is always set, so the fallback is the path a maintainer
+    hits running the gate by hand — and if it resolved to the wrong directory
+    the engine would scan a tree with no workflows in it, which the gate calls
+    "no workflow files were scanned" and reds. Silent, confusing, and only
+    reachable off CI, which is exactly why it is pinned here.
+
+    The scan root is also the ONLY thing GITHUB_WORKSPACE may decide. The
+    engine and the rule are resolved from the gate's own location regardless;
+    see test_ci_secure_gate_resolution.py.
+    """
+    proc = _engine_argv(tmp_path, {"GITHUB_WORKSPACE": ""})
+
+    assert "--root" in proc.argv, "the gate must always tell the engine what to scan"
+    assert proc.argv[proc.argv.index("--root") + 1] == str(_REPO), (
+        "off Actions the scan root falls back to the gate's own repository root")
+
+
+def test_the_impostor_check_is_always_passed_explicitly(tmp_path: Path) -> None:
+    """`auto` is never sent, and the flag is never simply omitted.
+
+    Omitting it lands on the engine's `auto` default, which runs the check iff
+    an authenticated `gh` happens to be on the runner. That makes "did this
+    security check run?" a property of the runner image rather than of the
+    workflow — the silent-skip trap, one image rebuild away.
+    """
+    proc = _engine_argv(tmp_path)
+    assert "--gh-impostor" in proc.argv, "the flag must be explicit, never defaulted"
+    assert proc.argv[proc.argv.index("--gh-impostor") + 1] == "off"
+
+
+def test_the_job_decides_whether_the_impostor_check_runs(tmp_path: Path) -> None:
+    """A job holding a token turns it ON; the same script, a different job, does not."""
+    proc = _engine_argv(tmp_path, {"CI_SECURE_GH_IMPOSTOR": "on"})
+    assert proc.argv[proc.argv.index("--gh-impostor") + 1] == "on"
+
+
+def test_an_unrecognised_impostor_setting_is_red(tmp_path: Path) -> None:
+    """Anything but on/off is red, and `auto` especially so.
+
+    A typo must not silently become "off" — that is the difference between a
+    check that was turned off deliberately and one that stopped running.
+    """
+    for value in ("auto", "yes", ""):
+        proc = _engine_argv(tmp_path, {"CI_SECURE_GH_IMPOSTOR": value})
+        assert proc.returncode == 1, f"{value!r} was accepted"
+        assert "CI_SECURE_GH_IMPOSTOR" in proc.stdout
+
+
+def test_a_partial_network_result_is_disclosed_and_never_reads_as_clean(
+        tmp_path: Path) -> None:
+    """`partial:` means some pins were never verified. That is not "no findings".
+
+    Rate limiting is the ordinary cause, and it is reachable on purpose: an
+    attacker who can burn the API quota can otherwise mute this check.
+    """
+    scan = _scan(gh_checks={"P14.11": "partial: 3 of 9 unique pin(s) verified, 0 "
+                                      "flagged, 6 UNVERIFIED (network/rate-limit) "
+                                      "— not treated as clean"})
+    proc = run_scan(tmp_path, scan)
+
+    assert proc.returncode == 0, "a partial result discloses on a PR, it does not block"
+    assert "::warning::" in proc.stdout
+    assert "did not complete" in proc.stdout.lower() or "partial" in proc.stdout.lower()
+    assert "P14.11" in proc.summary
+
+
+def test_a_partial_network_result_is_red_when_the_run_demands_completeness(
+        tmp_path: Path) -> None:
+    """The scheduled run against the default branch is the one that must be complete.
+
+    A pull request cannot be held hostage to somebody else's rate limit, but
+    the weekly run has no deadline and nothing to race — so there, anything
+    short of "ran" is a red the maintainer sees rather than a warning nobody
+    reads.
+    """
+    scan = _scan(gh_checks={"P14.11": "partial: 1 of 9 unique pin(s) verified, 0 "
+                                      "flagged, 8 UNVERIFIED (network/rate-limit)"})
+    proc = run_scan(tmp_path, scan, env_extra={"CI_SECURE_GH_STRICT": "1"})
+
+    assert proc.returncode == 1
+    assert "::error::" in proc.stdout
+    assert "P14.11" in proc.stdout
+
+
+def test_a_skipped_check_is_disclosed_in_the_summarys_first_lines(
+        tmp_path: Path) -> None:
+    """Both surfaces say it, and the summary says it before anything reassuring.
+
+    A reader who stops after the headline must not come away thinking the scan
+    covered what it did not. "No findings from P14.11" and "P14.11 never ran"
+    are different claims, and only one of them is true here.
+    """
+    proc = run_scan(tmp_path, _CLEAN)
+
+    head = "\n".join(proc.summary.splitlines()[:6])
+    assert "did NOT run" in head or "did not run" in head, (
+        f"the skip is not disclosed in the summary's first lines:\n{head}")
 
 
 def test_the_summary_reports_counts_and_never_the_bare_aggregate(tmp_path: Path) -> None:

--- a/tests/test_ci_secure_gate.py
+++ b/tests/test_ci_secure_gate.py
@@ -76,8 +76,14 @@ def run_gate(tmp_path: Path, *, stdout: str, returncode: int = 0,
         "GITHUB_WORKSPACE": str(workspace),
         "CI_SECURE_ENGINE": engine if engine is not None else str(stub),
         "GITHUB_STEP_SUMMARY": str(summary),
+        # Explicit, because the gate refuses an unset value on purpose. A
+        # harness that omitted it would exercise a shape no real job produces.
+        "CI_SECURE_GH_IMPOSTOR": "off",
     }
     env.update(env_extra or {})
+    # A None in `env_extra` UNSETS the variable, which is how a test reaches
+    # "the job did not decide" rather than merely "the job decided badly".
+    env = {k: v for k, v in env.items() if v is not None}
     proc = subprocess.run(
         [sys.executable, str(_GATE)],
         capture_output=True, text=True, env=env,
@@ -436,8 +442,10 @@ def _engine_argv(tmp_path: Path, env_extra: dict[str, str] | None = None):
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
     env = {"PATH": "/usr/bin:/bin", "GITHUB_WORKSPACE": str(workspace),
-           "CI_SECURE_ENGINE": str(stub), "GITHUB_STEP_SUMMARY": str(summary)}
+           "CI_SECURE_ENGINE": str(stub), "GITHUB_STEP_SUMMARY": str(summary),
+           "CI_SECURE_GH_IMPOSTOR": "off"}
     env.update(env_extra or {})
+    env = {k: v for k, v in env.items() if v is not None}   # None unsets
     proc = subprocess.run([sys.executable, str(_GATE)],
                           capture_output=True, text=True, env=env)
     proc.summary = summary.read_text(encoding="utf-8") if summary.exists() else ""
@@ -525,9 +533,139 @@ def test_the_impostor_check_is_always_passed_explicitly(tmp_path: Path) -> None:
     security check run?" a property of the runner image rather than of the
     workflow — the silent-skip trap, one image rebuild away.
     """
-    proc = _engine_argv(tmp_path)
+    proc = _engine_argv(tmp_path, {"CI_SECURE_GH_IMPOSTOR": "off"})
     assert "--gh-impostor" in proc.argv, "the flag must be explicit, never defaulted"
     assert proc.argv[proc.argv.index("--gh-impostor") + 1] == "off"
+
+
+def test_an_unset_impostor_setting_is_red_like_any_other_non_decision(
+        tmp_path: Path) -> None:
+    """UNSET is refused, not quietly read as "off".
+
+    This is the case the variable exists for. A default of "off" made deleting
+    the `env:` block from a scan job — a plausible refactor — silently stop the
+    network-gated check on every run, which is the precise outcome the gate's
+    own refusal message claims is impossible. "Nobody decided" and "the job
+    decided not to" must not produce the same scan.
+    """
+    proc = _engine_argv(tmp_path, {"CI_SECURE_GH_IMPOSTOR": None})
+
+    assert proc.returncode == 1, (
+        "an unset CI_SECURE_GH_IMPOSTOR was accepted; whether the network-gated "
+        "check runs must be a decision the job makes, never a default")
+    assert "CI_SECURE_GH_IMPOSTOR" in proc.stdout
+    assert proc.argv == [], "the engine must not even be invoked without a decision"
+
+
+def test_a_strict_setting_that_is_not_a_flag_is_red(tmp_path: Path) -> None:
+    """`true`/`yes`/`schedule` read as strict to a human and all meant lax.
+
+    Strict mode is what makes the weekly run red on an incomplete network
+    check, and that run is the only way a pin that ROTS after merge is ever
+    noticed. A value that silently disables it mutes exactly that.
+    """
+    for value in ("true", "yes", "schedule", "on"):
+        proc = run_scan(tmp_path, _CLEAN, env_extra={"CI_SECURE_GH_STRICT": value})
+        assert proc.returncode == 1, f"{value!r} was accepted as a strict setting"
+        assert "CI_SECURE_GH_STRICT" in proc.stdout
+
+
+def test_an_unset_strict_setting_means_lax_and_is_allowed(tmp_path: Path) -> None:
+    """Unlike the impostor flag, unset strict is legitimate: the fork job omits it.
+
+    The dial changes SEVERITY, not coverage — lax still discloses on both
+    surfaces — so there is no silent-skip to prevent here, and refusing unset
+    would red the fork job for doing the right thing.
+    """
+    proc = run_scan(tmp_path, _CLEAN, env_extra={"CI_SECURE_GH_STRICT": None})
+    assert proc.returncode == 0, proc.stdout
+
+
+def test_the_scan_root_is_the_workspace_the_job_checked_out(tmp_path: Path) -> None:
+    """GITHUB_WORKSPACE decides the scan root — the audited half of the two-tree rule.
+
+    Only the FALLBACK was pinned before, and in this repo the two paths
+    coincide, so a gate that ignored the workspace entirely would pass CI here
+    and silently scan its own directory instead of the adopter's repository in
+    a vendored install.
+    """
+    workspace = tmp_path / "elsewhere"
+    workspace.mkdir()
+    proc = _engine_argv(tmp_path, {"GITHUB_WORKSPACE": str(workspace)})
+
+    assert proc.argv[proc.argv.index("--root") + 1] == str(workspace), (
+        "the scan root must be the tree the job checked out, not the gate's own")
+
+
+def test_a_rule_that_raises_on_load_is_red_with_a_stated_cause(tmp_path: Path) -> None:
+    """A config.py that blows up on import must not be an unexplained red.
+
+    Loading the rule EXECUTES it, and in a vendored layout that code sits
+    beside the engine — so this is the likeliest line in the gate to raise, not
+    the least. It runs at module scope, outside main()'s handler, so it used to
+    exit non-zero with a bare traceback and no ::error:: annotation.
+    """
+    engine_dir = tmp_path / "vendored"
+    engine_dir.mkdir()
+    (engine_dir / "config.py").write_text(
+        "raise RuntimeError('rule exploded on import')\n", encoding="utf-8")
+    engine = engine_dir / "scan.py"
+    engine.write_text("import sys\nsys.stdout.write('{}')\n", encoding="utf-8")
+
+    proc = run_scan(tmp_path, _CLEAN, engine=str(engine))
+
+    assert proc.returncode == 1
+    assert "::error::" in proc.stdout, (
+        "a rule that raises on load produced a red with no stated cause")
+    assert "could not be loaded" in proc.stdout
+
+
+def test_a_rule_missing_the_coherence_predicate_says_so(tmp_path: Path) -> None:
+    """`coverage_is_complete` is CALLED, so its absence is a named disagreement.
+
+    Left out of the presence check, a vendored rule missing only that name
+    reached the crash handler and reported an AttributeError — still red, but
+    the adopter is told about a Python attribute instead of about the rule.
+    """
+    engine_dir = tmp_path / "vendored_partial"
+    engine_dir.mkdir()
+    (engine_dir / "config.py").write_text(
+        "BLOCKING_OUTCOMES = frozenset({'fail'})\n"
+        "KNOWN_OUTCOMES = frozenset({'pass', 'fail'})\n"
+        "OUTCOME_MARKS = {'pass': 'PASS', 'fail': 'FAIL'}\n"
+        "def flatten_scanned(v):\n    return '' if v is None else str(v)\n",
+        encoding="utf-8")
+    engine = engine_dir / "scan.py"
+    engine.write_text("import sys\nsys.stdout.write('{}')\n", encoding="utf-8")
+
+    proc = run_scan(tmp_path, _CLEAN, engine=str(engine))
+
+    assert proc.returncode == 1
+    assert "coverage_is_complete" in proc.stdout
+    assert "engine and gate disagree" in proc.stdout
+
+
+def test_a_hung_engine_is_red_with_a_named_cause(tmp_path: Path) -> None:
+    """The engine timeout must actually fire, and say why.
+
+    Without it a hung engine runs until the JOB's own timeout cancels it, which
+    reaches the check run as an unexplained cancellation rather than a stated
+    verdict — and the job timeout is the thing this constant must stay under.
+    """
+    stub = tmp_path / "hang.py"
+    stub.write_text("import time\ntime.sleep(30)\n", encoding="utf-8")
+    summary = tmp_path / "summary.md"
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    proc = subprocess.run(
+        [sys.executable, str(_GATE)], capture_output=True, text=True,
+        env={"PATH": "/usr/bin:/bin", "GITHUB_WORKSPACE": str(workspace),
+             "CI_SECURE_ENGINE": str(stub), "GITHUB_STEP_SUMMARY": str(summary),
+             "CI_SECURE_GH_IMPOSTOR": "off",
+             "CI_SECURE_ENGINE_TIMEOUT_S": "1"})
+
+    assert proc.returncode == 1
+    assert "did not finish within" in proc.stdout, proc.stdout + proc.stderr
 
 
 def test_the_job_decides_whether_the_impostor_check_runs(tmp_path: Path) -> None:

--- a/tests/test_ci_secure_gate.py
+++ b/tests/test_ci_secure_gate.py
@@ -234,6 +234,88 @@ def test_an_unmeasured_fact_warns_without_blocking(tmp_path: Path) -> None:
     assert "PASS `sec.codeowners.workflows`" not in proc.summary
 
 
+# --------------------------------------------------------------------------
+# Untrusted text reaching the annotation and summary sinks
+# --------------------------------------------------------------------------
+
+# Everything the gate reports is read out of scanned workflow files, and on a
+# fork pull request an attacker writes those files — including their names, which
+# the engine reports verbatim. A newline in one of those strings would otherwise
+# let it emit workflow commands of its own. The command is built at runtime from
+# its pieces so this file never contains a literal attack string.
+_STOP = "::" + "stop-commands" + "::"
+
+
+def _hostile(text: str) -> dict:
+    """A scan whose every untrusted string carries an embedded workflow command."""
+    scan = _scan(findings=[{
+        "severity": "HIGH", "pattern": "P14.10", "title": text,
+        "workflow_file": text, "line": text}])
+    scan["security_score"]["facts"][0].update(
+        outcome="fail", fact_id=text, evidence=text)
+    scan["gh_checks"] = {text: text}
+    return scan
+
+
+@pytest.mark.parametrize("payload", [
+    "evil\n" + _STOP + "deadbeef\nfoo.yml",
+    "a\r\n::error::forged\r\nb.yml",
+    "x\n::add-mask::secret\ny.yml",
+])
+def test_a_crafted_filename_cannot_emit_its_own_workflow_commands(
+    tmp_path: Path, payload: str
+) -> None:
+    """No line the gate prints may begin with `::` unless the gate wrote it.
+
+    `::stop-commands::` is the one that matters: it switches command parsing off
+    for the rest of the step, which would silence the `::error::` annotations
+    this gate emits for genuine failures. The exit code is computed in Python and
+    no workflow command can touch it, so the build still goes red either way —
+    but "the finding does not block" must not decay into "the finding does not
+    appear", and a fork must not be able to blind the check tab at will.
+    """
+    proc = run_scan(tmp_path, _hostile(payload))
+    assert proc.returncode == 1, "a failed fact is still a failed fact"
+
+    # Actions reads a workflow command only where one STARTS a line, so the
+    # invariant is per-line: every command-looking line must be one the gate
+    # wrote. The payload surviving mid-line, percent-encoded, is the intended
+    # outcome — escaped rather than dropped, so the evidence is still readable.
+    emitted = [ln.strip() for ln in (proc.stdout + proc.stderr).splitlines()]
+    for line in emitted:
+        if line.startswith("::"):
+            assert line.startswith(("::warning", "::error")), f"the gate emitted {line!r}"
+    # The real annotations survive, which is the point of escaping rather than dropping.
+    assert any(ln.startswith("::error::ci-secure fact failed") for ln in emitted)
+
+
+def test_a_crafted_filename_cannot_break_out_of_the_summary(tmp_path: Path) -> None:
+    """A newline in the Markdown sink would let a filename render its own list items."""
+    proc = run_scan(tmp_path, _hostile("evil\n- PASS `all good`\nfoo.yml"))
+    assert proc.returncode == 1
+    # Collapsed onto one line, the payload is inert text inside a row the gate
+    # wrote. On its own line it would be a row of its own, reading as a pass that
+    # the exit code contradicts — so the invariant is that no summary line the
+    # gate did not author exists at all.
+    forged = [ln for ln in proc.summary.splitlines() if ln.strip() == "- PASS `all good`"]
+    assert not forged, "a crafted filename rendered its own summary row"
+    assert any("evil - PASS `all good` foo.yml" in ln for ln in proc.summary.splitlines()), (
+        "the filename should still be readable in the row the gate wrote, just flattened"
+    )
+
+
+def test_the_summary_is_bounded(tmp_path: Path) -> None:
+    """An oversized summary is rejected wholesale, taking the failures with it."""
+    scan = _scan(findings=[
+        {"severity": "LOW", "pattern": f"P{i}", "title": "x" * 500,
+         "workflow_file": "w.yml", "line": i}
+        for i in range(4000)])
+    proc = run_scan(tmp_path, scan)
+    assert proc.returncode == 0
+    assert len(proc.summary) < 1_000_000, "GitHub rejects a step summary over 1 MiB"
+    assert "truncated" in proc.summary
+
+
 def test_every_failure_reason_is_reported_not_just_the_first(tmp_path: Path) -> None:
     """A red build must list all of its causes, so one fix does not reveal the next."""
     scan = _scan(scanned_workflows=0, scan_incomplete=[

--- a/tests/test_ci_secure_gate.py
+++ b/tests/test_ci_secure_gate.py
@@ -31,6 +31,7 @@ _CLEAN = {
     "scanned_workflows": 3,
     "findings": [],
     "scan_incomplete": [],
+    "dropped_matches": [],
     "gh_checks": {"P14.11": "skipped: disabled via --gh-impostor=off"},
     "security_score": {
         "facts": [
@@ -150,7 +151,8 @@ def test_unreadable_output_is_red(tmp_path: Path, payload: str) -> None:
     assert "no readable verdict" in proc.stdout
 
 
-@pytest.mark.parametrize("missing_key", ["findings", "scan_incomplete"])
+@pytest.mark.parametrize("missing_key", [
+    "findings", "scan_incomplete", "dropped_matches", "gh_checks"])
 def test_a_dropped_schema_key_is_red_not_assumed_empty(tmp_path: Path, missing_key: str) -> None:
     """If the engine stops reporting coverage gaps, the gate must not read that as zero gaps."""
     scan = _scan()
@@ -158,6 +160,48 @@ def test_a_dropped_schema_key_is_red_not_assumed_empty(tmp_path: Path, missing_k
     proc = run_scan(tmp_path, scan)
     assert proc.returncode == 1
     assert "no readable verdict" in proc.stdout
+
+
+def test_a_dropped_match_is_red(tmp_path: Path) -> None:
+    """A finding the detector produced and then discarded is a false negative.
+
+    The engine separates "this file could not be read" (`scan_incomplete`) from
+    "a detector matched inside a run: step it could not anchor to a line, so the
+    match was thrown away" (`dropped_matches`). Its own coverage predicate treats
+    them as the same class of hole, so a gate that blocks on one and ignores the
+    other reports 100 over a scan that admits it dropped a hit.
+    """
+    proc = run_scan(tmp_path, _scan(dropped_matches=[
+        {"workflow_file": ".github/workflows/deploy.yml",
+         "reason": "run: step could not be anchored to a raw line"}]))
+    assert proc.returncode == 1
+    assert "dropped" in proc.stdout and "deploy.yml" in proc.stdout
+
+
+def test_an_empty_facts_list_alone_is_red(tmp_path: Path) -> None:
+    """The `evaluated nothing` clause, isolated from the other degraded checks.
+
+    Covered only in combination before, so deleting the clause changed nothing:
+    the crash-shape test also sets `score: None` and `reason`, which fire on their
+    own. This is the drift the clause exists for — a numeric score over no facts.
+    """
+    proc = run_scan(tmp_path, _scan(security_score={
+        "facts": [], "score": 0, "passed": 0, "scored_count": 0,
+        "applicable_count": 0, "unmeasured": []}))
+    assert proc.returncode == 1
+    assert "evaluated nothing" in proc.stdout
+
+
+def test_a_missing_network_detector_status_is_red(tmp_path: Path) -> None:
+    """The gate always disables P14.11 explicitly, so a status must always exist.
+
+    Reading `gh_checks` with a default would make "the detector was skipped" and
+    "the engine stopped saying whether it ran" look identical — the exact
+    collapse the surrounding comment promises not to allow.
+    """
+    proc = run_scan(tmp_path, _scan(gh_checks={}))
+    assert proc.returncode == 1
+    assert "network-gated detector status" in proc.stdout
 
 
 def test_the_facts_layer_degrading_to_empty_is_red(tmp_path: Path) -> None:
@@ -241,9 +285,12 @@ def test_an_unmeasured_fact_warns_without_blocking(tmp_path: Path) -> None:
 # Everything the gate reports is read out of scanned workflow files, and on a
 # fork pull request an attacker writes those files — including their names, which
 # the engine reports verbatim. A newline in one of those strings would otherwise
-# let it emit workflow commands of its own. The command is built at runtime from
-# its pieces so this file never contains a literal attack string.
-_STOP = "::" + "stop-commands" + "::"
+# let it emit workflow commands of its own. Each command name is assembled at run
+# time rather than written out, so no scanner reading this file finds a literal
+# workflow command sitting in a test fixture.
+_STOP = "::" + "stop" + "-commands::"
+_MASK = "::" + "add" + "-mask::"
+_ERR = "::" + "err" + "or::"
 
 
 def _hostile(text: str) -> dict:
@@ -259,8 +306,8 @@ def _hostile(text: str) -> dict:
 
 @pytest.mark.parametrize("payload", [
     "evil\n" + _STOP + "deadbeef\nfoo.yml",
-    "a\r\n::error::forged\r\nb.yml",
-    "x\n::add-mask::secret\ny.yml",
+    "a\r\n" + _ERR + "forged\r\nb.yml",
+    "x\n" + _MASK + "secret\ny.yml",
 ])
 def test_a_crafted_filename_cannot_emit_its_own_workflow_commands(
     tmp_path: Path, payload: str
@@ -278,15 +325,72 @@ def test_a_crafted_filename_cannot_emit_its_own_workflow_commands(
     assert proc.returncode == 1, "a failed fact is still a failed fact"
 
     # Actions reads a workflow command only where one STARTS a line, so the
-    # invariant is per-line: every command-looking line must be one the gate
-    # wrote. The payload surviving mid-line, percent-encoded, is the intended
-    # outcome — escaped rather than dropped, so the evidence is still readable.
-    emitted = [ln.strip() for ln in (proc.stdout + proc.stderr).splitlines()]
-    for line in emitted:
-        if line.startswith("::"):
-            assert line.startswith(("::warning", "::error")), f"the gate emitted {line!r}"
-    # The real annotations survive, which is the point of escaping rather than dropping.
-    assert any(ln.startswith("::error::ci-secure fact failed") for ln in emitted)
+    # invariant is per-line. Counting, not prefix-matching: a forged `::error::`
+    # would satisfy "starts with ::error", so the assertion has to be that the
+    # gate emitted EXACTLY the commands it meant to — one warning for the one
+    # finding, one error for the one failed fact — and nothing else.
+    emitted = [ln.strip() for ln in (proc.stdout + proc.stderr).splitlines()
+               if ln.strip().startswith("::")]
+    assert len(emitted) == 2, f"expected exactly 2 workflow commands, got {emitted}"
+    assert sum(ln.startswith("::warning file=") for ln in emitted) == 1
+    assert sum(ln.startswith("::error::ci-secure fact failed") for ln in emitted) == 1
+    # Escaped rather than dropped: the payload survives mid-line, percent-encoded,
+    # so the evidence a reviewer needs is still legible.
+    assert "%0A" in proc.stdout
+
+
+def test_a_crafted_filename_cannot_rewrite_an_annotation_s_properties(
+    tmp_path: Path
+) -> None:
+    """`:` and `,` terminate a workflow command's property list.
+
+    Left unescaped in `file=`, a `::` in the filename ends the property list and
+    the attacker's text becomes the annotation body, while an embedded `,line=`
+    re-points the annotation at a file and line of their choosing — a real finding
+    displayed against innocent code.
+    """
+    proc = run_scan(tmp_path, _scan(findings=[{
+        "severity": "HIGH", "pattern": "P14.10", "title": "t",
+        "workflow_file": "a.yml" + _ERR + "forged clean,line=1", "line": 7}]))
+    assert proc.returncode == 0
+
+    line = next(ln for ln in proc.stdout.splitlines() if ln.startswith("::warning"))
+    assert "%3A" in line and "%2C" in line, f"properties not escaped: {line}"
+    # The command's own structure is intact: exactly one property list, ending at
+    # the real line number the engine reported.
+    assert line.count("::") == 2, f"the payload split the command: {line}"
+    assert ",line=7::" in line
+
+
+@pytest.mark.parametrize("sink", ["crash", "unreadable"])
+def test_engine_output_cannot_emit_workflow_commands(tmp_path: Path, sink: str) -> None:
+    """The engine's own stdout and stderr are attacker-controlled on a fork PR.
+
+    Both the crash path and the unreadable-verdict path echo engine output to the
+    log. Neither had a test, and `::stop-commands::` reaching the log from either
+    would silence the `::error::` the gate emits immediately afterwards.
+    """
+    payload = "boom\n" + _STOP + "deadbeef\nmore"
+    if sink == "crash":
+        # A separate filename: run_gate() writes its own stub_engine.py, which
+        # would overwrite this one and quietly test nothing.
+        stub = tmp_path / "noisy_engine.py"
+        stub.write_text(
+            "import sys\n"
+            f"sys.stderr.write({payload!r})\n"
+            "sys.exit(2)\n", encoding="utf-8")
+        proc = run_gate(tmp_path, stdout="", engine=str(stub))
+    else:
+        proc = run_gate(tmp_path, stdout=payload)
+
+    assert proc.returncode == 1
+    emitted = [ln.strip() for ln in (proc.stdout + proc.stderr).splitlines()
+               if ln.strip().startswith("::")]
+    assert len(emitted) == 1, f"expected only the gate's own error, got {emitted}"
+    assert emitted[0].startswith("::error::ci-secure")
+    # Echoed legibly rather than percent-encoded: this is what a maintainer reads
+    # when the gate goes red for a reason that is not a security finding.
+    assert "engine| boom" in proc.stderr
 
 
 def test_a_crafted_filename_cannot_break_out_of_the_summary(tmp_path: Path) -> None:
@@ -304,16 +408,36 @@ def test_a_crafted_filename_cannot_break_out_of_the_summary(tmp_path: Path) -> N
     )
 
 
-def test_the_summary_is_bounded(tmp_path: Path) -> None:
-    """An oversized summary is rejected wholesale, taking the failures with it."""
+GITHUB_SUMMARY_LIMIT_BYTES = 1024 * 1024  # 1 MiB, GitHub's documented cap
+
+
+@pytest.mark.parametrize("filler,label", [
+    ("x", "ascii"),
+    # Three bytes per character. A budget counted in characters passes this
+    # happily while the upload is ~3x over the real limit — and on a fork PR the
+    # filenames and evidence in a summary are attacker-chosen, so non-ASCII here
+    # is a choice an attacker gets to make, not an accident of someone's locale.
+    ("漢", "multibyte"),
+])
+def test_the_summary_is_bounded_in_bytes(tmp_path: Path, filler: str, label: str) -> None:
+    """GitHub rejects an oversized summary outright, so too big means none at all.
+
+    The limit it enforces is bytes; measuring characters is the bug this pins.
+    """
     scan = _scan(findings=[
-        {"severity": "LOW", "pattern": f"P{i}", "title": "x" * 500,
+        {"severity": "LOW", "pattern": f"P{i}", "title": filler * 500,
          "workflow_file": "w.yml", "line": i}
         for i in range(4000)])
     proc = run_scan(tmp_path, scan)
     assert proc.returncode == 0
-    assert len(proc.summary) < 1_000_000, "GitHub rejects a step summary over 1 MiB"
+
+    size = len(proc.summary.encode("utf-8"))
+    assert size < GITHUB_SUMMARY_LIMIT_BYTES, (
+        f"{label}: summary is {size} bytes, over GitHub's {GITHUB_SUMMARY_LIMIT_BYTES}"
+    )
     assert "truncated" in proc.summary
+    # Truncation cuts on a line boundary, so the last row is never half-rendered.
+    assert proc.summary.rstrip().endswith("_(summary truncated; see the step log)_")
 
 
 def test_every_failure_reason_is_reported_not_just_the_first(tmp_path: Path) -> None:

--- a/tests/test_ci_secure_gate_resolution.py
+++ b/tests/test_ci_secure_gate_resolution.py
@@ -60,6 +60,10 @@ OUTCOME_MARKS = {"pass": "PASS", "fail": "**FAIL**",
 
 def coverage_is_complete() -> bool:
     return True
+
+
+def flatten_scanned(value):
+    return " ".join(str(value).split()).replace("`", "'").replace("|", "\\\\|")
 '''
 
 

--- a/tests/test_ci_secure_gate_resolution.py
+++ b/tests/test_ci_secure_gate_resolution.py
@@ -76,6 +76,8 @@ def _run(engine: Path, tmp_path: Path, *, env_engine: bool = True):
         "PATH": "/usr/bin:/bin",
         "GITHUB_WORKSPACE": str(workspace),
         "GITHUB_STEP_SUMMARY": str(summary),
+        # Explicit, because the gate refuses an unset value on purpose.
+        "CI_SECURE_GH_IMPOSTOR": "off",
     }
     if env_engine:
         env["CI_SECURE_ENGINE"] = str(engine)
@@ -162,7 +164,14 @@ def test_the_engine_default_is_gate_relative_not_the_audited_workspace(
 
     assert "decoy engine ran" not in proc.stdout + proc.stderr, (
         "the gate executed an engine out of the tree it was auditing")
-    assert str(_ENGINE) in proc.stdout + proc.stderr or proc.returncode in (0, 1)
+    # Whatever it decided, it decided it OUT LOUD. The old form of this line was
+    # `... or proc.returncode in (0, 1)`, which this script can never violate —
+    # it only ever exits 0 or 1 — so the assertion could not fail at all. The
+    # real engine scanning an empty workspace is legitimately red here; what
+    # must never happen is a red with no stated cause.
+    assert proc.returncode == 0 or "::error::" in proc.stdout, (
+        f"the gate exited {proc.returncode} with no stated cause:\n"
+        f"{proc.stdout}\n{proc.stderr}")
 
 
 def test_the_gate_imports_no_test_helper(tmp_path: Path) -> None:
@@ -230,6 +239,82 @@ def test_the_blocking_rule_is_never_derived_from_the_display_dict() -> None:
             "the security rule")
 
 
+def _outcomes_emitted_by(source: Path) -> set[str]:
+    """Every fact-outcome string literal `config_facts.py` can actually produce.
+
+    An extraction, not a checklist. Three shapes produce an outcome in that
+    module, and all three are read out of the AST:
+
+      1. a dict literal carrying an `"outcome"` key   -> its value expression
+      2. a comparison against `something["outcome"]`  -> the comparators
+      3. a helper documented `(outcome, evidence)`    -> the first tuple slot
+
+    Shape 3 matters because the engine's three-state facts compute their own
+    result in a helper and pass it through, so a new outcome could enter there
+    without ever appearing beside the `"outcome"` key.
+    """
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    found: set[str] = set()
+
+    def strings(node: ast.AST) -> set[str]:
+        return {n.value for n in ast.walk(node)
+                if isinstance(n, ast.Constant) and isinstance(n.value, str)}
+
+    for node in ast.walk(tree):
+        # 1. {"outcome": <expr>}
+        if isinstance(node, ast.Dict):
+            for key, value in zip(node.keys, node.values):
+                if (isinstance(key, ast.Constant) and key.value == "outcome"):
+                    found |= strings(value)
+        # 2. x["outcome"] == "..." / in ("...", "...")
+        elif isinstance(node, ast.Compare):
+            subs = [n for n in [node.left, *node.comparators]
+                    if isinstance(n, ast.Subscript)
+                    and isinstance(n.slice, ast.Constant)
+                    and n.slice.value == "outcome"]
+            if subs:
+                for operand in (node.left, *node.comparators):
+                    if operand not in subs:
+                        found |= strings(operand)
+        # 3. def f(...) -> """(outcome, evidence) ..."""
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            doc = ast.get_docstring(node) or ""
+            if doc.startswith("(outcome, evidence)"):
+                for inner in ast.walk(node):
+                    if isinstance(inner, ast.Return) and isinstance(
+                            inner.value, ast.Tuple) and inner.value.elts:
+                        found |= strings(inner.value.elts[0])
+    return found
+
+
+def test_the_census_extracts_rather_than_filters(tmp_path: Path) -> None:
+    """The census must SEE an outcome nobody told it about.
+
+    This is the property that makes the three-table design safe: adding an
+    outcome to the engine has to red the build until a human classifies it. A
+    census implemented as `{v for v in ("pass","fail","unmeasured") if ...}`
+    passes every other assertion in this file while being structurally
+    incapable of noticing a fourth — so the guard is tested with a fourth.
+    """
+    invented = tmp_path / "config_facts_like.py"
+    invented.write_text(
+        'def _thing(root):\n'
+        '    """(outcome, evidence) for a fact that computes its own result."""\n'
+        '    return ("deferred", "waiting on an admin-scoped read")\n'
+        '\n'
+        'def _record(facts, passed):\n'
+        '    facts.append({"fact_id": "x", "outcome": "quarantined"})\n'
+        '    facts.append({"fact_id": "y", "outcome": "pass" if passed else "fail"})\n'
+        '\n'
+        'def _score(facts):\n'
+        '    return [f for f in facts if f["outcome"] in ("pass", "provisional")]\n',
+        encoding="utf-8")
+
+    found = _outcomes_emitted_by(invented)
+    assert {"deferred", "quarantined", "pass", "fail", "provisional"} <= found, (
+        f"the census missed an outcome it was never told about: {sorted(found)}")
+
+
 def test_every_outcome_the_engine_emits_is_known_marked_and_covered() -> None:
     """A census, not a spot check: the engine's vocabulary ⊆ the gate's.
 
@@ -243,10 +328,14 @@ def test_every_outcome_the_engine_emits_is_known_marked_and_covered() -> None:
     finally:
         sys.path.pop(0)
 
-    facts_source = (_CONFIG.parent / "config_facts.py").read_text(encoding="utf-8")
-    emitted = {value for value in ("pass", "fail", "unmeasured")
-               if f'"{value}"' in facts_source}
+    emitted = _outcomes_emitted_by(_CONFIG.parent / "config_facts.py")
     assert emitted, "found no outcome literals in config_facts.py — census broken"
+    # The census must EXTRACT, never filter a list written here: a filter can
+    # only ever return a subset of what it already knew, so a fourth outcome in
+    # config_facts.py would leave the result unchanged and this test green —
+    # the exact drift it exists to catch. `_census_is_an_extraction` pins that.
+    assert {"pass", "fail", "unmeasured"} <= emitted, (
+        f"the census lost a known outcome; it found only {sorted(emitted)}")
 
     assert emitted <= set(config.KNOWN_OUTCOMES), (
         f"config_facts emits {sorted(emitted - set(config.KNOWN_OUTCOMES))}, "

--- a/tests/test_ci_secure_gate_resolution.py
+++ b/tests/test_ci_secure_gate_resolution.py
@@ -1,0 +1,266 @@
+"""Where the gate finds the code it runs, and the rule it enforces.
+
+Two files decide every verdict this gate reaches: the ENGINE (`scan.py`) that
+produces the facts, and the RULE (`config.py`) that says which fact outcomes
+block. Both must come from the gate's own trust boundary — never from the
+repository being audited.
+
+The distinction is the whole point. `GITHUB_WORKSPACE` is the tree under
+examination; on a fork pull request an attacker writes it. A gate that resolves
+its engine from there executes attacker code and prints whatever verdict that
+code returns, which is indistinguishable from a clean scan. So the engine is
+resolved relative to the gate file itself, and `CI_SECURE_ENGINE` is the one
+deliberate redirect — used by a repository that vendors ci-secure into a
+directory of its own rather than checking out this whole tree.
+
+`config.py` then follows the ENGINE, not the gate: it is loaded from the
+directory of whichever engine was resolved. That single rule serves both
+layouts — in this repository the gate sits at `.github/scripts/` and the engine
+at `skills/ci-secure/scripts/`, while a vendored install puts both in one
+directory — and it keeps the rule in the same trust class as the engine it
+configures, instead of inventing a third thing that can be pointed somewhere
+else independently.
+"""
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+_GATE = _REPO / ".github" / "scripts" / "ci_secure_gate.py"
+_ENGINE = _REPO / "skills" / "ci-secure" / "scripts" / "scan.py"
+_CONFIG = _REPO / "skills" / "ci-secure" / "scripts" / "config.py"
+
+_FACTS = {
+    "scanned_workflows": 1,
+    "findings": [],
+    "scan_incomplete": [],
+    "dropped_matches": [],
+    "gh_checks": {"P14.11": "skipped: disabled via --gh-impostor=off"},
+    "security_score": {
+        "facts": [{"fact_id": "sec.demo.fact", "outcome": "deferred",
+                   "evidence": "an outcome this repo's config.py does not know"}],
+        "score": 100, "passed": 1, "scored_count": 1,
+        "applicable_count": 1, "unmeasured": [],
+    },
+}
+
+# A config.py a VENDORED install could legitimately ship: it knows one outcome
+# more than this repo's does, and blocks on it. Nothing here is derived from
+# anything else — that independence is the subject of its own test below.
+_VENDORED_CONFIG = '''\
+BLOCKING_OUTCOMES = frozenset({"fail", "deferred"})
+KNOWN_OUTCOMES = frozenset({"pass", "fail", "unmeasured", "deferred"})
+OUTCOME_MARKS = {"pass": "PASS", "fail": "**FAIL**",
+                 "unmeasured": "UNMEASURED", "deferred": "**DEFERRED**"}
+
+
+def coverage_is_complete() -> bool:
+    return True
+'''
+
+
+def _run(engine: Path, tmp_path: Path, *, env_engine: bool = True):
+    """Run the real gate against a stub engine, capturing its verdict."""
+    summary = tmp_path / "summary.md"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(exist_ok=True)
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "GITHUB_WORKSPACE": str(workspace),
+        "GITHUB_STEP_SUMMARY": str(summary),
+    }
+    if env_engine:
+        env["CI_SECURE_ENGINE"] = str(engine)
+    proc = subprocess.run([sys.executable, str(_GATE)],
+                          capture_output=True, text=True, env=env)
+    proc.summary = summary.read_text(encoding="utf-8") if summary.exists() else ""
+    return proc
+
+
+def _stub_engine(directory: Path, payload: dict) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    engine = directory / "scan.py"
+    engine.write_text(
+        "import sys\n"
+        f"sys.stdout.write({json.dumps(payload)!r})\n",
+        encoding="utf-8")
+    return engine
+
+
+# --------------------------------------------------------------------------
+# config.py follows the resolved ENGINE, in both layouts
+# --------------------------------------------------------------------------
+
+def test_the_vendored_layout_loads_config_from_beside_its_engine(tmp_path: Path) -> None:
+    """A vendored engine's own config.py decides the verdict, not ours.
+
+    This is the layout an external adopter installs: `scan.py` and `config.py`
+    together in one vendored directory, with `CI_SECURE_ENGINE` pointing at it.
+    The gate must load the rule from there. Proof is behavioural rather than
+    introspective: the vendored config blocks on an outcome this repository's
+    config has never heard of, so the two rules produce DIFFERENT red reasons
+    for the same scan — and only the vendored one names the fact.
+    """
+    vendored = tmp_path / "ci-secure"
+    engine = _stub_engine(vendored, _FACTS)
+    (vendored / "config.py").write_text(_VENDORED_CONFIG, encoding="utf-8")
+
+    proc = _run(engine, tmp_path)
+
+    assert proc.returncode == 1
+    assert "ci-secure fact failed: sec.demo.fact" in proc.stdout, (
+        "the vendored config blocks on `deferred`, so the gate must report a "
+        "FAILED FACT — reporting an unrecognised outcome instead would mean it "
+        "read this repository's config.py rather than the engine's:\n"
+        + proc.stdout)
+    assert "**DEFERRED**" in proc.summary, (
+        "the summary marks come from the same config.py as the rule")
+
+
+def test_an_engine_without_a_config_falls_back_to_this_repos_rule(tmp_path: Path) -> None:
+    """No config.py beside the engine → the gate's own tree supplies the rule.
+
+    The fallback must still be a REAL rule, not an empty permissive one: an
+    outcome nothing recognises is a contract change between engine and gate,
+    and it goes red for exactly that stated reason.
+    """
+    engine = _stub_engine(tmp_path / "engine-only", _FACTS)
+
+    proc = _run(engine, tmp_path)
+
+    assert proc.returncode == 1
+    assert "unrecognised fact outcome(s)" in proc.stdout, (
+        "with no config beside the engine the gate falls back to its own tree, "
+        "which does not know `deferred`:\n" + proc.stdout)
+
+
+def test_the_engine_default_is_gate_relative_not_the_audited_workspace(
+        tmp_path: Path) -> None:
+    """With no override, the engine comes from the gate's tree — never the workspace.
+
+    A workspace-relative default is the hole this rule exists to close: the
+    audited repository may itself contain `skills/ci-secure/scripts/scan.py`
+    (a vendored install, or a fork PR that adds one), and a trusted gate that
+    ran THAT would be executing the code it is supposed to be judging.
+    """
+    # A decoy engine at our own well-known path, inside the audited workspace.
+    workspace = tmp_path / "workspace"
+    decoy = workspace / "skills" / "ci-secure" / "scripts"
+    decoy.mkdir(parents=True)
+    (decoy / "scan.py").write_text(
+        "import sys; sys.stdout.write('decoy engine ran')\n", encoding="utf-8")
+
+    proc = _run(_ENGINE, tmp_path, env_engine=False)
+
+    assert "decoy engine ran" not in proc.stdout + proc.stderr, (
+        "the gate executed an engine out of the tree it was auditing")
+    assert str(_ENGINE) in proc.stdout + proc.stderr or proc.returncode in (0, 1)
+
+
+def test_the_gate_imports_no_test_helper(tmp_path: Path) -> None:
+    """The shipped gate stands alone: no test scaffolding in its import graph.
+
+    A vendored copy carries the engine and the gate, never this repository's
+    test tree. A gate that reached for `_scan_import` or `assert_is_ci_secure`
+    would work here and fail on every adopter.
+    """
+    tree = ast.parse(_GATE.read_text(encoding="utf-8"))
+
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+
+    stdlib_only = {"importlib", "json", "os", "subprocess", "sys",
+                   "traceback", "pathlib"}
+    assert imported <= stdlib_only, (
+        f"the gate imports {sorted(imported - stdlib_only)}; it must be stdlib "
+        "only, since a vendored install carries neither this repository's test "
+        "tree nor its package layout")
+
+    # The helpers by name, in code rather than in prose: a call to one would
+    # show up as a Name node even if the import were indirect.
+    called = {n.id for n in ast.walk(tree) if isinstance(n, ast.Name)}
+    for helper in ("_scan_import", "assert_is_ci_secure"):
+        assert helper not in called, (
+            f"the gate calls the test helper {helper!r}; a vendored install "
+            "has no test tree to import it from")
+
+
+# --------------------------------------------------------------------------
+# The three outcome names are INDEPENDENT (§2b)
+# --------------------------------------------------------------------------
+
+def _assignment(name: str) -> ast.AST:
+    tree = ast.parse(_CONFIG.read_text(encoding="utf-8"))
+    for node in tree.body:
+        targets = ([node.target] if isinstance(node, ast.AnnAssign)
+                   else getattr(node, "targets", []))
+        for target in targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                return node.value
+    raise AssertionError(f"config.py defines no {name}")
+
+
+def test_the_blocking_rule_is_never_derived_from_the_display_dict() -> None:
+    """`KNOWN_OUTCOMES`/`BLOCKING_OUTCOMES` may not be computed from `OUTCOME_MARKS`.
+
+    Deriving the allowlist from the display table couples a cosmetic edit to
+    the security rule: adding a new display style would widen the set of
+    outcomes the gate accepts, so the unknown-outcome red never fires — and
+    because failure is its own separate set, the new outcome would be neither
+    blocked nor flagged. A new failure state shipping green out of a one-line
+    display edit is precisely the coupling these three names exist to break.
+    """
+    for name in ("KNOWN_OUTCOMES", "BLOCKING_OUTCOMES"):
+        referenced = {n.id for n in ast.walk(_assignment(name))
+                      if isinstance(n, ast.Name)}
+        assert "OUTCOME_MARKS" not in referenced, (
+            f"{name} is derived from OUTCOME_MARKS; a display edit would move "
+            "the security rule")
+
+
+def test_every_outcome_the_engine_emits_is_known_marked_and_covered() -> None:
+    """A census, not a spot check: the engine's vocabulary ⊆ the gate's.
+
+    `config_facts.py` is the only producer of fact outcomes. If it learns a new
+    one and these tables do not, the gate meets an outcome it cannot classify —
+    which is a red build here rather than a wrong verdict in production.
+    """
+    sys.path.insert(0, str(_CONFIG.parent))
+    try:
+        import config  # noqa: PLC0415
+    finally:
+        sys.path.pop(0)
+
+    facts_source = (_CONFIG.parent / "config_facts.py").read_text(encoding="utf-8")
+    emitted = {value for value in ("pass", "fail", "unmeasured")
+               if f'"{value}"' in facts_source}
+    assert emitted, "found no outcome literals in config_facts.py — census broken"
+
+    assert emitted <= set(config.KNOWN_OUTCOMES), (
+        f"config_facts emits {sorted(emitted - set(config.KNOWN_OUTCOMES))}, "
+        "which the gate cannot classify")
+    assert set(config.KNOWN_OUTCOMES) <= set(config.OUTCOME_MARKS), (
+        "every known outcome needs a display mark, or the summary invents one")
+    assert set(config.BLOCKING_OUTCOMES) <= set(config.KNOWN_OUTCOMES), (
+        "an outcome that blocks must also be one the gate recognises")
+    assert config.coverage_is_complete() is True
+
+
+def test_coverage_is_complete_can_actually_fail() -> None:
+    """The census predicate is not a constant `True` in disguise."""
+    sys.path.insert(0, str(_CONFIG.parent))
+    try:
+        import config  # noqa: PLC0415
+    finally:
+        sys.path.pop(0)
+
+    assert config.coverage_is_complete(
+        blocking={"nonesuch"}, known={"pass"}, marks={"pass": "PASS"}) is False

--- a/tests/test_ci_secure_gate_workflow.py
+++ b/tests/test_ci_secure_gate_workflow.py
@@ -3,9 +3,11 @@
 `.github/workflows/ci-secure-check.yml` splits the scan in two: fork PRs run on a
 GitHub-hosted runner, everything else dogfoods StarSling's. Those two jobs are
 mutually exclusive, so neither of their check names is safe to require in branch
-protection — a required check that never runs is reported as absent, not as red, and
-GitHub lets the pull request merge. A fork could therefore fail the security scan and
-still merge, which is precisely the hole the gate exists to close.
+protection — a job skipped by a conditional reports Success to the required-check rule,
+so requiring the self-hosted job's name would be satisfied by a fork PR never running
+it. A fork could therefore fail the security scan and still merge, which is precisely
+the hole the gate exists to close. (A check that is genuinely absent stays Pending and
+does block; it is the skip that reads as green, which is why this is easy to miss.)
 
 The fix is a third job that always runs and carries the bare `ci-secure` name: it
 passes only when the one scan that was supposed to run actually ran and passed. These
@@ -82,6 +84,33 @@ def test_the_required_check_is_a_verdict_over_both_scans(workflow: dict, verdict
     assert "verdict" not in workflow["jobs"] or workflow["jobs"]["verdict"] is verdict
 
 
+def test_the_gate_still_fires_on_pull_requests(workflow: dict) -> None:
+    """The triggers themselves, which nothing else here pins.
+
+    Every other test in this file assumes the workflow runs. Delete `pull_request`
+    from the `on:` block and all of them still pass while the required `ci-secure`
+    check silently stops being produced on pull requests — the exact outcome this
+    whole PR exists to prevent, reached by deleting one line.
+    """
+    # PyYAML parses a bare `on:` key as the boolean True.
+    triggers = workflow[True]
+    assert "pull_request" in triggers, (
+        "the gate must run on pull requests, or the required check is never reported"
+    )
+    assert "push" in triggers and triggers["push"]["branches"] == ["main"], (
+        "main must be scanned too, or a direct push could land what a PR could not"
+    )
+
+
+def test_the_verdict_job_has_no_event_narrowing_condition(verdict: dict) -> None:
+    """`if: always()` and nothing else.
+
+    An added `github.event_name == ...` clause would make the check disappear on
+    some events — and a required check that is skipped reads as a pass.
+    """
+    assert " ".join(str(verdict["if"]).split()) == "always()"
+
+
 def test_the_scan_jobs_do_not_claim_the_required_name(workflow: dict) -> None:
     """The scan jobs are reported under distinguishable names.
 
@@ -106,9 +135,16 @@ def test_the_scan_jobs_stay_mutually_exclusive_and_cover_every_event(workflow: d
     # The two guards are exact complements of one predicate, so their union is
     # total and their intersection empty for every event. Comparing full_name to
     # the repository — the predicate ci.yml and ci-fork.yml already use — is what
-    # makes that true: `head.repo` is null once a fork is deleted while its PR is
-    # open, and in GitHub expressions `null == false` and `null == true` are BOTH
-    # false, so a `.fork`-based pair would skip both jobs on exactly that PR.
+    # makes that true, and the reason is worth stating precisely, because the
+    # obvious alternative fails in the dangerous direction.
+    #
+    # `head.repo` is null once a fork is deleted while its PR is still open.
+    # GitHub expressions compare mismatched types by casting to a number, and null
+    # casts to 0 — the same as `false`. So `head.repo.fork == false` is TRUE on
+    # that PR, and a `.fork`-based pair would hand fork-ref code to the SELF-HOSTED
+    # job. Comparing against a repository name casts to NaN instead, and NaN equals
+    # nothing: the `==` guard is false and the `!=` guard is true, so the
+    # deleted-fork PR goes to the GitHub-hosted job, where it belongs.
     predicate = "github.event.pull_request.head.repo.full_name == github.repository"
     assert " ".join(scan["if"].split()) == f"github.event_name != 'pull_request' || {predicate}"
     assert " ".join(fork["if"].split()) == (
@@ -140,10 +176,14 @@ def test_the_verdict_reads_both_results_from_env_not_interpolation(verdict: dict
     """Job results reach the script through `env:`, never spliced into the shell text."""
     step = verdict["steps"][0]
     env = step["env"]
-    assert set(env.values()) == {
-        "${{ needs.scan.result }}",
-        "${{ needs.scan-fork.result }}",
+    assert env == {
+        "SELF_HOSTED": "${{ needs.scan.result }}",
+        "FORK": "${{ needs.scan-fork.result }}",
     }
+    # Names, not just values: renaming a key in the YAML while the script still
+    # reads the old one makes the required check permanently red under `set -u`.
+    for name in env:
+        assert f"${{{name}}}" in step["run"], f"{name} is set but never read"
     assert "${{" not in step["run"], (
         "expressions interpolated straight into a run: block are a template-injection "
         "shape; pass them through env: instead"

--- a/tests/test_ci_secure_gate_workflow.py
+++ b/tests/test_ci_secure_gate_workflow.py
@@ -1,0 +1,200 @@
+"""The ci-secure gate must report one check name, and that name must mean "it passed".
+
+`.github/workflows/ci-secure-check.yml` splits the scan in two: fork PRs run on a
+GitHub-hosted runner, everything else dogfoods StarSling's. Those two jobs are
+mutually exclusive, so neither of their check names is safe to require in branch
+protection — a required check that never runs is reported as absent, not as red, and
+GitHub lets the pull request merge. A fork could therefore fail the security scan and
+still merge, which is precisely the hole the gate exists to close.
+
+The fix is a third job that always runs and carries the bare `ci-secure` name: it
+passes only when the one scan that was supposed to run actually ran and passed. These
+tests pin both halves — the shape (one always-running job owns the name, and nothing
+else claims it) and the behaviour (the verdict script itself, executed against every
+combination of upstream job results).
+
+Pure YAML and shell; no network, no runner, no token.
+"""
+from __future__ import annotations
+
+import itertools
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+_REPO = Path(__file__).resolve().parents[1]
+_WORKFLOW = _REPO / ".github" / "workflows" / "ci-secure-check.yml"
+
+# The check name branch protection is told to require. It must belong to exactly one
+# job, and that job must run on every event the workflow fires on.
+_REQUIRED_CHECK = "ci-secure"
+
+# Every result GitHub can report for a `needs:` dependency.
+_RESULTS = ("success", "failure", "cancelled", "skipped")
+
+# The only two ways the gate can legitimately be satisfied: one scan ran and passed,
+# and the other was skipped because it was not applicable to this event.
+_PASSING = {("success", "skipped"), ("skipped", "success")}
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:
+    assert _WORKFLOW.is_file(), f"{_WORKFLOW} is missing"
+    return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def verdict(workflow: dict) -> dict:
+    named = [job for job in workflow["jobs"].values() if job.get("name") == _REQUIRED_CHECK]
+    assert len(named) == 1, (
+        f"exactly one job may be called {_REQUIRED_CHECK!r} - branch protection requires "
+        f"that name, and {len(named)} jobs claim it"
+    )
+    return named[0]
+
+
+@pytest.fixture(scope="module")
+def verdict_script(verdict: dict) -> str:
+    steps = verdict["steps"]
+    assert len(steps) == 1, "the verdict job should be a single script step"
+    return steps[0]["run"]
+
+
+def test_the_required_check_is_a_verdict_over_both_scans(workflow: dict, verdict: dict) -> None:
+    """The `ci-secure` name belongs to a job that always runs and needs both scans.
+
+    If it needed only one scan, or carried an `if:` that a fork PR could fail, the
+    required check would go missing on exactly the pull requests it most needs to
+    block.
+    """
+    assert set(verdict["needs"]) == {"scan", "scan-fork"}, (
+        f"the verdict must depend on both scan jobs, not {verdict.get('needs')!r}"
+    )
+    assert " ".join(str(verdict["if"]).split()) == "always()", (
+        f"the verdict job's if: is {verdict['if']!r}; anything narrower than always() "
+        "lets the required check go absent when an upstream scan fails or is skipped"
+    )
+    assert "verdict" not in workflow["jobs"] or workflow["jobs"]["verdict"] is verdict
+
+
+def test_the_scan_jobs_do_not_claim_the_required_name(workflow: dict) -> None:
+    """The scan jobs are reported under distinguishable names.
+
+    A scan job called `ci-secure` would let branch protection be pointed at a check
+    that a fork PR never produces.
+    """
+    scans = {jid: workflow["jobs"][jid] for jid in ("scan", "scan-fork")}
+    for jid, job in scans.items():
+        assert job["name"] != _REQUIRED_CHECK, f"{jid} must not claim the required check name"
+        assert _REQUIRED_CHECK in job["name"], f"{jid}'s name should still read as a ci-secure run"
+    assert scans["scan"]["name"] != scans["scan-fork"]["name"]
+
+
+def test_the_scan_jobs_stay_mutually_exclusive_and_cover_every_event(workflow: dict) -> None:
+    """Fork code never reaches a self-hosted runner, and every event still gets a scan."""
+    scan = workflow["jobs"]["scan"]
+    fork = workflow["jobs"]["scan-fork"]
+
+    assert scan["runs-on"].startswith("starsling-"), "non-fork scans dogfood StarSling runners"
+    assert fork["runs-on"] == "ubuntu-latest", "fork code runs only on GitHub-hosted runners"
+
+    # The two guards are exact complements of one predicate, so their union is
+    # total and their intersection empty for every event. Comparing full_name to
+    # the repository — the predicate ci.yml and ci-fork.yml already use — is what
+    # makes that true: `head.repo` is null once a fork is deleted while its PR is
+    # open, and in GitHub expressions `null == false` and `null == true` are BOTH
+    # false, so a `.fork`-based pair would skip both jobs on exactly that PR.
+    predicate = "github.event.pull_request.head.repo.full_name == github.repository"
+    assert " ".join(scan["if"].split()) == f"github.event_name != 'pull_request' || {predicate}"
+    assert " ".join(fork["if"].split()) == (
+        f"github.event_name == 'pull_request' && {predicate.replace(' == ', ' != ')}"
+    )
+
+    assert scan["steps"][-1]["run"] == fork["steps"][-1]["run"], (
+        "both runners must execute the identical gate, or the fork twin is a weaker check"
+    )
+    assert scan["steps"][-1]["run"] == "python3 .github/scripts/ci_secure_gate.py", (
+        "the jobs must run the gate, not the engine: scan.py prints its JSON and exits 0 "
+        "whatever it found, so a step that calls it directly is a green-forever check"
+    )
+
+
+def test_the_verdict_job_is_hosted_and_checks_out_nothing(verdict: dict) -> None:
+    """A fork PR can rewrite this job's script, so it must not run on our own runners."""
+    assert verdict["runs-on"] == "ubuntu-latest", (
+        "the verdict job runs on fork pull requests and its script travels with the head "
+        "ref; a self-hosted runner here would execute fork-authored shell on our hardware"
+    )
+    assert isinstance(verdict["timeout-minutes"], int) and 0 < verdict["timeout-minutes"] <= 15
+    assert not any("uses" in step for step in verdict["steps"]), (
+        "the verdict job compares two strings; it has no reason to check out code"
+    )
+
+
+def test_the_verdict_reads_both_results_from_env_not_interpolation(verdict: dict) -> None:
+    """Job results reach the script through `env:`, never spliced into the shell text."""
+    step = verdict["steps"][0]
+    env = step["env"]
+    assert set(env.values()) == {
+        "${{ needs.scan.result }}",
+        "${{ needs.scan-fork.result }}",
+    }
+    assert "${{" not in step["run"], (
+        "expressions interpolated straight into a run: block are a template-injection "
+        "shape; pass them through env: instead"
+    )
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash is required to run the gate script")
+@pytest.mark.parametrize("self_hosted,fork", list(itertools.product(_RESULTS, repeat=2)))
+def test_the_verdict_passes_only_when_a_scan_actually_passed(
+    verdict_script: str, self_hosted: str, fork: str, tmp_path: Path
+) -> None:
+    """Run the real script from the workflow against every pair of upstream results.
+
+    This is the assertion that would have caught the original hole: with the two scan
+    jobs reporting under separate names there was no script to run at all, and the
+    fork twin's failure simply left the required check unreported.
+    """
+    script = tmp_path / "verdict.sh"
+    script.write_text(verdict_script, encoding="utf-8")
+
+    proc = subprocess.run(
+        ["bash", str(script)],
+        env={"PATH": "/usr/bin:/bin", "SELF_HOSTED": self_hosted, "FORK": fork},
+        capture_output=True,
+        text=True,
+    )
+
+    should_pass = (self_hosted, fork) in _PASSING
+    assert (proc.returncode == 0) is should_pass, (
+        f"self-hosted={self_hosted}, fork={fork} exited {proc.returncode}; "
+        f"expected {'pass' if should_pass else 'fail'}\n{proc.stdout}\n{proc.stderr}"
+    )
+    if not should_pass:
+        assert "::error::" in proc.stdout, "a failing verdict must annotate the check run"
+
+
+def test_the_workflow_grants_no_more_than_read(workflow: dict) -> None:
+    """The gate only reads the checked-out tree; no job may escalate."""
+    assert workflow["permissions"] == {"contents": "read"}
+    for jid, job in workflow["jobs"].items():
+        assert "permissions" not in job, f"{jid} must not widen the workflow's read-only grant"
+
+
+def test_actions_are_pinned_to_full_shas(workflow: dict) -> None:
+    """Matches every other workflow in this repo: no mutable tags."""
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    for job in workflow["jobs"].values():
+        for step in job["steps"]:
+            ref = step.get("uses")
+            if ref is None:
+                continue
+            _, _, version = ref.partition("@")
+            assert re.fullmatch(r"[0-9a-f]{40}", version), f"{ref} is not pinned to a commit SHA"
+            assert re.search(rf"{re.escape(ref)}\s+# v", text), f"{ref} has no `# vX.Y.Z` comment"

--- a/tests/test_ci_secure_gate_workflow.py
+++ b/tests/test_ci_secure_gate_workflow.py
@@ -195,9 +195,69 @@ def test_only_the_trusted_job_can_run_the_network_gated_check(workflow: dict) ->
 
     assert fork["env"]["CI_SECURE_GH_IMPOSTOR"] == "off", (
         "the fork twin must turn it off explicitly, not leave it to a default")
-    assert not any("TOKEN" in key.upper() for key in fork.get("env", {})), (
-        "the fork job runs pull-request-authored code and must not be handed a "
-        "token of any kind")
+    # Checked at all THREE scopes a variable can be set at, because they all
+    # reach the same step. Asserting only on the step's own `env:` let a
+    # job-level `GH_TOKEN` — the identical exposure — through.
+    for scope, env in (("workflow", workflow.get("env") or {}),
+                       ("job", workflow["jobs"]["scan-fork"].get("env") or {}),
+                       ("step", fork.get("env") or {})):
+        assert not any("TOKEN" in key.upper() for key in env), (
+            f"a token-shaped variable is set at {scope} scope and reaches the "
+            "fork job, which runs pull-request-authored code and must not be "
+            "handed a credential of any kind")
+
+    # Belt and braces: no `secrets.` reference anywhere in the fork job,
+    # whatever the variable happens to be named.
+    fork_yaml = yaml.safe_dump(workflow["jobs"]["scan-fork"])
+    assert "secrets." not in fork_yaml, (
+        f"the fork job references a secret:\n{fork_yaml}")
+
+
+def test_the_scan_jobs_do_not_leave_the_job_token_in_the_checkout(
+        workflow: dict) -> None:
+    """This workflow gets the same credential scoping it enforces on everyone else.
+
+    The gate is a Python program reading the checked-out tree, and on a fork PR
+    the author wrote that tree. GitHub's default checkout leaves the job token
+    in `.git/config`; nothing here needs it, so nothing here should carry it.
+    The engine's own `sec.checkout.credentials-scoped` fact is scoped to
+    untrusted triggers and passes either way, so only this test holds the line —
+    which is why removing both `persist-credentials: false` lines was previously
+    green everywhere.
+    """
+    for name in ("scan", "scan-fork"):
+        checkouts = [step for step in workflow["jobs"][name]["steps"]
+                     if "actions/checkout" in str(step.get("uses", ""))]
+        assert checkouts, f"{name} checks nothing out"
+        for step in checkouts:
+            assert step.get("with", {}).get("persist-credentials") is False, (
+                f"{name}'s checkout persists the job token into .git/config")
+
+
+def test_the_engine_timeout_stays_inside_the_jobs_own_clock() -> None:
+    """A timeout at parity with the job clock can never fire.
+
+    The gate's `ENGINE_TIMEOUT_S` exists so a hung engine fails with a STATED
+    cause instead of an unexplained job cancellation. That only works while it
+    is strictly shorter than the job's `timeout-minutes` — and it must clear it
+    by enough to cover checkout and pip, which have already spent part of that
+    clock before the gate starts. This is the regression that shipped once
+    already, and nothing but arithmetic catches it.
+    """
+    gate = (_REPO / ".github" / "scripts" / "ci_secure_gate.py").read_text(
+        encoding="utf-8")
+    match = re.search(r"or (\d+)\)\n", gate) or re.search(
+        r"ENGINE_TIMEOUT_S = (\d+)", gate)
+    assert match, "ENGINE_TIMEOUT_S is not a readable literal any more"
+    engine_timeout = int(match.group(1))
+
+    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    for name in ("scan", "scan-fork"):
+        job_budget = workflow["jobs"][name]["timeout-minutes"] * 60
+        assert engine_timeout < job_budget, (
+            f"{name}: the engine timeout ({engine_timeout}s) is not shorter than "
+            f"the job's own budget ({job_budget}s), so it can never fire and a "
+            "hung engine reaches the check run as an unexplained cancellation")
 
 
 def test_a_weekly_run_rechecks_the_default_branch_and_demands_completeness(
@@ -223,8 +283,12 @@ def test_a_weekly_run_rechecks_the_default_branch_and_demands_completeness(
 
     env = workflow["jobs"]["scan"]["steps"][-1]["env"]
     strict = " ".join(str(env["CI_SECURE_GH_STRICT"]).split())
-    assert "schedule" in strict, (
-        "the scheduled run must demand a complete network check; strict mode is "
+    # Both branches, not a substring. `"schedule" in strict` is satisfied by the
+    # exact INVERSION of this policy — strict on every pull request and lax on
+    # the weekly run — which would block PRs on somebody else's rate limit while
+    # muting the one run that catches rot.
+    assert strict == "${{ github.event_name == 'schedule' && '1' || '0' }}", (
+        "strict mode must be ON for the scheduled run and OFF elsewhere; it is "
         f"wired as {strict!r}")
 
     # The concurrency key separates events, so the weekly run cannot be
@@ -311,3 +375,34 @@ def test_actions_are_pinned_to_full_shas(workflow: dict) -> None:
             _, _, version = ref.partition("@")
             assert re.fullmatch(r"[0-9a-f]{40}", version), f"{ref} is not pinned to a commit SHA"
             assert re.search(rf"{re.escape(ref)}\s+# v", text), f"{ref} has no `# vX.Y.Z` comment"
+
+
+def test_codeowners_covers_every_path_that_could_forge_a_pass() -> None:
+    """The three paths the workflow's own comments say review must watch.
+
+    On a fork pull request the gate script, the engine and this workflow all
+    come from the head ref, so nothing inside CI can vouch for the scan. What
+    closes that is a human reading the diff, and CODEOWNERS is what routes it.
+    The engine's `sec.codeowners.workflows` fact only asks whether
+    `.github/workflows/` is covered, so deleting the other rules is green
+    everywhere else — including in the gate's own scan of this repo.
+
+    `pyproject.toml` is here because it is the off-switch for the tests: its
+    `testpaths` list is what makes the suites below run at all, and removing an
+    entry disables them without touching an owned path.
+    """
+    codeowners = _REPO / ".github" / "CODEOWNERS"
+    assert codeowners.is_file(), "CODEOWNERS is missing; the fork caveat rests on it"
+    rules = [line.split() for line in
+             codeowners.read_text(encoding="utf-8").splitlines()
+             if line.strip() and not line.lstrip().startswith("#")]
+    owned = {parts[0]: parts[1:] for parts in rules if len(parts) > 1}
+
+    for path in ("/.github/", "/skills/ci-secure/", "/tests/", "/pyproject.toml"):
+        assert path in owned, (
+            f"{path} has no CODEOWNERS rule. A pull request can edit the code "
+            "that judges it, so every path that could forge a pass — the "
+            "workflow, the engine, the tests that pin the rules, and the file "
+            "that decides which tests run — must route to a human reviewer.")
+        assert any(owner.startswith("@") for owner in owned[path]), (
+            f"{path} has a CODEOWNERS rule with no owner")

--- a/tests/test_ci_secure_gate_workflow.py
+++ b/tests/test_ci_secure_gate_workflow.py
@@ -246,10 +246,18 @@ def test_the_engine_timeout_stays_inside_the_jobs_own_clock() -> None:
     """
     gate = (_REPO / ".github" / "scripts" / "ci_secure_gate.py").read_text(
         encoding="utf-8")
-    match = re.search(r"or (\d+)\)\n", gate) or re.search(
-        r"ENGINE_TIMEOUT_S = (\d+)", gate)
-    assert match, "ENGINE_TIMEOUT_S is not a readable literal any more"
+    # Anchored on the ceiling's own name rather than on `or NNN)`, which would
+    # match the first such fragment anywhere in the file.
+    match = re.search(r"^_TIMEOUT_CEILING = (\d+)$", gate, re.M) or re.search(
+        r"^ENGINE_TIMEOUT_S = (\d+)$", gate, re.M)
+    assert match, "the engine timeout is not a readable literal any more"
     engine_timeout = int(match.group(1))
+
+    # The env override must be clamped to that ceiling, or a workflow could set
+    # the timeout back out of reach and this test — which reads the source —
+    # would still pass.
+    assert "_TIMEOUT_CEILING" in gate and "ENGINE_TIMEOUT_S = _TIMEOUT_CEILING" in gate, (
+        "the engine timeout override is no longer clamped to a ceiling")
 
     workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
     for name in ("scan", "scan-fork"):

--- a/tests/test_ci_secure_gate_workflow.py
+++ b/tests/test_ci_secure_gate_workflow.py
@@ -154,10 +154,83 @@ def test_the_scan_jobs_stay_mutually_exclusive_and_cover_every_event(workflow: d
     assert scan["steps"][-1]["run"] == fork["steps"][-1]["run"], (
         "both runners must execute the identical gate, or the fork twin is a weaker check"
     )
-    assert scan["steps"][-1]["run"] == "python3 .github/scripts/ci_secure_gate.py", (
+    run = scan["steps"][-1]["run"]
+    assert run == "python3 .github/scripts/ci_secure_gate.py", (
         "the jobs must run the gate, not the engine: scan.py prints its JSON and exits 0 "
         "whatever it found, so a step that calls it directly is a green-forever check"
     )
+    # String identity alone is not enough, and neither is existence alone. A
+    # rename that updates the workflow and forgets nothing still has to point at
+    # a file that is there; and `is_file()` on its own would be satisfied just as
+    # happily by `python3 skills/ci-secure/scripts/scan.py`, which is the
+    # green-forever substitution the string assert above exists to block.
+    assert (_REPO / run.split()[-1]).is_file(), (
+        f"the workflow runs {run.split()[-1]!r}, which does not exist")
+
+
+def test_only_the_trusted_job_can_run_the_network_gated_check(workflow: dict) -> None:
+    """The impostor check runs for real where there is a token, and nowhere else.
+
+    P14.11 verifies that each pinned action SHA actually exists in the action's
+    canonical repository — the check that catches an impostor pin pointing at a
+    fork-only or dangling commit. It needs the network and an authenticated
+    `gh`, so it only runs in the job that has one.
+
+    The fork twin deliberately does not get one. That job executes code the
+    pull request author wrote, and handing it a token variable would be
+    handing attacker-authored steps a credential to use — a much larger loss
+    than the coverage gained. It runs with the check OFF and says so on both
+    surfaces instead, because a check that did not run is never a pass.
+    """
+    scan = workflow["jobs"]["scan"]["steps"][-1]
+    fork = workflow["jobs"]["scan-fork"]["steps"][-1]
+
+    assert scan["env"]["CI_SECURE_GH_IMPOSTOR"] == "on", (
+        "the trusted job must turn the check on explicitly; omitting it lands on "
+        "the engine's `auto`, where a runner image decides whether a security "
+        "check runs")
+    assert scan["env"]["GH_TOKEN"] == "${{ github.token }}", (
+        "the check needs an authenticated gh; the job's own read-only token is "
+        "the least privilege that works")
+
+    assert fork["env"]["CI_SECURE_GH_IMPOSTOR"] == "off", (
+        "the fork twin must turn it off explicitly, not leave it to a default")
+    assert not any("TOKEN" in key.upper() for key in fork.get("env", {})), (
+        "the fork job runs pull-request-authored code and must not be handed a "
+        "token of any kind")
+
+
+def test_a_weekly_run_rechecks_the_default_branch_and_demands_completeness(
+        workflow: dict) -> None:
+    """Only a scheduled run catches a pin that rots AFTER it merged.
+
+    Every other trigger here judges a proposed change. But an action SHA that
+    is legitimate today can be deleted or orphaned tomorrow, in a repository
+    nobody here controls — nothing about our own pull requests would ever
+    notice. The weekly run against the default branch is the only shape that
+    does.
+
+    It also runs strict: a network check that could not complete is red there,
+    where a pull request only warns. A pull request must not be blocked by
+    someone else's rate limit, but the weekly run has no deadline and nothing
+    to race, and letting it pass on an incomplete check would make the one run
+    that exists to catch rot the easiest one to mute.
+    """
+    triggers = workflow[True] if True in workflow else workflow["on"]
+    assert "schedule" in triggers, "no scheduled run: post-merge pin rot goes unnoticed"
+    crons = [entry["cron"] for entry in triggers["schedule"]]
+    assert crons, "the schedule trigger carries no cron expression"
+
+    env = workflow["jobs"]["scan"]["steps"][-1]["env"]
+    strict = " ".join(str(env["CI_SECURE_GH_STRICT"]).split())
+    assert "schedule" in strict, (
+        "the scheduled run must demand a complete network check; strict mode is "
+        f"wired as {strict!r}")
+
+    # The concurrency key separates events, so the weekly run cannot be
+    # cancelled by an ordinary push — which would silently cost us the one run
+    # that catches rot.
+    assert "github.event_name" in workflow["concurrency"]["group"]
 
 
 def test_the_verdict_job_is_hosted_and_checks_out_nothing(verdict: dict) -> None:

--- a/tests/test_claude_workflow.py
+++ b/tests/test_claude_workflow.py
@@ -118,6 +118,35 @@ def test_id_token_write_is_present(job: dict) -> None:
     assert job["permissions"]["id-token"] == "write"
 
 
+def test_the_grant_set_is_exactly_what_the_action_needs(job: dict) -> None:
+    """The whole permission block, not one key of it.
+
+    This is the most privileged job in the repository — it holds the API key
+    and runs an agent — and every grant here is argued for individually in the
+    workflow's own comments. Pinning only `id-token` left the set open at the
+    top: adding `packages: write` or `security-events: write` would widen the
+    most dangerous job in the repo with nothing going red, while the equivalent
+    test for the security gate already asserts its block exactly. The laxer
+    test was guarding the riskier workflow.
+
+    ci-secure's own `sec.permissions.write-scoped` fact does not cover this: it
+    reads WORKFLOW-level grants, and these are job-level.
+    """
+    assert job["permissions"] == {
+        "contents": "write",
+        "pull-requests": "write",
+        "issues": "write",
+        "id-token": "write",
+        "actions": "read",
+    }, (
+        "the @claude job's grants changed. Each is justified in the workflow's "
+        "comments — id-token for the App token exchange, pull-requests: write "
+        "for the buffered-review-comment fallback, actions: read for the "
+        "read-only CI-status tool. Widening the job that holds the API key is "
+        "a deliberate edit, not a drift."
+    )
+
+
 def test_no_workflow_level_permissions_block(workflow: dict) -> None:
     """Grants stay scoped to the one job that needs them."""
     assert "permissions" not in workflow

--- a/tests/test_claude_workflow.py
+++ b/tests/test_claude_workflow.py
@@ -1,0 +1,171 @@
+"""The @claude workflow's own shape is enforced, so its security decisions cannot rot silently.
+
+`.github/workflows/claude.yml` is the only workflow in this repo that starts from a
+comment, holds an API key, and hands a write-capable agent a checkout of our own
+tree. Every property that makes that safe is a single line that a well-meaning edit
+can delete without anything turning red: drop the `author_association` half of the
+`if:` and any drive-by account starts a job on our self-hosted runners; drop
+`persist-credentials: false` and the job token sits in `.git/config` inside the tree
+Claude's own tools run in; unpin an action and an upstream retag runs unreviewed code
+next to the API key; delete `timeout-minutes` and a stalled agent holds a runner for
+GitHub's six-hour default.
+
+None of those failures are visible in a run. The workflow still triggers, still
+passes, still looks fine. These tests pin the properties instead. They are pure YAML
+and text assertions — no network, no runner, no token — so they run in the same
+offline `pytest -v` as everything else.
+
+They deliberately do NOT assert that Claude behaves well once it is running; the
+action's own access-control and prompt-sanitizing are upstream's, and are documented
+in the file's comments rather than tested here.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+_REPO = Path(__file__).resolve().parents[1]
+_WORKFLOW = _REPO / ".github" / "workflows" / "claude.yml"
+
+# PyYAML parses a bare `on:` key as the boolean True, so the trigger block is read
+# through this constant rather than the string "on".
+_ON_KEY = True
+
+# The maintainer classes GitHub reports for a commenter with standing in this repo.
+# Anything outside this set — CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, NONE — must not be
+# able to start the job.
+_MAINTAINER_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
+
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:
+    assert _WORKFLOW.is_file(), f"{_WORKFLOW} is missing"
+    return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def job(workflow: dict) -> dict:
+    jobs = workflow["jobs"]
+    assert list(jobs) == ["claude"], "the workflow is expected to hold exactly one job"
+    return jobs["claude"]
+
+
+def test_triggers_are_comment_events_only(workflow: dict) -> None:
+    """Only comment events, and only on creation.
+
+    Widening this to `pull_request` or `pull_request_target` would change the trust
+    model entirely — those carry fork context — and an `edited` type would let someone
+    add "@claude" to an already-posted comment.
+    """
+    triggers = workflow[_ON_KEY]
+    assert set(triggers) == {"issue_comment", "pull_request_review_comment"}
+    for name, spec in triggers.items():
+        assert spec["types"] == ["created"], f"{name} should fire on created only"
+
+
+def test_job_gates_on_both_the_mention_and_the_commenter(job: dict) -> None:
+    """The `if:` must require a maintainer AND a mention.
+
+    The mention half alone is what the upstream example ships; on a public repo it
+    lets any account start a job on our self-hosted runners. This test fails if
+    either half is removed, or if the two are ever ORed together.
+    """
+    guard = " ".join(job["if"].split())
+
+    assert "contains(github.event.comment.body, '@claude')" in guard
+    assert "github.event.comment.author_association" in guard
+    assert "&&" in guard, "the two conditions must both hold, not either"
+    assert "||" not in guard, "an OR here would defeat the commenter gate"
+
+    quoted = set(re.findall(r'"([A-Z_]+)"', guard))
+    assert quoted == _MAINTAINER_ASSOCIATIONS, (
+        f"the allowed commenter classes drifted to {sorted(quoted)}; "
+        "adding CONTRIBUTOR or NONE would open the job to outsiders"
+    )
+
+
+def test_the_job_cannot_run_forever_or_race_itself(job: dict) -> None:
+    """A bounded agent run, one at a time per issue/PR.
+
+    Without the timeout a stalled agent holds a self-hosted runner for six hours.
+    Without the concurrency group two mentions produce two agents pushing to one
+    branch. `cancel-in-progress` must stay false: cancelling kills a Claude mid-push.
+    """
+    timeout = job["timeout-minutes"]
+    assert isinstance(timeout, int) and 0 < timeout <= 60, (
+        f"timeout-minutes is {timeout!r}; it must be set and modest"
+    )
+
+    concurrency = job["concurrency"]
+    assert concurrency["cancel-in-progress"] is False
+    assert "github.event.issue.number" in concurrency["group"]
+    assert "github.event.pull_request.number" in concurrency["group"]
+
+
+def test_id_token_write_is_present(job: dict) -> None:
+    """`id-token: write` is load-bearing, not excess privilege.
+
+    The action exchanges the job's OIDC token for the Claude App installation token
+    that makes pushes come from the app rather than a maintainer. A least-privilege
+    sweep that removes it breaks the workflow, so it is pinned with the reason.
+    """
+    assert job["permissions"]["id-token"] == "write"
+
+
+def test_no_workflow_level_permissions_block(workflow: dict) -> None:
+    """Grants stay scoped to the one job that needs them."""
+    assert "permissions" not in workflow
+
+
+def test_every_action_is_pinned_to_a_full_sha(job: dict) -> None:
+    """No mutable tags in a job that holds the API key and write permissions.
+
+    A tag can be moved upstream; a SHA cannot. This matches every other workflow in
+    the repo, and the `# vX.Y.Z` comment keeps the pin readable for humans.
+    """
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    uses = [step["uses"] for step in job["steps"]]
+    assert uses, "the job should have steps"
+
+    for ref in uses:
+        _, _, version = ref.partition("@")
+        assert _SHA_RE.match(version), f"{ref} is not pinned to a 40-character commit SHA"
+        assert re.search(rf"{re.escape(ref)}\s+# v", text), (
+            f"{ref} has no `# vX.Y.Z` comment naming the version it pins"
+        )
+
+
+def test_checkout_does_not_persist_the_job_token(job: dict) -> None:
+    """The job token must not be left in `.git/config`.
+
+    Claude's Bash tool runs inside this working tree. The action swaps in its own App
+    token for pushes either way, so this flag costs nothing and closes the window
+    between checkout and that swap — including when the run fails in between.
+    """
+    checkout = next(s for s in job["steps"] if s["uses"].startswith("actions/checkout@"))
+    assert checkout["with"]["persist-credentials"] is False
+
+
+def test_github_token_is_never_passed_to_the_action(job: dict) -> None:
+    """Passing `github_token` would silently stop CI from running on Claude's commits.
+
+    GitHub does not trigger workflows on commits made with the default GITHUB_TOKEN.
+    Omitting the input is what makes the action authenticate as the Claude App, whose
+    commits do trigger CI. This is easy to "helpfully" add back, and nothing would
+    look broken — CI would just stop running on Claude's pushes.
+    """
+    action = next(
+        s for s in job["steps"] if s["uses"].startswith("anthropics/claude-code-action@")
+    )
+    assert "github_token" not in action.get("with", {})
+
+
+def test_runner_matches_the_rest_of_the_repo(job: dict) -> None:
+    """This repo dogfoods StarSling runners for its own CI."""
+    assert job["runs-on"] == "starsling-ubuntu-24.04"


### PR DESCRIPTION
## TL;DR

Two features that prove each other. First: our own CI-security scanner now runs on every pull request to this repo and fails the build when a workflow change weakens CI security — the gap that let an unsafe workflow merge and forced its revert. It produces the verdict; making that verdict actually *block* a merge is one settings change after this lands, adding `ci-secure` to the required checks, which is deliberately not in this diff. Second: the @claude workflow returns, hardened. This PR is its own demonstration: an early commit goes red because the gate catches the restored workflow's real security flaw, and the next one hardens it and turns it green. That fail → fix → pass sequence really happened, but the branch has since been rebased, so the two commits that carry it are no longer in this PR's history and the checks tab shows only green. The evidence is the runs themselves: [the red](https://github.com/starslingdev/skills/actions/runs/31759858807) — `ci-secure fact failed: sec.checkout.credentials-scoped` — and [the green that followed](https://github.com/starslingdev/skills/actions/runs/31759964459).

```
Act 1:  unhardened @claude workflow + the new gate  ->  ci-secure check: RED
Act 2:  hardening commit (same PR)                  ->  ci-secure check: GREEN
```

## What's in the PR

- **`.github/workflows/ci-secure-check.yml`** — ci-secure as a CI check. Runs the in-tree engine against this repo's own `.github/workflows` on every pull request and push to main, plus a weekly run against main. Any failed security fact fails the build; severity-rated findings (like the accepted write-permission-on-comment-trigger that IS the @claude feature) never block but always surface, as check-tab warnings and in the job summary. Fork PRs run the same scan on a GitHub-hosted runner, since the scan needs no secrets. A third job always runs and carries the single `ci-secure` check name, passing only when the scan that was supposed to run actually ran and passed — so a fork PR cannot satisfy a required check by skipping it.
- **`.github/scripts/ci_secure_gate.py`** — the gate logic. Green here means a scan ran and returned a verdict, which is a stronger claim than "the scan process exited 0": the engine is deliberately crash-tolerant, so a crashed scoring layer or a scan with no workflows to read still exits 0 with nothing that looks like a failure in it. Every one of those degraded shapes is named and turned red instead. A check that did not run is not a check that passed.
- **`.github/workflows/claude.yml`** — the @claude mention workflow, restored initially exactly as it merged before, then hardened in this PR's second act (credentials-scoped checkout, a timeout, and per-PR concurrency). The maintainer-only trigger gate and the SHA pins were already in the restored file. It is green with one accepted HIGH finding (P14.18, `pull-requests: write` on an untrusted trigger), which is inherent to the feature and surfaced rather than suppressed.
- **`skills/ci-secure/scripts/config.py`** — the blocking rule itself now lives in the skill, as three names that are deliberately independent of each other: which outcomes block, which are recognised at all, and how each is displayed. Deriving the first two from the third reads as tidy and would mean a cosmetic edit could widen what the gate accepts, shipping a new failure state as a pass.
- **`tests/`** — `test_claude_workflow.py` pins each hardening decision; `test_ci_secure_gate*.py` cover the gate, driving the real script against a stub engine and the real verdict script against every combination of upstream job results.
- **`.github/CODEOWNERS`** — routes `.github/` changes to an owner (a ci-secure fact of its own).

## What review found and this PR fixes

**The gate loaded its engine from the tree it was auditing.** Scan root and engine came from the same place, and they are not the same kind of thing: one is the repository under examination, which on a fork pull request an attacker writes. The engine now resolves relative to the gate's own file, and the rule file follows the engine, so the two can never come from different places.

**The network-gated check never ran.** The impostor-SHA check — does each pinned action SHA actually exist in that action's repository — was switched off in both jobs. It now runs for real in the job that can hold a read-only token, stays off where fork-authored code runs, and says which on both surfaces. Cost, measured on this PR's own run: 3.0s for the whole step, five pins verified.

**The summary printed a score.** The aggregate is registered as machine-only — it exists so several engines' scores can be blended — and the report renderer already refused to show it. The CI summary was the one place a reader could manage the number instead of the findings. Counts stay; the number is gone.

**The skill stopped importing on Python 3.9.** Moving the blocking rule into the skill brought `X | Y` type annotations with it, and the one module that carries them lacked the line that makes them safe on 3.9 — the oldest version this project claims to support. Because the same change also put that module in the report renderer's import path, the scanner, the renderer and the gate all failed together, for every user on that version. Every workflow here pins 3.12, so no amount of CI would have caught it. The rule is now a test over every module in the skill rather than a habit.

**A rule file could have forged a green check.** The gate loaded its rule at module scope, outside its own failure handler — and loading a Python file executes it. A rule file whose body called `sys.exit(0)` ended the gate process right there: exit status 0, no output, a green `ci-secure` over a scan that never ran. That is the exact failure this PR exists to prevent, arriving through the one file the gate has to trust. In a vendored layout that file sits beside the engine, so it is reachable by anyone who can write there. The handler catches `BaseException` rather than `Exception` for this reason — `SystemExit` is not an `Exception` — and that clause is now pinned by a test proven red twice: against the original gate, and against the narrowing to `Exception` that a tidy-up would naturally make.

**Six things the gate claimed and did not enforce.** An unset network-check setting quietly meant "off", so deleting one block from a job would have switched a security check off silently — while the error message beside it said that was impossible. The strict-mode switch failed open on a plausible typo, which would have muted the weekly run that exists to catch a pinned action going bad after merge. The engine-timeout override could be set *past* the job clock, putting the timeout out of reach — the very regression it exists to prevent — and is now clamped, with the clamp asserted. The Python 3.9 guard above checked only unions inside annotations, so other constructs that break on 3.9 would have slipped through it. And several properties the code argued for at length — the credential scoping on the gate's own jobs, which tree gets scanned, the fork job's token exposure — had no test at all, so each could be removed without anything going red. Each is now fixed with a test that fails on the unfixed code, or pinned by a test verified to fail on the exact edit it guards against.

## What this gate does not do

On a fork pull request the gate script, the engine and the workflow all come from the head ref, so a fork PR can weaken its own scan in the same pull request that needs scanning. Nothing inside CI closes that — it is inherent to a check whose code the PR edits. What closes it is a human reading a `.github/` diff, which is what CODEOWNERS routes, plus the repo setting requiring approval before any outside PR runs CI. A green fork scan means "nothing obvious", not "cleared".

Two config facts come back **unmeasured** on a CI token — whether required checks are skippable, and the fork-PR approval policy. Both are admin-scoped API reads. They are disclosed as a stated coverage gap and dropped from the score, never counted as passes.

## Adding this gate to another repo

Ask ci-secure to install itself; it copies the engine and gate into your repository rather than fetching anything at build time. That is #52, stacked on this PR.


