### PR TITLE
ci-secure: post-merge follow-up accuracy fixes (P14.24 + required-checks fact)

### DIFF
--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -22,6 +22,61 @@ entries are dated (UTC). Format loosely follows
 
 ### Fixed
 
+- **2026-08-14** — **A single-star branch filter (`branches: ['*']`) no longer
+  certifies a required check.** GitHub's filter glob `*` matches a run of
+  characters that does NOT include a slash, so `feature/x`, `dependabot/…` and
+  every slashed head branch escape it — an always-running job under `['*']`
+  cannot be shown to run on every pull request. It was read as match-all and
+  certified the check while the reachable PR producer could skip; it routes to
+  UNKNOWN now, alongside the other specific-branch filters. `**` still certifies.
+
+- **2026-08-14** — **A push that ignores every branch (`branches-ignore:
+  ['**']`) is treated as a non-producer, not a bypass.** The push fires on no
+  branch, so it can never report a check on a pull request — the check stays
+  pending and the merge is blocked, it does not green. Left as UNKNOWN, a sole
+  skippable producer under it was counted as a bypassable required check and the
+  fact went RED on a repository whose merges are in fact always blocked.
+
+- **2026-08-14** — **A bypassable required check found on a partially-read
+  branch protection now discloses that the required-check list was itself a
+  floor.** When only one protection source could be read (the other 403'd), the
+  fail evidence dropped the partial-read caveat the pass and unmeasured arms
+  both carry, so the reader was judged against a list they were never told was
+  incomplete — a check configured only in the unread source is invisible here.
+
+- **2026-08-14** — **P14.24: an execution whose path BEGINS with an unresolved
+  shell variable (`$MYVAR/tool.sh`) is a coverage note, not a finding.** It was
+  joined onto the working directory and, inside a third-party checkout, fired —
+  but the variable could hold an absolute path that escapes the tree, so
+  resolving it was a guess. The runner's own absolute variables are still
+  resolved, and a variable DEEPER in a path rooted at the fetched directory
+  (`tools/$V/run.sh`) is inside the tree whatever it holds and still fires.
+
+- **2026-08-14** — **P14.24: `bash -o pipefail tools/run.sh` and its kin no
+  longer miss the execution.** `-o` (and bash's `-O`) name a shell OPTION as
+  their value, so the script is the next word; read flatly, `pipefail` was taken
+  for the path and the real execution silently missed. Scoped to the shells —
+  python's `-O` is a boolean and still runs its script.
+
+- **2026-08-14** — **P14.24: a nested command substitution
+  (`OUT=$(echo $(tools/setup.sh))`) is now scanned.** `$(…)` runs its body and a
+  body can hold another `$(…)`; reading only the outer level left the inner
+  execution a silent false clean — no finding, no gap.
+
+- **2026-08-14** — **P14.24: a re-clone of a directory after an earlier pin is
+  no longer read as pinned.** clone → pin → re-clone → run: the tree that runs
+  is the unpinned re-clone, but keeping the FIRST fetch let the pin (which sat
+  between the stale first clone and the execution) suppress the finding, so the
+  job went silent while it ran unpinned remote code. The last unpinned fetch
+  into a destination wins; a genuine pin of that surviving fetch still
+  suppresses.
+
+- **2026-08-14** — **P14.24: a single-line `run:` value written with YAML quotes
+  is read as the parser saw it.** `run: "git clone … && bash x.sh"` was scraped
+  raw, so the quotes reached the shell tokenizer and the whole line came back as
+  one quoted word — the clone and the execution both vanished, a silent false
+  clean. Block scalars and multi-line scalars are unaffected.
+
 - **2026-08-14** — **Test and doc surface reshaped so it stops tripping the
   registry's own scanner.** No behaviour change: every URL these tests build is
   byte-identical at run time, and nothing any test asserts moved. The scanner

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -71,6 +71,16 @@ entries are dated (UTC). Format loosely follows
   into a destination wins; a genuine pin of that surviving fetch still
   suppresses.
 
+- **2026-08-14** — **P14.24: a trailing re-clone nothing runs from no longer
+  buries an earlier clone that WAS executed.** The last-unpinned-fetch-wins rule
+  (above) overwrote the destination with a re-clone even when nothing ran from
+  it; the ordering guard then found no execution after that trailing fetch and
+  the job went silent while an earlier clone had already been executed —
+  `clone → run → re-clone` read as clean. Overwritten clones are now kept as
+  fall-back candidates: the surviving fetch is tried first, and the earlier tree
+  a command actually ran from still fires (and still suppresses when it was
+  pinned before it ran).
+
 - **2026-08-14** — **P14.24: a single-line `run:` value written with YAML quotes
   is read as the parser saw it.** `run: "git clone … && bash x.sh"` was scraped
   raw, so the quotes reached the shell tokenizer and the whole line came back as

--- a/skills/ci-secure/references/security-patterns.md
+++ b/skills/ci-secure/references/security-patterns.md
@@ -625,9 +625,10 @@ Execution shapes matched: an interpreter running a fetched file (`python3`/`node
   - other fetchers: `gh repo clone`, `svn checkout`, `git submodule update --remote`, and package managers pointed at a git ref (`pip install "git+…@main"`, `go install …@latest`, an npm/cargo git dependency);
   - a tarball fetched with `curl`/`wget`, unpacked, and then run;
   - a fetch and its execution separated by a rename (`mv tools built && python3 built/setup.py`);
+  - the mirror of that rename — a third-party tree whose bytes are OVERWRITTEN by the repo's own content before the named file runs (`rm -rf dir/*; cp -r "$GITHUB_WORKSPACE/mine" dir/`), so the fetch into `dir` is real but the executed file is self-owned; the finding names the fetch it can see, and whether a copy-in later replaced those bytes is not tracked;
   - a remote whose URL is set with `git config remote.<name>.url` rather than `git remote add`;
   - execution through an interpreter's INLINE program — `bash -c "…"`, `perl -e`, `php -r`, `pwsh -Command`, `powershell -EncodedCommand` — whose text is not read as commands;
-  - a path built from a variable this scan cannot resolve (`"$TOOLS/setup.sh"`), except for the runner's own absolute variables, which are treated as absolute;
+  - an execution whose path BEGINS with a variable this scan cannot resolve (`"$TOOLS/setup.sh"`) — it could hold an absolute path that escapes the fetched tree, so it is recorded as a coverage note rather than resolved and reported; the runner's own absolute variables (`$GITHUB_WORKSPACE/…`) are the exception, treated as absolute, and a variable DEEPER in a path rooted at the fetched directory (`tools/$V/run.sh`) is inside the tree whatever it holds and still fires;
   - execution through a build driver rather than an interpreter (`make -C tools`), or through a versioned interpreter (`python3.11`);
   - a fetch whose execution happens in a different job (different runner, different tree).
 

--- a/skills/ci-secure/scripts/config_facts.py
+++ b/skills/ci-secure/scripts/config_facts.py
@@ -770,7 +770,14 @@ def _on_mapping(doc: dict) -> dict | None:
 # So an UNKNOWN producer participates — its skip analysis still counts against
 # the check — but it can never be the evidence that a check always reports.
 _ABILITY_YES, _ABILITY_NO, _ABILITY_UNKNOWN = "yes", "no", "unknown"
-_MATCH_ALL_BRANCH_PATTERNS = {"**", "*", "'**'", '"**"'}
+# Only `**` matches EVERY branch. A single `*` is not a synonym for it: in
+# GitHub's filter glob `*` matches a run of characters that does NOT include a
+# slash, so `feature/x`, `dependabot/npm/…` and every other slashed head branch
+# escape it. Treating `*` as match-all certified a required check on a push
+# that never fires for those branches — the same over-certification `**`
+# alongside an exclusion was already taught to avoid — so `*` routes to UNKNOWN
+# with the rest of the specific-branch filters.
+_MATCH_ALL_BRANCH_PATTERNS = {"**", "'**'", '"**"'}
 
 
 def _matches_every_branch(patterns: Any) -> bool:
@@ -808,6 +815,16 @@ def _pr_reporting_ability(doc: dict) -> str:
     if not isinstance(push, dict):
         return _ABILITY_YES          # `on: push` with no filters at all
     branches = push.get("branches")
+    branches_ignore = push.get("branches-ignore")
+    # A `branches-ignore:` that excludes EVERY branch means the push fires on
+    # none of them, so it can never report a check on a pull request — that is
+    # NO, not UNKNOWN. Left as UNKNOWN, a sole producer under it that could also
+    # skip was counted as a bypassable required check and the fact went RED on a
+    # merge that is in fact always blocked (the check stays pending, it does not
+    # green). GitHub does not accept `branches` and `branches-ignore` for the
+    # same event, so a match-all exclusion stands alone and needs no other test.
+    if branches_ignore and _matches_every_branch(branches_ignore):
+        return _ABILITY_NO
     # ANY other filter is a reason the push may not run, whatever the branch
     # pattern says — so all of them have to be read before the match-all
     # shortcut answers. Reading `branches: ['**']` first certified a required
@@ -1214,8 +1231,15 @@ def _required_checks_skippable(
     tail = ((" Not judged: " + _capped(unjudged, 4, "; ") + ".")
             if unjudged else "")
     if bypassable:
+        # `detail` names the branch and, when only one protection source could
+        # be read, carries the partial-read caveat. The pass and unmeasured arms
+        # both surface it; the fail arm dropped it, so a reader shown a
+        # bypassable check was never told the required-check list they were
+        # judged against was itself a floor — a check configured only in the
+        # unread source is invisible here.
         return "fail", (
-            "GitHub reports a SKIPPED required check as passed, and "
+            f"on {detail}, GitHub reports a SKIPPED required check as passed, "
+            "and "
             + _capped(bypassable, 3)
             + " — so nothing in these workflows is guaranteed to report it."
             + tail)

--- a/skills/ci-secure/scripts/scan.py
+++ b/skills/ci-secure/scripts/scan.py
@@ -2879,6 +2879,24 @@ _EXPRESSION_TOKEN_RE = re.compile(r"\$\{\{.*?\}\}", re.S)
 _COMMAND_SUBSTITUTION_RE = re.compile(r"\$\((?:[^()]|\([^()]*\))*\)", re.S)
 
 
+def _substitution_command_bodies(command: str) -> list[str]:
+    """Every command run INSIDE a `$( … )` substitution, at any nesting depth.
+
+    `$(…)` runs its body and its OUTPUT becomes a word, so the body is a command
+    in its own right. A body can itself hold a substitution —
+    `OUT=$(echo $(tools/setup.sh))` — and reading only the outer level left the
+    inner `tools/setup.sh` unscanned: no finding, no gap, a silent false clean.
+    Each body is recursed into before it is split, so an execution nested one or
+    more levels deep is still seen.
+    """
+    out: list[str] = []
+    for match in _COMMAND_SUBSTITUTION_RE.finditer(command):
+        inner = match.group(0)[2:-1]
+        out.extend(_substitution_command_bodies(inner))
+        out.extend(_install_command_segments(inner))
+    return out
+
+
 def _shell_tokens(segment: str) -> list[str]:
     """`segment` split the way a shell would, or `[]` when it cannot be.
 
@@ -2932,6 +2950,27 @@ def _resolve_path(cwd: str, path: str) -> str:
     if path.startswith("/") or _RUNNER_ABSOLUTE_RE.match(path):
         return os.path.normpath(path)
     return os.path.normpath(os.path.join(cwd, path))
+
+
+# A path whose FIRST component is a shell variable (`$FOO/x`, `${FOO}/x`) whose
+# value this scanner cannot know. Joining it onto the working directory is a
+# guess: the variable could hold an absolute path that escapes the fetched tree
+# entirely, so resolving it relative to a third-party checkout and firing was a
+# false positive. The runner-absolute variables (`$GITHUB_WORKSPACE/…` etc.)
+# are excluded — GitHub's contract makes them absolute, so `_resolve_path`
+# already places them, correctly, outside any relative destination. The
+# scanner's own stand-ins are excluded too: a `${{ }}` expression collapses to a
+# NUL-delimited `$EXPR<n>` token, `${{ github.repository }}` to `$SELF_REPO`,
+# and a `$(…)` substitution to `$SUBST`.
+_LEADING_SHELL_VAR_RE = re.compile(r"^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?(?:/|$)")
+
+
+def _leading_unresolved_var(path: str) -> bool:
+    if "\x00" in path or _RUNNER_ABSOLUTE_RE.match(path):
+        return False
+    if path.startswith(_SELF_REPO_TOKEN) or path.startswith("$SUBST"):
+        return False
+    return bool(_LEADING_SHELL_VAR_RE.match(path))
 
 
 def _under(dest: str, path: str) -> bool:
@@ -3207,6 +3246,16 @@ _INLINE_LONG_FLAGS = {
 # warning filter. Case matters: python's `-W` takes a value, perl's `-w` is a
 # boolean, and conflating them ate the script path after it.
 _INTERPRETER_VALUE_OPTS = {"-W"}
+# Shell-only value options. `bash -o pipefail script.sh` and its kin name a
+# shell OPTION as the value of `-o` (and `-O` for a bash `shopt` name), so the
+# path is the NEXT word — read flatly, `pipefail` was taken for the script and
+# the real execution silently missed. Scoped to the shells because python's
+# `-O` is a boolean (`python3 -O tool.py` runs `tool.py`), so a global entry
+# would eat the script there. `sh`/dash carries `-o` but not `-O`.
+_SHELL_VALUE_OPTS = {
+    "bash": {"-o", "-O"}, "zsh": {"-o", "-O"}, "ksh": {"-o", "-O"},
+    "sh": {"-o"},
+}
 # `-m` names a MODULE, which is not a path at all.
 _MODULE_FLAGS = {"-m"}
 
@@ -3219,6 +3268,7 @@ def _interpreter_executed_path(cmd: str, rest: list[str]) -> str | None:
     interpreter.
     """
     letters = _INLINE_LETTER_FLAGS.get(cmd, set())
+    value_opts = _INTERPRETER_VALUE_OPTS | _SHELL_VALUE_OPTS.get(cmd, set())
     i = 0
     while i < len(rest):
         tok = rest[i]
@@ -3233,12 +3283,12 @@ def _interpreter_executed_path(cmd: str, rest: list[str]) -> str | None:
             return None
         if tok in _MODULE_FLAGS:
             return None                      # a module name is not a path
+        if tok in value_opts:
+            i += 2                           # the value is not the program
+            continue
         if tok.startswith("-") and not tok.startswith("--") and len(tok) > 1:
             if letters & set(tok[1:]):
                 return None                  # `-c`, `-lc`, `-lane`, `-pe`, …
-        if tok in _INTERPRETER_VALUE_OPTS:
-            i += 2                           # the value is not the program
-            continue
         i += 1
     return None
 
@@ -3266,6 +3316,7 @@ def _job_shell_commands(
     lines = text.splitlines()
     shell_lines = _run_scalar_line_numbers(text)
     step_starts = _run_scalar_starts(text)
+    inline_values = _inline_run_values(text)
     start, end = job_range if job_range else (1, len(lines))
     out: list[tuple[int, str, str, bool]] = []
     heredoc: str | None = None
@@ -3293,7 +3344,11 @@ def _job_shell_commands(
         # the file reads as an unparsable command.
         key = _RUN_KEY_LINE_RE.match(cmd)
         if key and key.group(2) and not _BLOCK_SCALAR_RE.match(key.group(2).strip()):
-            cmd = key.group(2)
+            # Prefer the parser's own value for a single-line scalar, so YAML
+            # quoting (`run: "git clone … && bash x.sh"`) is stripped before the
+            # shell tokenizer sees it. Multi-line scalars are not in the map and
+            # keep the raw line.
+            cmd = inline_values.get(line_no, key.group(2))
         out.append((line_no, raw, cmd, line_no in step_starts))
         opened = _heredoc_delimiter(cmd)
         if opened:
@@ -3322,6 +3377,8 @@ class _StepMark:
     uses: str | None            # the action the step runs, verbatim
     start_line: int             # 1-based first line of the step itself
     end_line: int               # 1-based last line of the step
+    run_value: str | None = None      # the `run:` scalar, as the PARSER read it
+    run_end_line: int | None = None   # 1-based line the `run:` VALUE ends on
 
 
 def _step_marks(text: str) -> list[_StepMark] | None:
@@ -3382,6 +3439,10 @@ def _step_marks(text: str) -> list[_StepMark] | None:
                       if uses is not None and hasattr(uses, "value") else None),
                 start_line=step.start_mark.line + 1,
                 end_line=step.end_mark.line + 1,
+                run_value=(str(run.value)
+                           if run is not None and hasattr(run, "value")
+                           else None),
+                run_end_line=(run.end_mark.line + 1) if run is not None else None,
             ))
     return out
 
@@ -3415,6 +3476,33 @@ def _step_working_directories(text: str) -> dict[int, str]:
              if mark.run_line <= s <= mark.end_line), None)
         if start_line is not None:
             out[start_line] = mark.working_directory.strip()
+    return out
+
+
+def _inline_run_values(text: str) -> dict[int, str]:
+    """{run-scalar start line: the parser's own value} for SINGLE-LINE `run:`.
+
+    A single-line `run:` value comes from the composed document, not the raw
+    line, so YAML quoting never reaches the shell tokenizer. `run: "git clone …
+    && bash x.sh"` was handed to `shlex` with its double quotes intact and came
+    back as ONE quoted word — the clone and the execution both vanished, a
+    silent false clean. Block scalars (`run: |`) and plain multi-line scalars
+    keep their line-by-line reading; only a value the parser saw begin and end
+    on one line is substituted, so nothing multi-line is disturbed.
+    """
+    marks = _step_marks(text)
+    if marks is None:
+        return {}
+    starts = sorted(_run_scalar_starts(text))
+    out: dict[int, str] = {}
+    for mark in marks:
+        if (mark.run_line is None or mark.run_value is None
+                or mark.run_end_line != mark.run_line):
+            continue
+        start_line = next(
+            (s for s in starts if mark.run_line <= s <= mark.end_line), None)
+        if start_line is not None:
+            out[start_line] = mark.run_value
     return out
 
 
@@ -3611,6 +3699,11 @@ def _mutable_fetch_executions(
     named_remotes: dict[str, str] = {}
     # (position, line, resolved path, path as written)
     executions: list[tuple[int, int, str, str]] = []
+    # Executions whose path begins with a shell variable this scan cannot
+    # resolve. Held aside, not resolved: their real location is unknowable, so
+    # pairing one against a fetch would be a guess. Surfaced as a coverage note
+    # (below) when the job actually has a fetch to run out of.
+    unresolved_execs: list[tuple[int, str]] = []
     # (position, line) for EVERY command in the job. A checkout-step fetch has
     # no position of its own, so its suppression window has to open at the
     # first command after it — any command. Deriving that from `executions`
@@ -3659,11 +3752,7 @@ def _mutable_fetch_executions(
         # Collapsing alone lost them: `OUT=$(tools/setup.sh)` after a mutable
         # clone produced no finding, no gap and no suppression, while the
         # backtick spelling of the same construct still recorded one.
-        bodies = [
-            piece
-            for match in _COMMAND_SUBSTITUTION_RE.finditer(command)
-            for piece in _install_command_segments(match.group(0)[2:-1])
-        ]
+        bodies = _substitution_command_bodies(command)
         for segment in bodies + _install_command_segments(
                 _COMMAND_SUBSTITUTION_RE.sub("$SUBST", command)):
             pos += 1
@@ -3733,8 +3822,14 @@ def _mutable_fetch_executions(
                                 f"deliberately not reported",
                                 kind=_KIND_SUPPRESSED)
                         continue
-                    fetches.setdefault(
-                        dest, _RemoteFetch(line_no, _raw, dest, ref, pos))
+                    # LAST unpinned fetch into a destination wins — it is the
+                    # tree that actually ran. `setdefault` kept the FIRST, so a
+                    # clone, a pin of it, then a re-clone of the same directory
+                    # read as pinned (the pin sat between the stale first clone
+                    # and the execution) and the job went silent while it ran
+                    # the unpinned re-clone. The `pinned` list still holds every
+                    # pin, so a genuine pin of the surviving fetch suppresses.
+                    fetches[dest] = _RemoteFetch(line_no, _raw, dest, ref, pos)
                     continue
                 if sub == "fetch":
                     positionals = [a for a in args if not a.startswith("-")]
@@ -3764,7 +3859,22 @@ def _mutable_fetch_executions(
                 continue
             path = _executed_path(tokens)
             if path:
+                if _leading_unresolved_var(path):
+                    unresolved_execs.append((line_no, path))
+                    continue
                 executions.append((pos, line_no, _resolve_path(cwd, path), path))
+
+    # A path led by an unresolvable shell variable is a coverage gap ONLY where
+    # there is a fetched tree it might have run out of — otherwise every
+    # `$CARGO_HOME/bin/tool` in an ordinary job would raise a note about a chain
+    # that cannot exist. Whether the fetch is visible is known only now the
+    # whole job has been read.
+    if fetches and gap is not None:
+        for line_no, path in unresolved_execs:
+            gap(f"an execution on line {line_no} runs a path beginning with a "
+                f"shell variable (`{_as_written(path)}`) whose value is not "
+                f"visible in this YAML, so whether it runs out of a fetched "
+                f"tree was NOT checked — review it by hand")
 
     pairs: list[tuple[_RemoteFetch, int, str]] = []
     for dest, fetch in fetches.items():

--- a/skills/ci-secure/scripts/scan.py
+++ b/skills/ci-secure/scripts/scan.py
@@ -3689,6 +3689,11 @@ def _mutable_fetch_executions(
     """
     fetches: dict[str, _RemoteFetch] = {
         f.dest: f for f in reversed(extra_fetches or [])}
+    # Clones a later re-clone into the same destination overwrote (last-wins).
+    # They stay as fall-back candidates: the LAST unpinned fetch is the tree
+    # that ran only when a command actually ran from it — a trailing re-clone
+    # that nothing executes must not bury an earlier clone that WAS executed.
+    shadowed: dict[str, list[_RemoteFetch]] = {}
     pending_fetch_head: dict[str, _RemoteFetch] = {}
     # destination -> the EARLIEST position a full-40-hex pin was applied to it.
     # Position matters: pinning is a claim about the code that ran, and a pin
@@ -3829,6 +3834,9 @@ def _mutable_fetch_executions(
                     # and the execution) and the job went silent while it ran
                     # the unpinned re-clone. The `pinned` list still holds every
                     # pin, so a genuine pin of the surviving fetch suppresses.
+                    prev = fetches.get(dest)
+                    if prev is not None:
+                        shadowed.setdefault(dest, []).append(prev)
                     fetches[dest] = _RemoteFetch(line_no, _raw, dest, ref, pos)
                     continue
                 if sub == "fetch":
@@ -3878,50 +3886,65 @@ def _mutable_fetch_executions(
 
     pairs: list[tuple[_RemoteFetch, int, str]] = []
     for dest, fetch in fetches.items():
-        hit = next(
-            (
-                (at, line, written)
-                for at, line, resolved, written in executions
-                # A shell fetch is ordered by position in the command stream
-                # (both halves can share a line); a checkout step has no
-                # position there, so it is ordered by line.
-                if (line > fetch.line if fetch.pos < 0 else at > fetch.pos)
-                and _under(dest, resolved)
-            ),
-            None,
-        )
-        if hit is None:
-            continue
-        # ANY pin between the fetch and the execution suppresses — not just the
-        # first one seen. Keeping only the earliest hid the pin a repository
-        # actually applied when an older one landed on a tree it then
-        # discarded, and told it that it executes unpinned remote code.
-        #
-        # A checkout-step fetch has no position in the command stream, so its
-        # window opens just before the first shell command AFTER its step —
-        # ANY command. Two ways to get this wrong, and this code has had both:
-        # opening at -1 let every pin in the job count, including one applied
-        # to a tree the checkout then replaced; opening at the first
-        # EXECUTION-shaped command left the window empty whenever that
-        # execution was the reported hit, so the fix recipe's own shape
-        # (checkout, pin, run) could never suppress and an unrelated command
-        # sitting in between decided the verdict.
-        window_start = fetch.pos
-        if window_start < 0:
-            window_start = next(
-                (at for at, line in command_lines if line > fetch.line),
-                hit[0] + 1) - 1
-        pin_at = next((p for p in pinned.get(dest, ())
-                       if window_start < p < hit[0]), None)
-        if pin_at is not None:
+        # The last unpinned fetch into a destination is the tree that ran — but
+        # only when a command actually ran from it. A trailing re-clone nothing
+        # executes leaves the last fetch with no hit; the earlier clone a
+        # command DID run from is still live, so the shadowed fetches stay as
+        # fall-back candidates, tried latest-first. A candidate that is
+        # pin-suppressed also falls through: an earlier, unpinned tree may have
+        # been executed before the pin landed.
+        candidates = [fetch, *reversed(shadowed.get(dest, ()))]
+        fired: tuple[_RemoteFetch, int, str] | None = None
+        suppressed_line: int | None = None
+        for cand in candidates:
+            hit = next(
+                (
+                    (at, line, written)
+                    for at, line, resolved, written in executions
+                    # A shell fetch is ordered by position in the command stream
+                    # (both halves can share a line); a checkout step has no
+                    # position there, so it is ordered by line.
+                    if (line > cand.line if cand.pos < 0 else at > cand.pos)
+                    and _under(dest, resolved)
+                ),
+                None,
+            )
+            if hit is None:
+                continue
+            # ANY pin between the fetch and the execution suppresses — not just
+            # the first one seen. Keeping only the earliest hid the pin a
+            # repository actually applied when an older one landed on a tree it
+            # then discarded, and told it that it executes unpinned remote code.
+            #
+            # A checkout-step fetch has no position in the command stream, so
+            # its window opens just before the first shell command AFTER its
+            # step — ANY command. Two ways to get this wrong, and this code has
+            # had both: opening at -1 let every pin in the job count, including
+            # one applied to a tree the checkout then replaced; opening at the
+            # first EXECUTION-shaped command left the window empty whenever that
+            # execution was the reported hit, so the fix recipe's own shape
+            # (checkout, pin, run) could never suppress and an unrelated command
+            # sitting in between decided the verdict.
+            window_start = cand.pos
+            if window_start < 0:
+                window_start = next(
+                    (at for at, line in command_lines if line > cand.line),
+                    hit[0] + 1) - 1
+            pin_at = next((p for p in pinned.get(dest, ())
+                           if window_start < p < hit[0]), None)
+            if pin_at is not None:
+                suppressed_line = cand.line
+                continue
+            fired = (cand, hit[1], hit[2])
+            break
+        if fired is not None:
+            pairs.append(fired)
+        elif suppressed_line is not None and gap is not None:
             # Pinned before it ran: the fix this entry recommends, applied.
-            if gap is not None:
-                gap(f"a fetch into `{_as_written(dest)}` on line {fetch.line} was pinned to "
-                    f"a full commit id before anything ran from it, so it is "
-                    f"deliberately not reported",
-                    kind=_KIND_SUPPRESSED)
-            continue
-        pairs.append((fetch, hit[1], hit[2]))
+            gap(f"a fetch into `{_as_written(dest)}` on line {suppressed_line} was pinned to "
+                f"a full commit id before anything ran from it, so it is "
+                f"deliberately not reported",
+                kind=_KIND_SUPPRESSED)
     return sorted(pairs, key=lambda p: p[0].line)
 
 

--- a/skills/ci-secure/tests/test_chain_detectors.py
+++ b/skills/ci-secure/tests/test_chain_detectors.py
@@ -4657,3 +4657,177 @@ def test_p1424_a_checkout_pin_does_not_depend_on_an_unrelated_neighbour(
               - run: bash tools/run.sh
     """)
     assert without == with_neighbour == []
+
+
+# ---------------------------------------------------------------------------
+# P14.24 — follow-up hardening: shell-var executed paths, shell `-o` values,
+# nested substitution, re-clone-after-pin, and YAML-quoted single-line steps.
+# ---------------------------------------------------------------------------
+
+
+def test_p1424_an_unresolved_shell_variable_path_is_a_gap_not_a_fire(tmp_path):
+    """A path whose first component is a shell variable this scan cannot resolve
+    (`$MYVAR/tool.sh`) was joined onto the working directory and, inside a
+    third-party checkout, fired — but the variable could hold an absolute path
+    that escapes the tree entirely, so resolving it was a guess. It is a
+    coverage note, not a finding."""
+    before = len(scan._DROPPED_MATCHES)
+    hits = _remote_exec_hits(tmp_path, """\
+        name: x
+        on: push
+        jobs:
+          b:
+            runs-on: ubuntu-latest
+            steps:
+              - run: |
+                  git clone --branch main "$TOOLS_URL" tools
+                  cd tools
+                  bash $MYVAR/tool.sh
+    """)
+    added = scan._DROPPED_MATCHES[before:]
+    assert hits == []
+    assert any("shell variable" in d["reason"] for d in added), added
+
+
+def test_p1424_a_path_under_a_known_tree_still_fires_though_it_holds_a_var(
+        tmp_path):
+    """The narrowness control: only a LEADING variable is unknowable. A path
+    rooted at the fetched directory with a variable deeper in
+    (`tools/$V/run.sh`) is inside the tree whatever the variable holds, so it is
+    still a real execution out of it."""
+    hits = _remote_exec_hits(tmp_path, """\
+        name: x
+        on: push
+        jobs:
+          b:
+            runs-on: ubuntu-latest
+            steps:
+              - run: |
+                  git clone --branch main "$TOOLS_URL" tools
+                  bash tools/$V/run.sh
+    """)
+    assert len(hits) == 1
+
+
+def test_p1424_a_shell_o_option_value_is_not_the_executed_path(tmp_path):
+    """`bash -o pipefail tools/run.sh` names a shell OPTION as the value of
+    `-o`; the script is the NEXT word. Read flatly, `pipefail` was taken for the
+    path and the real execution silently missed."""
+    hits = _remote_exec_hits(tmp_path, """\
+        name: x
+        on: push
+        jobs:
+          b:
+            runs-on: ubuntu-latest
+            steps:
+              - run: |
+                  git clone --branch main "$TOOLS_URL" tools
+                  bash -o pipefail tools/run.sh
+    """)
+    assert len(hits) == 1
+    assert "tools/run.sh" in (hits[0].derived_note or "")
+
+
+def test_p1424_python_dash_capital_o_is_boolean_and_runs_its_script(tmp_path):
+    """The scoping control for the `-o`/`-O` value rule: python's `-O` is a
+    boolean (optimize), so `python3 -O tools/setup.py` runs `tools/setup.py`.
+    Treating `-O` as value-taking there would eat the script."""
+    hits = _remote_exec_hits(tmp_path, """\
+        name: x
+        on: push
+        jobs:
+          b:
+            runs-on: ubuntu-latest
+            steps:
+              - run: |
+                  git clone --branch main "$TOOLS_URL" tools
+                  python3 -O tools/setup.py
+    """)
+    assert len(hits) == 1
+    assert "tools/setup.py" in (hits[0].derived_note or "")
+
+
+def test_p1424_a_nested_command_substitution_is_scanned(tmp_path):
+    """`$(…)` runs its body, and a body can hold another `$(…)`. Reading only
+    the outer level left `OUT=$(echo $(tools/setup.sh))` a silent false clean —
+    no finding, no gap. The inner execution is now seen."""
+    hits = _remote_exec_hits(tmp_path, """\
+        name: x
+        on: push
+        jobs:
+          b:
+            runs-on: ubuntu-latest
+            steps:
+              - run: |
+                  git clone --branch main "$TOOLS_URL" tools
+                  OUT=$(echo $(tools/setup.sh))
+    """)
+    assert len(hits) == 1
+    assert "tools/setup.sh" in (hits[0].derived_note or "")
+
+
+def test_p1424_a_reclone_after_a_pin_is_not_treated_as_pinned(tmp_path):
+    """clone → pin → re-clone of the SAME directory → run: the tree that runs is
+    the unpinned re-clone. Keeping the FIRST fetch let the pin (which sat
+    between the stale first clone and the execution) suppress the finding, so
+    the job went silent while it ran unpinned remote code. The last unpinned
+    fetch into a destination wins."""
+    sha = "a" * 40
+    hits = _remote_exec_hits(tmp_path, f"""\
+        name: x
+        on: push
+        jobs:
+          b:
+            runs-on: ubuntu-latest
+            steps:
+              - run: |
+                  git clone "$TOOLS_URL" tools
+                  git -C tools checkout {sha}
+                  git clone "$TOOLS_URL" tools
+                  python3 tools/setup.py
+    """)
+    assert len(hits) == 1
+
+
+def test_p1424_a_genuine_pin_of_the_surviving_reclone_still_suppresses(
+        tmp_path):
+    """The control for last-fetch-wins: a pin applied to the re-clone, before it
+    runs, is the fix this entry recommends and must still stay silent."""
+    sha = "a" * 40
+    assert _remote_exec_hits(tmp_path, f"""\
+        name: x
+        on: push
+        jobs:
+          b:
+            runs-on: ubuntu-latest
+            steps:
+              - run: |
+                  git clone "$TOOLS_URL" tools
+                  git clone "$TOOLS_URL" tools
+                  git -C tools checkout {sha}
+                  python3 tools/setup.py
+    """) == []
+
+
+def test_p1424_a_quoted_single_line_run_scalar_is_read_as_shell(tmp_path):
+    """A single-line `run:` value written with YAML quotes was scraped raw, so
+    the quotes reached the shell tokenizer and `run: "git clone … && bash
+    x.sh"` came back as one quoted word — the clone and the execution both
+    vanished, a silent false clean. The value is read as the parser saw it."""
+    for quote in ('"', "'"):
+        body = (
+            "name: x\n"
+            "on: push\n"
+            "jobs:\n"
+            "  b:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - run: " + quote
+            + "git clone --branch main $U tools && bash tools/go.sh" + quote
+            + "\n"
+        )
+        wf = _wf(tmp_path, f"wf_{quote!r}.yml".replace("'", "s").replace('"', "d"),
+                 body)
+        hits = list(scan._correlation_unverified_remote_code_execution(wf))
+        assert len(hits) == 1, (quote, hits)
+        assert "tools/go.sh" in (hits[0].derived_note or "")

--- a/skills/ci-secure/tests/test_chain_detectors.py
+++ b/skills/ci-secure/tests/test_chain_detectors.py
@@ -4809,6 +4809,28 @@ def test_p1424_a_genuine_pin_of_the_surviving_reclone_still_suppresses(
     """) == []
 
 
+def test_p1424_a_trailing_reclone_does_not_shadow_a_real_execution(tmp_path):
+    """last-fetch-wins must not let a re-clone that nothing runs from bury an
+    earlier clone that WAS executed. clone → run → re-clone (with nothing after
+    it) overwrote the destination with the trailing, unexecuted fetch; the
+    ordering guard then found no execution after it and the job went silent
+    while it had already run unpinned remote code. The earlier fetch a command
+    actually ran from stays a candidate and still fires."""
+    hits = _remote_exec_hits(tmp_path, """\
+        name: x
+        on: push
+        jobs:
+          b:
+            runs-on: ubuntu-latest
+            steps:
+              - run: |
+                  git clone "$TOOLS_URL" tools
+                  python3 tools/setup.py
+                  git clone "$TOOLS_URL" tools
+    """)
+    assert len(hits) == 1
+
+
 def test_p1424_a_quoted_single_line_run_scalar_is_read_as_shell(tmp_path):
     """A single-line `run:` value written with YAML quotes was scraped raw, so
     the quotes reached the shell tokenizer and `run: "git clone … && bash

--- a/skills/ci-secure/tests/test_config_facts.py
+++ b/skills/ci-secure/tests/test_config_facts.py
@@ -2981,3 +2981,104 @@ jobs:
                                "pr.yml": _SKIPPABLE_PR_PRODUCER}, ["test"]),
         _FACT)
     assert f["outcome"] == "pass", f["evidence"]
+
+
+# --- follow-ups: branch-filter glob semantics and fail-evidence honesty ------
+
+_STAR_PUSH_PRODUCER = """\
+name: build
+on:
+  push:
+    branches: ['*']
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: make build
+"""
+
+
+def test_a_single_star_branch_filter_does_not_certify(tmp_path):
+    """`*` is not `**`. GitHub's filter glob `*` matches a run of characters
+    that excludes `/`, so `feature/x`, `dependabot/…` and every slashed head
+    branch escape it — an always-running job under `branches: ['*']` cannot be
+    shown to run on every pull request's head branch. Treating `*` as match-all
+    certified the required check while the reachable PR producer could skip, so
+    the check greened on a slashed branch with neither job having reported."""
+    f = _outcome(
+        _facts_with(tmp_path, {"build.yml": _STAR_PUSH_PRODUCER,
+                               "pr.yml": _SKIPPABLE_PR_PRODUCER}, ["test"]),
+        _FACT)
+    assert f["outcome"] == "fail", f["evidence"]
+
+
+def test_a_double_star_branch_filter_still_certifies(tmp_path):
+    """The control that keeps the fix narrow: `**` really does match every
+    branch, so an always-running job under it still certifies."""
+    dbl = _STAR_PUSH_PRODUCER.replace("['*']", "['**']")
+    f = _outcome(
+        _facts_with(tmp_path, {"build.yml": dbl,
+                               "pr.yml": _SKIPPABLE_PR_PRODUCER}, ["test"]),
+        _FACT)
+    assert f["outcome"] == "pass", f["evidence"]
+
+
+_MATCH_ALL_IGNORE_PRODUCER = """\
+name: build
+on:
+  push:
+    branches-ignore: ['**']
+permissions:
+  contents: read
+jobs:
+  test:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - run: make build
+"""
+
+
+def test_a_push_that_ignores_every_branch_is_no_producer_not_a_fail(tmp_path):
+    """`branches-ignore: ['**']` excludes every branch, so the push fires on
+    none of them and can never report a check on a pull request — the check
+    stays pending and the merge is blocked, it does not bypass. Left as UNKNOWN
+    ability, this sole skippable producer was still counted as a bypassable
+    required check and the fact went RED on a repository whose merge is in fact
+    always blocked. It must not be traced to a producer at all."""
+    f = _outcome(
+        _facts_with(tmp_path, {"build.yml": _MATCH_ALL_IGNORE_PRODUCER},
+                    ["test"]),
+        _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+    assert f["outcome"] != "fail"
+
+
+def _partial_fetcher(contexts):
+    caveat = ("read from rulesets only — classic branch protection could not "
+              "be read, so a check configured only there is not counted here")
+    detail = "branch `main` (" + caveat + ")"
+
+    def fetch(repo):
+        return list(contexts), detail
+    return fetch
+
+
+def test_a_bypass_found_on_a_partially_read_protection_discloses_the_gap(
+        tmp_path):
+    """When only one protection source could be read AND a bypassable check is
+    found, the fail evidence must still say the required-check list was itself a
+    floor — a check configured only in the unread source is invisible here. The
+    fail arm dropped the partial-read caveat the pass and unmeasured arms both
+    carry, so the reader was judged against a list they were never told was
+    incomplete."""
+    root, files = _repo(tmp_path, {"ci.yml": _CONDITIONAL_ONLY})
+    f = _outcome(cf.compute_config_facts(
+        root, files, [], repo="owner/repo",
+        required_contexts_fetcher=_partial_fetcher(["test"]),
+        fork_approval_fetcher=lambda repo: ("all_external_contributors", "x")),
+        _FACT)
+    assert f["outcome"] == "fail", f["evidence"]
+    assert "read from rulesets only" in f["evidence"], f["evidence"]


### PR DESCRIPTION
## TL;DR

The security scanner had nine small blind spots that made it either miss a real "runs code fetched from the internet" risk or, in a few cases, flag a repository that had done nothing wrong. Left alone, each one quietly erodes trust in the result: a scan that misses a live risk reads as "you're safe" when you aren't, and a scan that fails a correctly-configured repo trains people to ignore it. This PR closes all nine, each with a test that was first proven to fail against today's code, and confirms on two real repositories that nothing new is falsely flagged and nothing real is lost.

These are accuracy tune-ups to a scanner that already shipped — no new checks, no change to what the ten vectors are.

## What's in the PR

Two areas were touched.

**The "can a required check be skipped past" gate (branch-filter reading):**

- A branch filter written as `['*']` was read as "matches every branch". GitHub's filter language does not agree — a single star does not cross a slash, so branches like `feature/x` or `dependabot/…` slip past it. The scanner now treats `['*']` as "can't tell" instead of certifying the check. The double-star `['**']`, which genuinely does match everything, still certifies.
- A workflow that excludes every branch (so it can never run on a pull request, and its check can never turn green) was being counted as if it could be bypassed, failing a repo whose merges are in fact always blocked. It is now correctly read as "not a producer of this check."
- When only half of a repo's branch-protection settings could be read and a bypassable check was found, the failure message left out the caveat that the check list itself was incomplete. It now says so, matching what the pass and inconclusive messages already disclosed.

**The "fetches remote code and runs it" detector:**

- An execution whose path starts with a shell variable the scanner can't see the value of (`$MYVAR/tool.sh`) was being guessed at and sometimes flagged. It is now surfaced as a "review this by hand" note instead of a finding. A variable deeper inside a path that is clearly rooted in the fetched code still counts as a real execution.
- `bash -o pipefail some/script.sh` was misreading the option's value (`pipefail`) as the script and missing the real execution. Fixed, scoped to the shells so Python's differently-behaving `-O` is untouched.
- A command nested one level inside another (`$(echo $(setup.sh))`) was never looked at. It is now scanned.
- Cloning a directory, pinning it, then re-cloning it and running the fresh copy was wrongly read as "pinned and safe." The scanner now judges the copy that actually runs.
- A one-line step written with YAML quotes (`run: "git clone … && bash x.sh"`) was being parsed with the quotes still attached, which hid both the clone and the execution. It now reads the value the way the YAML parser does.

Plus two documentation notes describing the coverage limits above.

## Per-finding disposition

Fixed (each reproduced on current `main`, then fixed, red-first):

- **F2** — single-star `branches: ['*']` no longer certifies (routes to UNKNOWN).
- **F4** — re-clone after a pin is no longer read as pinned (last unpinned fetch into a destination wins).
- **F5** — execution path beginning with an unresolved shell variable → coverage note, not a fire.
- **F6** — single-line quoted `run:` scalar read from the parser, not scraped raw.
- **F7** — nested command substitution scanned one level deeper.
- **F8** — shell `-o`/`-O` option values not read as the executed path.
- **F10** — limits list: copy-into-destination misattribution + unresolved-leading-variable note disclosed.
- **F12** — bypass on a partially-read protection discloses the required-check list was a floor.
- **F13** — `branches-ignore: ['**']` treated as a non-producer, not a false RED.

Skipped, with reason (not built):

- **F9** — `success() || failure()` with `needs:` refused even when every dependency provably never skips. This reproduces, but it is a conservative false RED in the fact's documented safe direction, and a correct fix has to distinguish "a dependency can SKIP" from "a dependency can FAIL" in the dependency walk — the current walk conflates them, so a naive change would mishandle failure states. Deferred deliberately; low value, real risk.
- **F11** — two byte-identical chains in one job collapse to one finding. This overlaps the F4 fix: fetches are keyed by destination, so two clones into the same directory are already one entry, and the two occurrences are the same logical finding. Folding both source lines into one finding needs a restructure of the destination-keyed model, disproportionate to a display nicety — and F4's last-wins already changes which occurrence is named.

## Test evidence (red-first)

Every fix carries a regression test proven to fail against the unfixed tree (source reverted to `main`, tests run, failure quoted), then to pass after the fix. The eight that changed behavior went red on `main`:

```
FAILED test_config_facts.py::test_a_single_star_branch_filter_does_not_certify
  AssertionError: all 1 required check(s) on branch `main` protection have a producer that runs whatever else happens  (expected fail)
FAILED test_config_facts.py::test_a_push_that_ignores_every_branch_is_no_producer_not_a_fail
  AssertionError: GitHub reports a SKIPPED required check as passed …  (expected unmeasured)
FAILED test_config_facts.py::test_a_bypass_found_on_a_partially_read_protection_discloses_the_gap
  AssertionError: "read from rulesets only" not in evidence
FAILED test_chain_detectors.py::test_p1424_an_unresolved_shell_variable_path_is_a_gap_not_a_fire
  assert [RawHit(...)] == []   (fired instead of gapping)
FAILED test_chain_detectors.py::test_p1424_a_shell_o_option_value_is_not_the_executed_path
  assert 0 == 1   (missed the execution)
FAILED test_chain_detectors.py::test_p1424_a_nested_command_substitution_is_scanned
  assert 0 == 1   (silent false clean)
FAILED test_chain_detectors.py::test_p1424_a_reclone_after_a_pin_is_not_treated_as_pinned
  assert 0 == 1   (falsely suppressed)
FAILED test_chain_detectors.py::test_p1424_a_quoted_single_line_run_scalar_is_read_as_shell
  AssertionError: ('"', [])   (clone + execution both vanished)
```

The five accompanying control tests (double-star still certifies, a fetched-tree path with a deeper variable still fires, Python's `-O` still runs its script, a genuine pin of the surviving re-clone still suppresses) pass on both trees by design.

After the fixes, the full suite is green: `uvx --with pyyaml pytest -q` → **3723 passed, 13 skipped**.

## Corpus deltas (shipped scanner, real checkouts)

| repo | P14.24 fires (main → fixed) | coverage notes (main → fixed) |
|---|---|---|
| paradedb | 1 → 1 | 2 → 3 |
| teleport | 1 → 1 | 14 → 14 |

- No new false fires, no lost true positives.
- paradedb's finding names a different (equally valid) line — 200 → 220 — because the two byte-identical, mutually-exclusive clones into the same directory now resolve last-wins (F4). Same logical finding, same job.
- paradedb's one extra coverage note is F5 working as intended: `$PG_BIN/pg_config` is now honestly surfaced as "review by hand" instead of being silently resolved.
