### PR TITLE
Add a setup step for running ci-secure as a CI check in your repo

### DIFF
--- a/.github/scripts/ci_secure_gate.py
+++ b/.github/scripts/ci_secure_gate.py
@@ -3,7 +3,12 @@
 
 Runs the ci-secure engine against the repository root, then applies the gate:
 
-  facts    -> deterministic pass/fail security checks; ANY fail exits 1.
+  facts    -> deterministic pass/fail security checks; ANY fail exits 1,
+              UNLESS `--advisory` was passed, which downgrades a failed
+              fact to a warning and nothing else (see advisory_requested).
+              The scaffold this skill installs ships that flag ON, so
+              advisory is the configuration most copies of this file run
+              under - do not read the line above without this one.
   findings -> severity-rated pattern matches; they never exit non-zero, but
               each one becomes a ::warning:: annotation and a summary row,
               so accepting one is a visible decision, not silence.

--- a/.github/scripts/ci_secure_gate.py
+++ b/.github/scripts/ci_secure_gate.py
@@ -327,9 +327,12 @@ def main() -> int:
             f"CI_SECURE_GH_IMPOSTOR must be 'on' or 'off', not {IMPOSTOR!r} - "
             "'auto' is refused on purpose, because it makes whether the "
             "network-gated check runs depend on the runner image rather than "
-            "on this job. Leaving the variable unset lands on 'off', which is "
-            "a DISCLOSED off: it is reported under 'Network-gated detectors' "
-            "as a check that did not run, never as one that passed")
+            "on this job. An UNSET value is refused for the same reason and "
+            "reaches you as this same error: deleting the `env:` block must "
+            "not be a way to turn the check off. Set it to 'off' explicitly "
+            "if you want it off - that is a DISCLOSED off, reported under "
+            "'Network-gated detectors' as a check that did not run, never as "
+            "one that passed")
 
     if STRICT_RAW not in ("0", "1"):
         return fail(

--- a/.github/scripts/ci_secure_gate.py
+++ b/.github/scripts/ci_secure_gate.py
@@ -325,9 +325,11 @@ def main() -> int:
     if IMPOSTOR not in ("on", "off"):
         return fail(
             f"CI_SECURE_GH_IMPOSTOR must be 'on' or 'off', not {IMPOSTOR!r} - "
-            "'auto' and an unset value are refused on purpose, because they make "
-            "whether the network-gated check runs depend on the runner image "
-            "rather than on this job")
+            "'auto' is refused on purpose, because it makes whether the "
+            "network-gated check runs depend on the runner image rather than "
+            "on this job. Leaving the variable unset lands on 'off', which is "
+            "a DISCLOSED off: it is reported under 'Network-gated detectors' "
+            "as a check that did not run, never as one that passed")
 
     if STRICT_RAW not in ("0", "1"):
         return fail(

--- a/README.md
+++ b/README.md
@@ -92,6 +92,34 @@ The scan runs locally in seconds from your checkout; `gh` is optional and used
 only for the impostor-SHA check and for noting which findings sit in dormant
 workflows.
 
+### Keeping it fixed: ci-secure as a CI check
+
+A scan tells you what is wrong today. It does nothing about next week, which is
+when the workflow gets edited. Ask for the check and ci-secure sets itself up to
+run on every pull request:
+
+> install ci-secure as a CI check
+
+1. It **copies** the scanner into your repository — under `ci-secure/`, plus one
+   workflow — and hands you a pull request to review and merge. Nothing is
+   downloaded at build time, so the code judging your pull requests is code you
+   can read, and it changes only when you ask for an update.
+2. The **first run reports without blocking**. A repository that has never been
+   scanned usually has two or three findings, and the setup pull request should
+   not brick your merge path on day one.
+3. When you have fixed those, **you** make it blocking: delete the `--advisory`
+   flag from the workflow and add `ci-secure` to your required checks. From then
+   on a failed security check stops the merge.
+4. If you ever need out, remove `ci-secure` from your required checks — one
+   settings change, reversible. Not deleting the workflow, which would leave you
+   believing you have a check you do not.
+
+Your CI re-checks the copied files against a manifest of hashes on every run, so
+a local edit somebody made while debugging and never removed shows up instead of
+quietly weakening the check. Asking for an update re-copies the code and leaves
+your workflow file alone — the runner, the triggers and the flag you deleted are
+yours.
+
 ## Install
 
 ```bash

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -49,7 +49,26 @@ entries are dated (UTC). Format loosely follows
   destination is checked to be inside the repository before anything is
   written, so a symlink committed at `ci-secure/`, at any directory beneath it,
   or at `.github/` makes the install refuse rather than quietly write the gate
-  and a live workflow somewhere your pull requests would never see them.
+  and a live workflow somewhere your pull requests would never see them. The
+  same check refuses a symlink aimed at another file INSIDE your repository,
+  which stays contained and would still have written the licence text over
+  whatever it pointed at. The install also refuses `--into` a subdirectory of a
+  repository rather than its root (a workflow written there is one GitHub never
+  runs, and it looked like it had worked), and refuses a `ci-secure/` directory
+  that already holds files of yours — the workflow re-checks that directory
+  against the manifest every run, so merging into it would have red every run
+  from the first, with an error about drift that named your own files. A
+  refresh now writes no workflow at all: re-adding the advisory template beside
+  a copy you had renamed or deleted reached the same "quietly back to advisory"
+  outcome by adding rather than overwriting. `--verify` treats compiled
+  bytecode as drift even when `VENDORED.json` lists it, and treats any symlink
+  under the vendored tree as drift — the manifest is repository content and
+  cannot exempt a `.pyc`, and a symlinked `__pycache__` hid one from the walk
+  entirely. A malformed `VENDORED.json` reds with a stated reason instead of a
+  stack trace. The gate also now refuses arguments other than `--advisory`
+  rather than ignoring them, and its refusal message for an unset
+  `CI_SECURE_GH_IMPOSTOR` no longer claims that unset is a supported, disclosed
+  setting — it is refused, which is the entire point of having no default.
 
 - **2026-08-15** — **`config.py` now owns the one definition of how a scanned
   string is neutralized.** `flatten_scanned()` collapses whitespace, replaces

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -29,8 +29,9 @@ entries are dated (UTC). Format loosely follows
   you merge, updated only when you ask — plus one workflow whose always-running
   verdict job carries the `ci-secure` check. Nothing happens on its own: the
   setup runs when you ask for it, the check ships in `--advisory` mode, and it
-  blocks a merge only once YOU add `ci-secure` to your required checks. No ci-secure code is fetched and executed at CI time: a pin
-  can be moved or deleted in a repository you do not control, and we ship a
+  blocks a merge only once YOU add `ci-secure` to your required checks. No
+  ci-secure code is fetched and executed at CI time: a pin can be moved or
+  deleted in a repository you do not control, and we ship a
   detector for that shape (P14.24). `scripts/vendor.py` does the copying, writes
   a `VENDORED.json` of per-file hashes, and re-checks them from your own CI, so
   a local edit to the vendored gate is loud instead of invisible. The workflow
@@ -44,10 +45,7 @@ entries are dated (UTC). Format loosely follows
   this could do. Ships alongside the skill's own `LICENSE`. The gate program
   gained an `--advisory` flag for this; our own workflow still runs it without
   the flag, and the vendored gate is held byte-identical to ours so a weaker
-  copy cannot ship. `--verify` reports compiled bytecode found in the vendored
-  tree rather than passing over it, because a `.pyc` written with an unchecked
-  hash is loaded without being compared to its source and can override a file
-  that hashed correctly; the workflow stops the gate writing any. Every
+  copy cannot ship. Every
   destination is checked to be inside the repository before anything is
   written, so a symlink committed at `ci-secure/`, at any directory beneath it,
   or at `.github/` makes the install refuse rather than quietly write the gate
@@ -81,6 +79,44 @@ entries are dated (UTC). Format loosely follows
   one an attacker aims at.
 
 ### Fixed
+
+- **2026-08-15** — **`--verify` no longer passes a vendored copy that was made
+  smaller than the one that was reviewed.** Deleting a vendored file *and* its
+  `VENDORED.json` entry left every remaining hash correct, so the drift check
+  reported a match — the manifest was allowed to define its own domain. This is
+  not the documented "anyone who can edit the gate can edit the manifest"
+  caveat: nothing is edited-with-a-matching-hash, the copy is simply shrunk. It
+  matters most for `config.py`, the rule that says which outcomes block: with
+  the vendored copy gone the gate falls back to a path *inside the repository
+  being audited*, so one pull request could delete the rule here, add its own
+  there, and be judged by a rule it wrote — under a green drift check. The
+  manifest is now checked for completeness before any hash is compared.
+
+- **2026-08-15** — **The setup no longer asks the wrong repository whether a
+  destination is a repository root.** `GIT_DIR` overrides `git -C`, so an
+  exported one — from a hook, a `rebase -x`, a worktree-driven session — made
+  the subdirectory guard read an unrelated repository's toplevel, refuse a
+  perfectly good install, and tell you to vendor the gate and a live workflow
+  into *that other repository* instead. The same variable made the recorded
+  source commit a stranger's HEAD. All git calls now run with the ambient
+  `GIT_*` variables stripped. Relatedly, the working-tree-dirty check now has
+  the timeout and return-code check its sibling call always had: any failure of
+  `git status` previously read as "clean" and stamped the manifest with a bare
+  sha, which asserts this copy is byte-for-byte the published commit.
+
+- **2026-08-15** — **`--verify` escapes what it reads out of your repository
+  before printing it.** `VENDORED.json` arrives with a branch, a pull request
+  checkout or a fork clone, and its strings went to a step log unescaped — a
+  newline in the recorded version forged a `::notice::all clear` on the check
+  run, and one in a `files` key emitted `::stop-commands::`, swallowing every
+  drift reason printed after it so the step red with no stated cause. The gate
+  has escaped engine output for this reason all along; the drift check runs in
+  the step above it and reads from the same trust class.
+
+- **2026-08-15** — **`PYTHONDONTWRITEBYTECODE` now covers the whole scan job.**
+  Scoped to the gate step alone, it stopped one step short of the drift check
+  itself — the step whose entire purpose is rejecting bytecode was the one
+  Python was free to write it from.
 
 - **2026-08-15** — **The skill imports again on Python 3.9**, the floor
   `pyproject.toml` declares. `config.py` was the only module under `scripts/`

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -24,57 +24,33 @@ entries are dated (UTC). Format loosely follows
   these instead of hardcoding a copy that can drift from the engine's.
 
 - **2026-08-15** — **You can now set ci-secure up as a CI check in your own
-  repository.** Say *"install ci-secure as a CI check"* and it does four things,
-  in this order: (1) COPIES the engine, the gate and the licence into your
-  repository — under `ci-secure/`, plus one workflow whose always-running
-  verdict job carries the `ci-secure` check — and hands you a pull request to
-  review and merge; (2) the first run REPORTS WITHOUT BLOCKING, because a
-  repository that has never been scanned usually has two or three findings and
-  the setup pull request should not brick your merge path on day one; (3) once
-  you have fixed those, YOU make it blocking by deleting the `--advisory` flag
-  and adding `ci-secure` to your required checks; (4) if you ever need out, you
-  remove it from your required checks — one reversible settings change, not
-  deleting the workflow. Nothing here happens on its own: it runs when you ask,
-  and it blocks a merge only after you make it required. No
-  ci-secure code is fetched and executed at CI time: a pin can be moved or
-  deleted in a repository you do not control, and we ship a
-  detector for that shape (P14.24). `scripts/vendor.py` does the copying, writes
-  a `VENDORED.json` of per-file hashes, and re-checks them from your own CI, so
-  a local edit to the vendored gate is loud instead of invisible. The workflow
-  ships in `--advisory` mode, which downgrades failed FACTS only — a crashed
-  engine, zero workflows scanned, an unrecognised outcome or an incomplete scan
-  stay red, because a ramp for findings must never become a mute button for a
-  broken scan. Refreshing replaces the vendored code and drops what a newer
-  version no longer ships, but never rewrites your workflow file: the runner,
-  the triggers and the `--advisory` flag you deleted when you went blocking are
-  yours, and an update that quietly put advisory back would be the worst thing
-  this could do. Ships alongside the skill's own `LICENSE`. The gate program
-  gained an `--advisory` flag for this; our own workflow still runs it without
-  the flag, and the vendored gate is held byte-identical to ours so a weaker
-  copy cannot ship. Every
-  destination is checked to be inside the repository before anything is
-  written, so a symlink committed at `ci-secure/`, at any directory beneath it,
-  or at `.github/` makes the install refuse rather than quietly write the gate
-  and a live workflow somewhere your pull requests would never see them. The
-  same check refuses a symlink aimed at another file INSIDE your repository,
-  which stays contained and would still have written the licence text over
-  whatever it pointed at. The install also refuses `--into` a subdirectory of a
-  repository rather than its root (a workflow written there is one GitHub never
-  runs, and it looked like it had worked), and refuses a `ci-secure/` directory
-  that already holds files of yours — the workflow re-checks that directory
-  against the manifest every run, so merging into it would have red every run
-  from the first, with an error about drift that named your own files. A
-  refresh now writes no workflow at all: re-adding the advisory template beside
-  a copy you had renamed or deleted reached the same "quietly back to advisory"
-  outcome by adding rather than overwriting. `--verify` treats compiled
-  bytecode as drift even when `VENDORED.json` lists it, and treats any symlink
-  under the vendored tree as drift — the manifest is repository content and
-  cannot exempt a `.pyc`, and a symlinked `__pycache__` hid one from the walk
-  entirely. A malformed `VENDORED.json` reds with a stated reason instead of a
-  stack trace. The gate also now refuses arguments other than `--advisory`
-  rather than ignoring them, and its refusal message for an unset
-  `CI_SECURE_GH_IMPOSTOR` no longer claims that unset is a supported, disclosed
-  setting — it is refused, which is the entire point of having no default.
+  repository.** Say *"install ci-secure as a CI check"* and it (1) COPIES the
+  engine, gate and licence into your repo plus one workflow, as a pull request
+  you review and merge; (2) REPORTS WITHOUT BLOCKING on the first run, so the
+  setup does not brick your merge path on day one; (3) becomes blocking when
+  YOU delete the `--advisory` flag and add `ci-secure` to your required checks;
+  (4) is undone by removing that required check, never by deleting the
+  workflow. Nothing happens on its own, and it blocks only after you make it
+  required.
+
+  Nothing is fetched and executed at CI time — a pin can be moved or deleted in
+  a repository you do not control, and we ship a detector for that shape
+  (P14.24). `scripts/vendor.py` does the copying and writes a `VENDORED.json`
+  of per-file hashes that your own CI re-checks every run, so a local edit to
+  the copied gate is loud instead of invisible. `--advisory` downgrades failed
+  FACTS only: a crashed engine, zero workflows scanned, an unrecognised outcome
+  or an incomplete scan stay red, because a ramp for findings must never become
+  a mute button for a broken scan. Updating re-copies the code and never
+  rewrites your workflow file — the runner, the triggers and the flag you
+  deleted are yours. The copied gate is held byte-identical to the one this
+  repo runs on itself, so a weaker copy cannot ship.
+
+  Setup refuses anything that is not plainly your repository rather than
+  writing and hoping: a destination that resolves outside it, a subdirectory
+  rather than the root, or a `ci-secure/` directory already holding files of
+  yours. `--verify` treats compiled bytecode and symlinks under the copied tree
+  as drift even when the manifest lists them, since the manifest is repository
+  content and cannot exempt them.
 
 - **2026-08-15** — **`config.py` now owns the one definition of how a scanned
   string is neutralized.** `flatten_scanned()` collapses whitespace, replaces

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -80,6 +80,21 @@ entries are dated (UTC). Format loosely follows
 
 ### Fixed
 
+- **2026-08-15** — **The gate setup instructions cover the paths a real
+  session actually takes.** Setup and refresh are the same command, and which
+  one runs is decided by whether `VENDORED.json` is already there — so an
+  agent following the setup steps on a repo that had the vendored copy but no
+  workflow announced a workflow that was never written. The instructions now
+  name that discriminator, stop rather than guessing when the destination is
+  not a git work tree, warn when a repository has no workflows at all (the gate
+  reds permanently on "nothing scanned", which `--advisory` does not clear),
+  say that the copied files are left uncommitted and nothing runs until they
+  are committed, complete the list of refusals, and require checking for local
+  edits before a refresh overwrites them. "Make ci-secure block my PRs" now has
+  a procedure of its own instead of resolving to a setup run that changes
+  nothing. Backing the gate out has an order: the workflow first, then the
+  vendored directory.
+
 - **2026-08-15** — **`--verify` no longer passes a vendored copy that was made
   smaller than the one that was reviewed.** Deleting a vendored file *and* its
   `VENDORED.json` entry left every remaining hash correct, so the drift check

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -27,15 +27,21 @@ entries are dated (UTC). Format loosely follows
   it by name and it VENDORS the engine, the gate and the licence into your
   repository — copied in, reviewed as a pull request, refreshed when you ask —
   plus one workflow whose always-running verdict job carries the required
-  `ci-secure` check. Nothing is fetched and executed at CI time: a pin can be
-  moved or deleted in a repository you do not control, and we ship a detector
-  for that shape (P14.24). `scripts/vendor.py` does the copying, writes a
-  `VENDORED.json` of per-file hashes, and re-checks them from your own CI, so a
-  local edit to the vendored gate is loud instead of invisible. The workflow
+  `ci-secure` check. No ci-secure code is fetched and executed at CI time: a pin
+  can be moved or deleted in a repository you do not control, and we ship a
+  detector for that shape (P14.24). `scripts/vendor.py` does the copying, writes
+  a `VENDORED.json` of per-file hashes, and re-checks them from your own CI, so
+  a local edit to the vendored gate is loud instead of invisible. The workflow
   ships in `--advisory` mode, which downgrades failed FACTS only — a crashed
   engine, zero workflows scanned, an unrecognised outcome or an incomplete scan
   stay red, because a ramp for findings must never become a mute button for a
-  broken scan.
+  broken scan. Refreshing replaces the vendored code and drops what a newer
+  version no longer ships, but never rewrites your workflow file: the runner,
+  the triggers and the `--advisory` flag you deleted when you went blocking are
+  yours, and an update that quietly put advisory back would be the worst thing
+  this could do. Ships alongside the skill's own `LICENSE`, and adds
+  `--advisory` to the gate this repository runs on itself — the vendored gate is
+  held byte-identical to it, so a weaker copy cannot ship.
 
 - **2026-08-15** — **`config.py` now owns the one definition of how a scanned
   string is neutralized.** `flatten_scanned()` collapses whitespace, replaces

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -23,11 +23,13 @@ entries are dated (UTC). Format loosely follows
   new failure state as a pass. Anything running ci-secure as a CI gate imports
   these instead of hardcoding a copy that can drift from the engine's.
 
-- **2026-08-15** — **ci-secure can install itself as a blocking CI gate.** Ask
-  it by name and it VENDORS the engine, the gate and the licence into your
-  repository — copied in, reviewed as a pull request, refreshed when you ask —
-  plus one workflow whose always-running verdict job carries the required
-  `ci-secure` check. No ci-secure code is fetched and executed at CI time: a pin
+- **2026-08-15** — **You can now set ci-secure up as a CI check in your own
+  repository.** Ask for it by name, and ci-secure VENDORS the engine, the gate
+  and the licence into your repository — copied in, reviewed as a pull request
+  you merge, updated only when you ask — plus one workflow whose always-running
+  verdict job carries the `ci-secure` check. Nothing happens on its own: the
+  setup runs when you ask for it, the check ships in `--advisory` mode, and it
+  blocks a merge only once YOU add `ci-secure` to your required checks. No ci-secure code is fetched and executed at CI time: a pin
   can be moved or deleted in a repository you do not control, and we ship a
   detector for that shape (P14.24). `scripts/vendor.py` does the copying, writes
   a `VENDORED.json` of per-file hashes, and re-checks them from your own CI, so

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -24,12 +24,18 @@ entries are dated (UTC). Format loosely follows
   these instead of hardcoding a copy that can drift from the engine's.
 
 - **2026-08-15** — **You can now set ci-secure up as a CI check in your own
-  repository.** Ask for it by name, and ci-secure VENDORS the engine, the gate
-  and the licence into your repository — copied in, reviewed as a pull request
-  you merge, updated only when you ask — plus one workflow whose always-running
-  verdict job carries the `ci-secure` check. Nothing happens on its own: the
-  setup runs when you ask for it, the check ships in `--advisory` mode, and it
-  blocks a merge only once YOU add `ci-secure` to your required checks. No
+  repository.** Say *"install ci-secure as a CI check"* and it does four things,
+  in this order: (1) COPIES the engine, the gate and the licence into your
+  repository — under `ci-secure/`, plus one workflow whose always-running
+  verdict job carries the `ci-secure` check — and hands you a pull request to
+  review and merge; (2) the first run REPORTS WITHOUT BLOCKING, because a
+  repository that has never been scanned usually has two or three findings and
+  the setup pull request should not brick your merge path on day one; (3) once
+  you have fixed those, YOU make it blocking by deleting the `--advisory` flag
+  and adding `ci-secure` to your required checks; (4) if you ever need out, you
+  remove it from your required checks — one reversible settings change, not
+  deleting the workflow. Nothing here happens on its own: it runs when you ask,
+  and it blocks a merge only after you make it required. No
   ci-secure code is fetched and executed at CI time: a pin can be moved or
   deleted in a repository you do not control, and we ship a
   detector for that shape (P14.24). `scripts/vendor.py` does the copying, writes

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -23,6 +23,20 @@ entries are dated (UTC). Format loosely follows
   new failure state as a pass. Anything running ci-secure as a CI gate imports
   these instead of hardcoding a copy that can drift from the engine's.
 
+- **2026-08-15** — **ci-secure can install itself as a blocking CI gate.** Ask
+  it by name and it VENDORS the engine, the gate and the licence into your
+  repository — copied in, reviewed as a pull request, refreshed when you ask —
+  plus one workflow whose always-running verdict job carries the required
+  `ci-secure` check. Nothing is fetched and executed at CI time: a pin can be
+  moved or deleted in a repository you do not control, and we ship a detector
+  for that shape (P14.24). `scripts/vendor.py` does the copying, writes a
+  `VENDORED.json` of per-file hashes, and re-checks them from your own CI, so a
+  local edit to the vendored gate is loud instead of invisible. The workflow
+  ships in `--advisory` mode, which downgrades failed FACTS only — a crashed
+  engine, zero workflows scanned, an unrecognised outcome or an incomplete scan
+  stay red, because a ramp for findings must never become a mute button for a
+  broken scan.
+
 - **2026-08-15** — **`config.py` now owns the one definition of how a scanned
   string is neutralized.** `flatten_scanned()` collapses whitespace, replaces
   the backtick and escapes the pipe — the rule the report renderer already

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -45,7 +45,11 @@ entries are dated (UTC). Format loosely follows
   copy cannot ship. `--verify` reports compiled bytecode found in the vendored
   tree rather than passing over it, because a `.pyc` written with an unchecked
   hash is loaded without being compared to its source and can override a file
-  that hashed correctly; the workflow stops the gate writing any.
+  that hashed correctly; the workflow stops the gate writing any. Every
+  destination is checked to be inside the repository before anything is
+  written, so a symlink committed at `ci-secure/`, at any directory beneath it,
+  or at `.github/` makes the install refuse rather than quietly write the gate
+  and a live workflow somewhere your pull requests would never see them.
 
 - **2026-08-15** — **`config.py` now owns the one definition of how a scanned
   string is neutralized.** `flatten_scanned()` collapses whitespace, replaces

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -39,9 +39,13 @@ entries are dated (UTC). Format loosely follows
   version no longer ships, but never rewrites your workflow file: the runner,
   the triggers and the `--advisory` flag you deleted when you went blocking are
   yours, and an update that quietly put advisory back would be the worst thing
-  this could do. Ships alongside the skill's own `LICENSE`, and adds
-  `--advisory` to the gate this repository runs on itself — the vendored gate is
-  held byte-identical to it, so a weaker copy cannot ship.
+  this could do. Ships alongside the skill's own `LICENSE`. The gate program
+  gained an `--advisory` flag for this; our own workflow still runs it without
+  the flag, and the vendored gate is held byte-identical to ours so a weaker
+  copy cannot ship. `--verify` reports compiled bytecode found in the vendored
+  tree rather than passing over it, because a `.pyc` written with an unchecked
+  hash is loaded without being compared to its source and can override a file
+  that hashed correctly; the workflow stops the gate writing any.
 
 - **2026-08-15** — **`config.py` now owns the one definition of how a scanned
   string is neutralized.** `flatten_scanned()` collapses whitespace, replaces

--- a/skills/ci-secure/LICENSE
+++ b/skills/ci-secure/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 StarSling
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/ci-secure/SKILL.md
+++ b/skills/ci-secure/SKILL.md
@@ -590,23 +590,35 @@ That writes, all under `<repo-root>`:
 - `.github/workflows/ci-secure.yml`, only if it does not already exist
   (see Refresh).
 
-Everything that can refuse — a copy that cannot install, a missing
-licence — refuses before the first byte is written, and the workflow is
-written last, after the manifest. So a non-zero exit means at worst a
-partly-copied `ci-secure/`, never a live workflow with no gate behind
-it. Report the error and stop; do not retry blind.
+Everything that can refuse refuses before the first byte is written, and
+the workflow is written last, after the manifest. So a non-zero exit
+means at worst a partly-copied `ci-secure/`, never a live workflow with
+no gate behind it. It refuses on: a vendored copy trying to install, a
+missing licence, a `<repo-root>` that is a subdirectory of a repository
+rather than its root, a destination redirected by a symlink, and a
+`ci-secure/` directory that already holds someone else's files — that
+last one because the workflow re-checks that directory against the
+manifest on every run and would red on anything else it finds there.
+Report the error and stop; do not retry blind.
 
 If it reports that `.github/workflows/ci-secure.yml` already existed, the
 install did NOT wire anything up — resolve that with the user before
 telling them they have a gate.
 
-Then walk the user through the following, in the PR body and in the
-message that hands the PR over. They need it whether or not a PR gets
-opened:
+Then walk the user through the following in the message that hands the
+work over. They need it whether or not a PR gets opened. Items 1, 3 and
+4 also belong in the PR body; items 2, 5 and 6 name weaknesses the repo
+still has, so on a public repository keep those out of the PR body and
+say them to the user directly — the disclosure corollary below applies
+to an install PR as much as to a fix PR:
 
 1. **Requirements**: Python 3.12 and PyYAML, both pinned in the
    workflow. The engine is not stdlib-only; the gate is. `vendor.py`
-   itself needs Python 3.10 or newer to run.
+   itself needs Python 3.9 or newer to run. **Check their default
+   branch**: the workflow ships `push: branches: [main]`, so if theirs
+   is not `main`, change it in the file before handing it over — left as
+   shipped that trigger silently covers nothing, and it is the one that
+   re-judges what already merged. Pull requests are judged either way.
 2. **It ships in `--advisory` mode.** A repo that has never been scanned
    usually reds two or three facts on its first run (workflows with no
    `permissions:`, no CODEOWNERS entry for `.github/`). Advisory reports
@@ -630,14 +642,23 @@ opened:
    checks are skippable, and the fork-PR approval policy. Both are
    admin-scoped API reads. They are disclosed and dropped from the
    score, never counted as passes.
-6. **A pull request can edit the workflow that judges it.** On
-   `pull_request` GitHub runs the definition from the PR, so this check
-   is only as strong as review on `.github/` — which is why a CODEOWNERS
-   entry there is one of the facts it checks. Tell them to require that
-   review before they make `ci-secure` a required check.
+6. **A pull request can edit the workflow that judges it — and the gate
+   it runs.** On `pull_request` GitHub checks out the PR's tree, so both
+   `.github/workflows/ci-secure.yml` and the vendored `ci-secure/` are
+   the PR's versions. Tell them to require review on **both** paths
+   before making `ci-secure` a required check. A CODEOWNERS entry for
+   `.github/` is one of the facts this gate checks; `/ci-secure/` is not
+   — nothing checks it for them, and `.github/` alone leaves the gate,
+   the engine, `config.py` (which defines which outcomes block) and the
+   manifest editable by an ordinary approval. Hashing does not help
+   here: whoever edits the vendored gate edits `VENDORED.json` in the
+   same commit.
 
 **Refresh** ("update the ci-secure gate"): re-run `vendor.py --into`
-from the current skill version and open a PR with the delta.
+from the current skill version. This writes into their tree exactly as
+the install does, so the same rule binds — say what will be rewritten,
+get a yes, and only then run it. Show them the resulting diff; open a PR
+only if they ask for one.
 
 - The vendored CODE is replaced, and files a newer version no longer
   ships are removed. Hand edits to it surface as that PR's diff for the
@@ -645,15 +666,20 @@ from the current skill version and open a PR with the delta.
   (`vendor.py --verify ci-secure`), which catches the local edit made
   while debugging and never removed — not a determined attacker, who can
   edit the manifest in the same commit.
-- **Their workflow is left exactly as it is**, always. It is theirs:
-  the runner, the triggers, and the `--advisory` flag they deleted when
-  they went blocking. Overwriting it on refresh would quietly return a
-  blocking gate to advisory, and since it is deliberately not
-  checksummed, nothing downstream would catch that. If the template has
-  changed in a way they want, show them the diff against
-  `<ci-secure>/scaffold/ci-secure.yml` and let them choose.
-- If the vendored copy is already current, say so and open nothing. A
-  PR whose only change is a rewritten manifest is noise.
+- **A refresh writes no workflow at all**, whether or not one is sitting
+  at `.github/workflows/ci-secure.yml`. That file is theirs: the runner,
+  the triggers, the path they moved it to, and the `--advisory` flag they
+  deleted when they went blocking. Rewriting it — or re-adding the
+  template beside a copy they renamed — quietly returns a blocking gate
+  to advisory, and since it is deliberately not checksummed nothing
+  downstream would catch that. If the template has changed in a way they
+  want, show them the diff against `<ci-secure>/scaffold/ci-secure.yml`
+  and let them choose.
+- There is no dry run, and `--verify` compares their copy against its own
+  manifest, not against this skill — so "is it already current?" can only
+  be answered after the refresh, from `git diff`. If that diff is empty,
+  say so and open nothing: a PR whose only change is a rewritten manifest
+  is noise.
 
 ## NEVER rules
 
@@ -672,7 +698,9 @@ from the current skill version and open a PR with the delta.
   unasked.** Render to tmp; only the explicit save pick (or `open`)
   writes `./ci-secure-report.md` — one stable name, as both siblings use,
   so a re-run overwrites the last report instead of accreting dated copies
-  the user has to reconcile.
+  the user has to reconcile. The gate install and refresh are the other
+  writers, and they are asked for by name: the same rule binds them, which
+  is why each states what it will write and waits for a yes.
 - **Never widen a fix beyond what the catalog recipe specifies.** Each
   vector's patch is exactly its recipe; adjacent hardening is a separate
   finding and a separate dispatch.

--- a/skills/ci-secure/SKILL.md
+++ b/skills/ci-secure/SKILL.md
@@ -569,9 +569,25 @@ into the user's tree unasked" rule binds: say exactly what will be
 written, get a yes, and only then run it. Do it on a branch, as one
 setup PR; never push without asking.
 
-`<repo-root>` is the output of `git rev-parse --show-toplevel`, never
-the current directory — vendoring into a subdirectory produces a
-workflow GitHub never runs and an install that looks like it worked.
+Check three things BEFORE saying what will be written, because two of
+them change the answer and the third makes the install pointless:
+
+- `git rev-parse --show-toplevel` gives `<repo-root>`. It is never the
+  current directory — vendoring into a subdirectory produces a workflow
+  GitHub never runs and an install that looks like it worked. If that
+  command FAILS, this is not a git work tree: stop and ask, rather than
+  falling back to the current directory, which is that same outcome
+  reached by guessing.
+- **Does `<repo-root>/ci-secure/VENDORED.json` already exist?** Install
+  and Refresh below are the same command, and this file is what decides
+  which one runs. If it exists this is a REFRESH — go to Refresh, and do
+  not promise a workflow, because a refresh writes none even when none
+  is there.
+- **Does `<repo-root>/.github/workflows/` hold any workflow?** With
+  nothing to scan, the gate reports "no workflow files were scanned",
+  which is a DEGRADED outcome and stays red even in `--advisory` — a
+  permanently red check that neither documented remedy clears. Say so
+  and let the user decide before installing.
 
 ```bash
 <ci-secure>/scripts/vendor.py --into <repo-root>
@@ -594,16 +610,26 @@ Everything that can refuse refuses before the first byte is written, and
 the workflow is written last, after the manifest. So a non-zero exit
 means at worst a partly-copied `ci-secure/`, never a live workflow with
 no gate behind it. It refuses on: a vendored copy trying to install, a
-missing licence, a `<repo-root>` that is a subdirectory of a repository
-rather than its root, a destination redirected by a symlink, and a
-`ci-secure/` directory that already holds someone else's files — that
-last one because the workflow re-checks that directory against the
-manifest on every run and would red on anything else it finds there.
-Report the error and stop; do not retry blind.
+missing licence, an incomplete skill, a `<repo-root>` that is a
+subdirectory of a repository rather than its root, a destination
+redirected by a symlink, a `ci-secure` that exists and is not a
+directory, and a `ci-secure/` directory that already holds someone
+else's files — that last one because the workflow re-checks that
+directory against the manifest on every run and would red on anything
+else it finds there. That collision refusal applies to a FIRST install
+only; a refresh expects to find our files there. Report the error and
+stop; do not retry blind.
 
 If it reports that `.github/workflows/ci-secure.yml` already existed, the
 install did NOT wire anything up — resolve that with the user before
-telling them they have a gate.
+telling them they have a gate. The exit code is 0 either way, so read
+the output; do not infer success from it.
+
+The install leaves everything UNCOMMITTED, and nothing runs until those
+files are on a branch GitHub can see. Say that plainly when handing over
+— committing is theirs to do unless they ask, and the NEVER rules below
+bind. If their tree already had uncommitted work in it, say that too:
+the vendored files are now mixed in with it.
 
 Then walk the user through the following in the message that hands the
 work over. They need it whether or not a PR gets opened. Items 1, 3 and
@@ -627,17 +653,31 @@ to an install PR as much as to a fix PR:
    engine, zero workflows scanned, an unrecognised outcome or an
    incomplete scan stay red, because a ramp for findings must never
    become a mute button for a broken scan.
-3. **Going blocking**, once those are burned down: drop `--advisory`,
-   then require **`ci-secure`** — the always-running verdict job, never
-   the scan job. A conditional job that gets skipped reports Success to
-   a required-check rule, so requiring one is a rule that can be
-   satisfied by never running it.
+3. **Going blocking**, once those are burned down: drop `--advisory`
+   from the "Run ci-secure" step in
+   `.github/workflows/ci-secure.yml`, then require **`ci-secure`** — the
+   always-running verdict job, never the scan job. A conditional job that
+   gets skipped reports Success to a required-check rule, so requiring
+   one is a rule that can be satisfied by never running it. The second
+   half is a repository setting only they can change.
+
+   "Make ci-secure block my PRs" on a repo that already has the gate is
+   asking for this, not for an install — the install command would run a
+   refresh, touch no workflow, and leave `--advisory` exactly where it
+   was. Editing that one line is a write into their tree like any other:
+   say which line, get a yes, then make the edit.
 4. **Getting out**, if it ever reds their default branch: un-require
-   `ci-secure` (one settings change, reversible). **Not** deleting the
-   workflow — that leaves them believing they have a check they do not.
-   Putting `--advisory` back is the narrower remedy and only clears a
-   red caused by a failed fact; it will not clear a crashed engine, an
-   incomplete scan, or a rate-limited weekly run.
+   `ci-secure` (one settings change, reversible, and it needs admin).
+   That unblocks MERGES; the branch itself stays red until the cause is
+   fixed, because the `push:` trigger keeps running. **Not** deleting
+   the workflow — that leaves them believing they have a check they do
+   not. Putting `--advisory` back is the narrower remedy and only clears
+   a red caused by a failed fact; it will not clear a crashed engine, an
+   incomplete scan, or a rate-limited weekly run — the workflow also
+   runs weekly, which is where that last one comes from. If they want
+   the gate gone entirely, the order matters: delete the workflow FIRST,
+   then `ci-secure/`. The other way round reds every run in between, on
+   the drift check, before the gate is even reached.
 5. **Two facts stay UNMEASURED** on any CI token: whether required
    checks are skippable, and the fork-PR approval policy. Both are
    admin-scoped API reads. They are disclosed and dropped from the
@@ -660,9 +700,15 @@ the install does, so the same rule binds — say what will be rewritten,
 get a yes, and only then run it. Show them the resulting diff; open a PR
 only if they ask for one.
 
+- Run `vendor.py --verify ci-secure` and `git status` FIRST. A refresh
+  overwrites every vendored file, and an UNCOMMITTED local edit is gone
+  for good — `git diff` afterwards cannot show what it replaced, because
+  there is no committed version to compare against. If either command
+  shows local changes, surface them and get a decision before running
+  anything.
 - The vendored CODE is replaced, and files a newer version no longer
-  ships are removed. Hand edits to it surface as that PR's diff for the
-  user to resolve. Their CI re-checks the copy every run
+  ships are removed. Committed hand edits show up in the resulting
+  `git diff` for the user to resolve. Their CI re-checks the copy every run
   (`vendor.py --verify ci-secure`), which catches the local edit made
   while debugging and never removed — not a determined attacker, who can
   edit the manifest in the same commit.
@@ -689,7 +735,9 @@ only if they ask for one.
   between dispatches.
 - **Never push, commit, or open a PR from inside the skill unless the user
   explicitly asks.** By default the user reviews the working tree
-  themselves. (Corollary: if the user does
+  themselves, and that includes the gate install, a refresh, and the
+  one-line `--advisory` edit that goes blocking: each of those WRITES
+  with consent, and none of them commits. (Corollary: if the user does
   ask you to open a PR for the fixes, the PR body must not name the
   vulnerability class being closed or narrate the attack — a public PR
   describing an unfixed-until-now hole is a disclosure. Describe the

--- a/skills/ci-secure/SKILL.md
+++ b/skills/ci-secure/SKILL.md
@@ -590,8 +590,15 @@ That writes, all under `<repo-root>`:
 - `.github/workflows/ci-secure.yml`, only if it does not already exist
   (see Refresh).
 
-If the command exits non-zero it has written nothing — it validates
-before it writes — so report the error and stop rather than retrying.
+Everything that can refuse — a copy that cannot install, a missing
+licence — refuses before the first byte is written, and the workflow is
+written last, after the manifest. So a non-zero exit means at worst a
+partly-copied `ci-secure/`, never a live workflow with no gate behind
+it. Report the error and stop; do not retry blind.
+
+If it reports that `.github/workflows/ci-secure.yml` already existed, the
+install did NOT wire anything up — resolve that with the user before
+telling them they have a gate.
 
 Then walk the user through the following, in the PR body and in the
 message that hands the PR over. They need it whether or not a PR gets

--- a/skills/ci-secure/SKILL.md
+++ b/skills/ci-secure/SKILL.md
@@ -552,7 +552,9 @@ actually changed its file.
 **Reached by NAMING it** — "install ci-secure as a CI check", "make
 ci-secure block my PRs", "add the ci-secure gate", "update/refresh the
 ci-secure gate". A scan request is not an install request: audit as
-usual and, if a gate would help, offer one at the close.
+usual, and do not add a gate option to the Phase 6 close, whose option
+list is fixed. If the user asks what would stop the findings coming
+back, this section is the answer.
 
 A scan says what is wrong today. A gate stops it coming back — the same
 engine, on every pull request, red when a security fact fails. It is
@@ -562,19 +564,42 @@ they can read and it cannot change underneath them. Fetching a pinned
 SHA and executing it at CI time is a shape this skill FLAGS (P14.24); do
 not ship it.
 
-**Install** (one setup PR on their branch — the "never push without
-asking" rule still applies):
+**Install.** This WRITES INTO their working tree, so the "never write
+into the user's tree unasked" rule binds: say exactly what will be
+written, get a yes, and only then run it. Do it on a branch, as one
+setup PR; never push without asking.
+
+`<repo-root>` is the output of `git rev-parse --show-toplevel`, never
+the current directory — vendoring into a subdirectory produces a
+workflow GitHub never runs and an install that looks like it worked.
 
 ```bash
 <ci-secure>/scripts/vendor.py --into <repo-root>
 ```
 
-That writes `ci-secure/` (engine + `gate.py` + `LICENSE` +
-`VENDORED.json`) and `.github/workflows/ci-secure.yml`. Cover these in
-the PR body:
+That writes, all under `<repo-root>`:
+
+- `ci-secure/scripts/` — the engine (`scan.py`, `config.py`,
+  `config_facts.py`, `gh_utils.py`), `gate.py`, and `vendor.py` itself,
+  which is what their CI runs to check the copy has not drifted;
+- `ci-secure/references/security-patterns.md` — the pattern catalog the
+  engine reads at runtime. It is a large document that quotes attack
+  shapes, so a repo running its own secret or malware scanners may want
+  to allow-list the path;
+- `ci-secure/LICENSE` and `ci-secure/VENDORED.json`;
+- `.github/workflows/ci-secure.yml`, only if it does not already exist
+  (see Refresh).
+
+If the command exits non-zero it has written nothing — it validates
+before it writes — so report the error and stop rather than retrying.
+
+Then walk the user through the following, in the PR body and in the
+message that hands the PR over. They need it whether or not a PR gets
+opened:
 
 1. **Requirements**: Python 3.12 and PyYAML, both pinned in the
-   workflow. The engine is not stdlib-only; the gate is.
+   workflow. The engine is not stdlib-only; the gate is. `vendor.py`
+   itself needs Python 3.10 or newer to run.
 2. **It ships in `--advisory` mode.** A repo that has never been scanned
    usually reds two or three facts on its first run (workflows with no
    `permissions:`, no CODEOWNERS entry for `.github/`). Advisory reports
@@ -589,23 +614,39 @@ the PR body:
    a required-check rule, so requiring one is a rule that can be
    satisfied by never running it.
 4. **Getting out**, if it ever reds their default branch: un-require
-   `ci-secure` (one settings change, reversible) or put `--advisory`
-   back. **Not** deleting the workflow — that leaves them believing they
-   have a check they do not.
+   `ci-secure` (one settings change, reversible). **Not** deleting the
+   workflow — that leaves them believing they have a check they do not.
+   Putting `--advisory` back is the narrower remedy and only clears a
+   red caused by a failed fact; it will not clear a crashed engine, an
+   incomplete scan, or a rate-limited weekly run.
 5. **Two facts stay UNMEASURED** on any CI token: whether required
    checks are skippable, and the fork-PR approval policy. Both are
    admin-scoped API reads. They are disclosed and dropped from the
    score, never counted as passes.
+6. **A pull request can edit the workflow that judges it.** On
+   `pull_request` GitHub runs the definition from the PR, so this check
+   is only as strong as review on `.github/` — which is why a CODEOWNERS
+   entry there is one of the facts it checks. Tell them to require that
+   review before they make `ci-secure` a required check.
 
 **Refresh** ("update the ci-secure gate"): re-run `vendor.py --into`
-from the current skill version and open a PR with the delta. Hand edits
-to vendored files surface as that PR's diff for the user to resolve —
-they are never silently clobbered outside a PR. The workflow file is
-deliberately NOT checksummed: runners and triggers are theirs to tune.
-The vendored CODE is, and their CI re-checks it every run
-(`vendor.py --verify ci-secure`). That catches the local edit made while
-debugging and never removed — not a determined attacker, who can edit
-the manifest in the same commit.
+from the current skill version and open a PR with the delta.
+
+- The vendored CODE is replaced, and files a newer version no longer
+  ships are removed. Hand edits to it surface as that PR's diff for the
+  user to resolve. Their CI re-checks the copy every run
+  (`vendor.py --verify ci-secure`), which catches the local edit made
+  while debugging and never removed — not a determined attacker, who can
+  edit the manifest in the same commit.
+- **Their workflow is left exactly as it is**, always. It is theirs:
+  the runner, the triggers, and the `--advisory` flag they deleted when
+  they went blocking. Overwriting it on refresh would quietly return a
+  blocking gate to advisory, and since it is deliberately not
+  checksummed, nothing downstream would catch that. If the template has
+  changed in a way they want, show them the diff against
+  `<ci-secure>/scaffold/ci-secure.yml` and let them choose.
+- If the vendored copy is already current, say so and open nothing. A
+  PR whose only change is a rewritten manifest is noise.
 
 ## NEVER rules
 

--- a/skills/ci-secure/SKILL.md
+++ b/skills/ci-secure/SKILL.md
@@ -547,6 +547,66 @@ If the user asks for verification next steps: run the report self-check
 `--clone <audited-repo>` to confirm every fix in `## Fixes applied`
 actually changed its file.
 
+## Add ci-secure as a CI gate
+
+**Reached by NAMING it** — "install ci-secure as a CI check", "make
+ci-secure block my PRs", "add the ci-secure gate", "update/refresh the
+ci-secure gate". A scan request is not an install request: audit as
+usual and, if a gate would help, offer one at the close.
+
+A scan says what is wrong today. A gate stops it coming back — the same
+engine, on every pull request, red when a security fact fails. It is
+**vendored, never fetched**: the engine, the gate and the licence are
+COPIED into the user's repository, so the code judging their PRs is code
+they can read and it cannot change underneath them. Fetching a pinned
+SHA and executing it at CI time is a shape this skill FLAGS (P14.24); do
+not ship it.
+
+**Install** (one setup PR on their branch — the "never push without
+asking" rule still applies):
+
+```bash
+<ci-secure>/scripts/vendor.py --into <repo-root>
+```
+
+That writes `ci-secure/` (engine + `gate.py` + `LICENSE` +
+`VENDORED.json`) and `.github/workflows/ci-secure.yml`. Cover these in
+the PR body:
+
+1. **Requirements**: Python 3.12 and PyYAML, both pinned in the
+   workflow. The engine is not stdlib-only; the gate is.
+2. **It ships in `--advisory` mode.** A repo that has never been scanned
+   usually reds two or three facts on its first run (workflows with no
+   `permissions:`, no CODEOWNERS entry for `.github/`). Advisory reports
+   them without blocking, so the installing PR does not brick their
+   merge path. **`--advisory` downgrades FAILED FACTS ONLY** — a crashed
+   engine, zero workflows scanned, an unrecognised outcome or an
+   incomplete scan stay red, because a ramp for findings must never
+   become a mute button for a broken scan.
+3. **Going blocking**, once those are burned down: drop `--advisory`,
+   then require **`ci-secure`** — the always-running verdict job, never
+   the scan job. A conditional job that gets skipped reports Success to
+   a required-check rule, so requiring one is a rule that can be
+   satisfied by never running it.
+4. **Getting out**, if it ever reds their default branch: un-require
+   `ci-secure` (one settings change, reversible) or put `--advisory`
+   back. **Not** deleting the workflow — that leaves them believing they
+   have a check they do not.
+5. **Two facts stay UNMEASURED** on any CI token: whether required
+   checks are skippable, and the fork-PR approval policy. Both are
+   admin-scoped API reads. They are disclosed and dropped from the
+   score, never counted as passes.
+
+**Refresh** ("update the ci-secure gate"): re-run `vendor.py --into`
+from the current skill version and open a PR with the delta. Hand edits
+to vendored files surface as that PR's diff for the user to resolve —
+they are never silently clobbered outside a PR. The workflow file is
+deliberately NOT checksummed: runners and triggers are theirs to tune.
+The vendored CODE is, and their CI re-checks it every run
+(`vendor.py --verify ci-secure`). That catches the local edit made while
+debugging and never removed — not a determined attacker, who can edit
+the manifest in the same commit.
+
 ## NEVER rules
 
 - **Never modify a file outside the one named in a finding's

--- a/skills/ci-secure/scaffold/ci-secure.yml
+++ b/skills/ci-secure/scaffold/ci-secure.yml
@@ -12,9 +12,14 @@
 # from the pull request, so a pull request can edit THIS FILE — point the gate
 # at a different engine, or weaken the step — and the check it reports is the
 # edited one. That is true of every in-repo check, and the edit is visible in
-# the diff. Requiring review on `.github/` (a CODEOWNERS entry, which this gate
-# also checks for) is what actually closes it. Do that before you make the check
-# required.
+# the diff. Requiring review on BOTH `.github/` (a CODEOWNERS entry, which this
+# gate also checks for) and `/ci-secure/` is what actually closes it. `.github/`
+# alone is half the trust path: the gate, the engine, `config.py` — which
+# defines which outcomes block — and the manifest all live under `/ci-secure/`,
+# are checked out from the pull request too, and none of them are under
+# `.github/`. A pull request that edits `ci-secure/scripts/config.py` and its
+# hash in `VENDORED.json` passes the drift check and needs no `.github/`
+# approval. Do both before you make the check required.
 #
 # WHAT TO REQUIRE IN BRANCH PROTECTION: `ci-secure`, the verdict job at the
 # bottom. Not the scan job. A job that a condition skips reports as Success to a

--- a/skills/ci-secure/scaffold/ci-secure.yml
+++ b/skills/ci-secure/scaffold/ci-secure.yml
@@ -116,6 +116,14 @@ jobs:
       - name: Run ci-secure
         run: python3 ci-secure/scripts/gate.py --advisory
         env:
+          # No `__pycache__` in the vendored tree. A `.pyc` written with an
+          # unchecked hash is loaded without being compared to its source, so
+          # one sitting next to a hash-verified `config.py` can override it —
+          # which is why the drift check reports bytecode rather than ignoring
+          # it. This is the other half: the gate never writes any, so the only
+          # bytecode that can ever appear there is bytecode somebody committed.
+          PYTHONDONTWRITEBYTECODE: "1"
+
           # The gate resolves its engine relative to its own file, which in a
           # vendored layout is this directory. `config.py` — the rule that says
           # which outcomes block — is then loaded from beside that engine, so

--- a/skills/ci-secure/scaffold/ci-secure.yml
+++ b/skills/ci-secure/scaffold/ci-secure.yml
@@ -1,0 +1,170 @@
+# ci-secure as a blocking CI check.
+#
+# Installed by ci-secure into your repository, together with a vendored copy of
+# the engine and the gate under `ci-secure/`. Nothing is fetched at CI time: the
+# code that judges your pull requests is code you can read, in your repository,
+# changed only by a pull request you review.
+#
+# WHAT TO REQUIRE IN BRANCH PROTECTION: `ci-secure`, the verdict job at the
+# bottom. Not the scan job. A job that a condition skips reports as Success to a
+# required-check rule, so requiring a conditional job is a rule that can be
+# satisfied by never running it.
+#
+# TRIGGERS, and why each one is here:
+#   pull_request      the point of the gate — judge the change before it lands
+#   push (default)    catches anything that reached the branch another way
+#   schedule          re-judges what already merged. It is the only trigger that
+#                     notices a pinned action SHA that ROTS: legitimate today,
+#                     deleted or orphaned tomorrow in a repository you do not
+#                     control. No pull request of yours would ever see it.
+#   workflow_dispatch so you can run it by hand while burning down findings
+#
+# NOT merge_group, deliberately. If you run a merge queue and add it, trace two
+# things first: a check required in the queue whose workflow does not trigger on
+# `merge_group` never reports, and the queue waits forever; and a verdict job
+# that greens while the scan it needs was SKIPPED for that event hands you back
+# the skipped-check bypass this file exists to close.
+#
+# FIRST RUN: expect two or three red facts on a repository that has never been
+# scanned — most commonly workflows that do not declare `permissions:` and a
+# missing CODEOWNERS entry for `.github/`. That is the gate working. It ships in
+# `--advisory` mode so those do not block your merges on day one; burn them
+# down, then delete the flag (see "GOING BLOCKING" below).
+#
+# IF THIS EVER REDS YOUR DEFAULT BRANCH AND YOU NEED OUT: remove `ci-secure`
+# from your required checks (one settings change, reversible in a click), or put
+# `--advisory` back. Do NOT delete the workflow — that leaves you with a
+# security check you believe you have and do not.
+#
+# REQUIREMENTS: Python 3.12 (pinned below rather than inherited from the runner
+# image — this is a security gate, and which interpreter it runs under should
+# not drift with an image rebuild) and PyYAML. The engine is not stdlib-only;
+# the gate is.
+name: CI security
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  # `github.event_name` is in the key on purpose: without it an ordinary push
+  # can cancel the weekly run, silently costing you the one run whose whole job
+  # is catching rot.
+  group: ci-secure-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# The gate only reads the checked-out tree.
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: ci-secure scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          # The scan reads the tree; it has no reason to hold a credential, and
+          # a credential left in the checkout is one of the things it flags.
+          persist-credentials: false
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.12"
+      - run: pip install pyyaml
+
+      # Is the vendored copy still the code that was reviewed? This catches the
+      # accident — a local edit made while debugging, still there six months
+      # later, quietly weakening a check nobody re-read. It is NOT a tamper
+      # seal: anyone who can edit the vendored gate can edit the manifest in the
+      # same commit. The accident is the case that actually happens.
+      - name: Check the vendored ci-secure copy has not drifted
+        run: python3 ci-secure/scripts/vendor.py --verify ci-secure
+
+      - name: Run ci-secure
+        run: python3 ci-secure/scripts/gate.py --advisory
+        env:
+          # The gate resolves its engine relative to its own file, which in a
+          # vendored layout is this directory. `config.py` — the rule that says
+          # which outcomes block — is then loaded from beside that engine, so
+          # this one pointer moves both and they can never come from different
+          # places.
+          CI_SECURE_ENGINE: ci-secure/scripts/scan.py
+
+          # The impostor-SHA check (P14.11) verifies that each pinned action SHA
+          # actually exists in the action's canonical repository, which catches
+          # a pin aimed at a fork-only or dangling commit. It needs an
+          # authenticated `gh`.
+          #
+          # ON for your own branches, OFF for pull requests from forks. This one
+          # job serves both, and a fork pull request runs code its author wrote
+          # — handing that a token variable costs more than the coverage it
+          # buys. On fork runs the check is off and the gate says so, on both
+          # surfaces, because a check that did not run is never a pass. `auto`
+          # is not offered: it would make "did this security check run?" depend
+          # on the runner image.
+          CI_SECURE_GH_IMPOSTOR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'off' || 'on' }}
+          GH_TOKEN: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '' || github.token }}
+
+          # A network check that could not finish is red on the weekly run and a
+          # warning everywhere else. Your pull requests should not be blocked by
+          # somebody else's rate limit; the weekly run has no deadline and
+          # nothing to race, and it is the run that must not be mutable by
+          # exhausting API quota.
+          CI_SECURE_GH_STRICT: ${{ github.event_name == 'schedule' && '1' || '0' }}
+
+  # ONE always-running job carries the required check name.
+  #
+  # This is NOT the same shape as the verdict job in starslingdev/skills, and
+  # copying that one here would break: it arbitrates between two mutually
+  # exclusive scan jobs (self-hosted and hosted-fork), so it needs both, and a
+  # `needs:` on a job that does not exist never resolves. One scan job means one
+  # dependency and a simpler rule — but the rule it enforces is the same one,
+  # and it is the reason this job exists at all: a scan that was skipped,
+  # cancelled or failed is not a scan that passed, and GitHub reads a skipped
+  # required check as green.
+  #
+  # `always()`, not `!cancelled()`: a cancelled run reports this job as skipped,
+  # which a required-check rule reads as green. A superseded run is left to
+  # report a red instead — the cost is a stale red in the history, and the
+  # alternative is a one-click way to turn the gate green.
+  verdict:
+    name: ci-secure
+    needs: [scan]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require the scan to have passed
+        env:
+          SCAN: ${{ needs.scan.result }}
+        run: |
+          set -euo pipefail
+          echo "scan: ${SCAN}"
+          if [ "${SCAN}" = "success" ]; then
+            echo "ci-secure passed."
+            exit 0
+          fi
+          echo "::error::ci-secure has no passing verdict (scan=${SCAN}) - a scan that did not run, was cancelled, or failed is not a pass"
+          exit 1
+
+# GOING BLOCKING, once the first-run findings are burned down:
+#   1. delete `--advisory` from the "Run ci-secure" step above;
+#   2. add `ci-secure` to your branch protection's required checks.
+#
+# `--advisory` only ever downgrades a FAILED FACT. Everything that means the
+# scan could not be trusted — the engine crashing, zero workflow files scanned,
+# an outcome the gate cannot classify, an incomplete scan — stays red in
+# advisory mode too. Advisory is a ramp for findings, never a mute button for a
+# broken scan.
+#
+# Two facts will likely stay UNMEASURED whatever you do: whether your required
+# checks can be skipped, and your fork-PR approval policy. Both are repository
+# settings behind admin-scoped API endpoints that a CI job's token cannot read.
+# They are reported as unmeasured and are excluded from the score rather than
+# counted as passes — a coverage gap stated out loud, not a clean result.

--- a/skills/ci-secure/scaffold/ci-secure.yml
+++ b/skills/ci-secure/scaffold/ci-secure.yml
@@ -1,7 +1,7 @@
 # ci-secure as a blocking CI check.
 #
-# Installed by ci-secure into your repository, together with a vendored copy of
-# the engine and the gate under `ci-secure/`. No ci-secure code is fetched at CI
+# Written into your repository when you set ci-secure up as a gate, together
+# with a vendored copy of the engine and the gate under `ci-secure/`. No ci-secure code is fetched at CI
 # time: the code that judges your pull requests is code you can read, in your
 # repository, changed only by a pull request you review. The one thing this job
 # does install from the network is PyYAML, pinned by version below — the engine
@@ -64,10 +64,11 @@
 # you cannot fix in your own repository, so read it as "not measured", not as
 # "newly insecure".
 #
-# REQUIREMENTS: Python 3.12 (pinned below rather than inherited from the runner
-# image — this is a security gate, and which interpreter it runs under should
-# not drift with an image rebuild) and PyYAML, pinned to a version for the same
-# reason. The engine is not stdlib-only; the gate is.
+# REQUIREMENTS: Python 3.12 and PyYAML, both named below rather than inherited
+# from the runner image — this is a security gate, and which interpreter and
+# parser it runs under should not change silently with an image rebuild. Both
+# are MINOR-version pins: the patch release still moves. The engine is not
+# stdlib-only; the gate is.
 name: CI security
 
 on:
@@ -85,7 +86,10 @@ concurrency:
   group: ci-secure-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
-# The gate only reads the checked-out tree.
+# The gate reads the checked-out tree. On non-fork runs it ALSO reads the
+# GitHub API, with a token, for the impostor-SHA check — see
+# CI_SECURE_GH_IMPOSTOR below. `contents: read` is what that needs and the
+# most this job ever gets; nothing here writes.
 permissions:
   contents: read
 
@@ -94,12 +98,25 @@ jobs:
     name: ci-secure scan
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      # No `__pycache__` in the vendored tree, for EVERY python step in this
+      # job rather than the last one. A `.pyc` written with an unchecked hash
+      # is loaded without being compared to its source, so one sitting next to
+      # a hash-verified `config.py` can override it — which is why the drift
+      # check reports bytecode rather than ignoring it. Scoped to the gate step
+      # alone, the guard stopped exactly one step short of the drift check
+      # itself, which runs python first and would have been free to write the
+      # bytecode the step after it exists to reject.
+      PYTHONDONTWRITEBYTECODE: "1"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
-          # The scan reads the tree; it has no reason to hold a credential, and
-          # a credential left in the checkout is one of the things it flags.
+          # The scan reads the tree; it has no reason to hold a credential.
+          # Hardening you keep rather than something the gate enforces: the
+          # credentials-scoped fact only looks at UNTRUSTED triggers, and
+          # plain `pull_request` is not one, so deleting this line is not
+          # something the scan below would tell you about.
           persist-credentials: false
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
@@ -108,6 +125,9 @@ jobs:
       # this resolves to gets a say in what the scan sees and therefore in what
       # the gate reports. An unpinned install is the one piece of code in this
       # job that could change without a pull request of yours.
+      # A version pin binds a name, not bytes — no `--require-hashes`. It buys
+      # "no surprise version change between runs", which is the drift that
+      # actually happens, and not integrity against a compromised index.
       - run: pip install pyyaml==6.0.2
 
       # Is the vendored copy still the code that was reviewed? This catches the
@@ -121,14 +141,6 @@ jobs:
       - name: Run ci-secure
         run: python3 ci-secure/scripts/gate.py --advisory
         env:
-          # No `__pycache__` in the vendored tree. A `.pyc` written with an
-          # unchecked hash is loaded without being compared to its source, so
-          # one sitting next to a hash-verified `config.py` can override it —
-          # which is why the drift check reports bytecode rather than ignoring
-          # it. This is the other half: the gate never writes any, so the only
-          # bytecode that can ever appear there is bytecode somebody committed.
-          PYTHONDONTWRITEBYTECODE: "1"
-
           # The gate resolves its engine relative to its own file, which in a
           # vendored layout is this directory. `config.py` — the rule that says
           # which outcomes block — is then loaded from beside that engine, so

--- a/skills/ci-secure/scaffold/ci-secure.yml
+++ b/skills/ci-secure/scaffold/ci-secure.yml
@@ -1,9 +1,20 @@
 # ci-secure as a blocking CI check.
 #
 # Installed by ci-secure into your repository, together with a vendored copy of
-# the engine and the gate under `ci-secure/`. Nothing is fetched at CI time: the
-# code that judges your pull requests is code you can read, in your repository,
-# changed only by a pull request you review.
+# the engine and the gate under `ci-secure/`. No ci-secure code is fetched at CI
+# time: the code that judges your pull requests is code you can read, in your
+# repository, changed only by a pull request you review. The one thing this job
+# does install from the network is PyYAML, pinned by version below — the engine
+# parses your workflows with it, so it sits inside the verdict's trust path and
+# is named here rather than left as an implicit runner detail.
+#
+# WHAT THIS CANNOT DO: on `pull_request`, GitHub runs the workflow definition
+# from the pull request, so a pull request can edit THIS FILE — point the gate
+# at a different engine, or weaken the step — and the check it reports is the
+# edited one. That is true of every in-repo check, and the edit is visible in
+# the diff. Requiring review on `.github/` (a CODEOWNERS entry, which this gate
+# also checks for) is what actually closes it. Do that before you make the check
+# required.
 #
 # WHAT TO REQUIRE IN BRANCH PROTECTION: `ci-secure`, the verdict job at the
 # bottom. Not the scan job. A job that a condition skips reports as Success to a
@@ -12,7 +23,10 @@
 #
 # TRIGGERS, and why each one is here:
 #   pull_request      the point of the gate — judge the change before it lands
-#   push (default)    catches anything that reached the branch another way
+#   push              catches anything that reached the branch another way. It
+#                     is written as `branches: [main]` below; if your default
+#                     branch is not `main`, change it there or this trigger
+#                     silently covers nothing.
 #   schedule          re-judges what already merged. It is the only trigger that
 #                     notices a pinned action SHA that ROTS: legitimate today,
 #                     deleted or orphaned tomorrow in a repository you do not
@@ -32,14 +46,23 @@
 # down, then delete the flag (see "GOING BLOCKING" below).
 #
 # IF THIS EVER REDS YOUR DEFAULT BRANCH AND YOU NEED OUT: remove `ci-secure`
-# from your required checks (one settings change, reversible in a click), or put
-# `--advisory` back. Do NOT delete the workflow — that leaves you with a
-# security check you believe you have and do not.
+# from your required checks (one settings change, reversible in a click). Do NOT
+# delete the workflow — that leaves you with a security check you believe you
+# have and do not. Putting `--advisory` back is the narrower remedy: it covers a
+# red caused by a FAILED FACT and nothing else, so it will not clear a red from
+# a crashed engine, an incomplete scan, or a rate-limited weekly run.
+#
+# ON THE WEEKLY RUN specifically: it is the one run where an unfinished network
+# check is red rather than a warning, so a GitHub API outage or an exhausted
+# rate limit reds your default branch until the next run. That is deliberate —
+# the run that must not be silenceable by burning API quota — but it is a red
+# you cannot fix in your own repository, so read it as "not measured", not as
+# "newly insecure".
 #
 # REQUIREMENTS: Python 3.12 (pinned below rather than inherited from the runner
 # image — this is a security gate, and which interpreter it runs under should
-# not drift with an image rebuild) and PyYAML. The engine is not stdlib-only;
-# the gate is.
+# not drift with an image rebuild) and PyYAML, pinned to a version for the same
+# reason. The engine is not stdlib-only; the gate is.
 name: CI security
 
 on:
@@ -76,7 +99,11 @@ jobs:
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.12"
-      - run: pip install pyyaml
+      # Pinned: the engine parses your workflow files with PyYAML, so whatever
+      # this resolves to gets a say in what the scan sees and therefore in what
+      # the gate reports. An unpinned install is the one piece of code in this
+      # job that could change without a pull request of yours.
+      - run: pip install pyyaml==6.0.2
 
       # Is the vendored copy still the code that was reviewed? This catches the
       # accident — a local edit made while debugging, still there six months
@@ -109,7 +136,15 @@ jobs:
           # is not offered: it would make "did this security check run?" depend
           # on the runner image.
           CI_SECURE_GH_IMPOSTOR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'off' || 'on' }}
-          GH_TOKEN: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '' || github.token }}
+          #
+          # The condition below is inverted on purpose. Actions has no ternary,
+          # only `&&`/`||` over truthiness, and THE EMPTY STRING IS FALSY — so
+          # `is-a-fork && '' || github.token` reads as "no token on forks" and
+          # hands one to every fork pull request, because the empty middle term
+          # is falsy and the `||` takes over. The value being withheld can never
+          # be the middle term; the condition is flipped instead, so the token
+          # sits on the truthy branch and the empty string is the fallback.
+          GH_TOKEN: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.token || '' }}
 
           # A network check that could not finish is red on the weekly run and a
           # warning everywhere else. Your pull requests should not be blocked by

--- a/skills/ci-secure/scaffold/gate.py
+++ b/skills/ci-secure/scaffold/gate.py
@@ -3,7 +3,12 @@
 
 Runs the ci-secure engine against the repository root, then applies the gate:
 
-  facts    -> deterministic pass/fail security checks; ANY fail exits 1.
+  facts    -> deterministic pass/fail security checks; ANY fail exits 1,
+              UNLESS `--advisory` was passed, which downgrades a failed
+              fact to a warning and nothing else (see advisory_requested).
+              The scaffold this skill installs ships that flag ON, so
+              advisory is the configuration most copies of this file run
+              under - do not read the line above without this one.
   findings -> severity-rated pattern matches; they never exit non-zero, but
               each one becomes a ::warning:: annotation and a summary row,
               so accepting one is a visible decision, not silence.

--- a/skills/ci-secure/scaffold/gate.py
+++ b/skills/ci-secure/scaffold/gate.py
@@ -86,13 +86,56 @@ def load_config():
     return None, None
 
 
-CONFIG, CONFIG_PATH = load_config()
+# Loading the rule EXECUTES code - `spec.loader.exec_module` - and in a vendored
+# layout that code sits beside the engine rather than in this tree, which makes
+# this the likeliest line in the file to raise, not the least. It runs at module
+# scope, OUTSIDE main()'s handler, so a config.py with a syntax error or an
+# import-time raise used to exit non-zero with a bare traceback and no
+# `::error::` - the "unexplained red" this file argues against everywhere else.
+# The failure is captured here and re-reported as a stated verdict in main().
+#
+# `BaseException`, not `Exception`, and that is the load-bearing part rather
+# than defensive habit: `SystemExit` is not an `Exception`, so a config.py whose
+# module body called `sys.exit(0)` ENDED THIS PROCESS RIGHT HERE with status 0
+# and no output - a green gate over a scan that never ran. Narrowing this clause
+# is a natural-looking tidy-up that brings that forged pass straight back, which
+# is why `test_a_rule_that_exits_cleanly_on_load_cannot_forge_a_pass` pins it.
+#
+# Deliberately unannotated: a PEP 604 `BaseException | None` here would be
+# evaluated at module scope, and this file is vendored into adopters' repos
+# where python3 is whatever they have. That is the same break this PR fixed in
+# the skill's own config.py.
+try:
+    CONFIG, CONFIG_PATH = load_config()
+    CONFIG_ERROR = None
+except BaseException as _exc:                                 # noqa: BLE001
+    CONFIG, CONFIG_PATH, CONFIG_ERROR = None, None, _exc
 
 # The job's own timeout-minutes would eventually catch a hung engine, but only
 # as an unexplained cancellation; failing here names the cause on the check run.
 # It must therefore fire FIRST: at parity with the job's 10 minutes this path was
 # unreachable, because checkout and pip had already spent a minute of that clock.
-ENGINE_TIMEOUT_S = 420
+#
+# Overridable by env so the timeout can be exercised for real in a test rather
+# than trusted. A test that has to sleep 420s does not get written, and an
+# untested timeout is how this constant sat at parity with the job clock -
+# unreachable - in the first place.
+#
+# The override can only ever SHORTEN the wait, and the clamp is what makes that
+# true rather than a comment hoping it is. Without it a workflow could set the
+# variable high enough to put the timeout back out of reach, which is exactly
+# the regression this constant exists to prevent - and the invariant test reads
+# the source literal, so it would not notice. A zero, a negative or a
+# non-numeric falls back to the default, since "no timeout at all" is the
+# failure being prevented, not a way to ask for one.
+_TIMEOUT_CEILING = 420
+try:
+    ENGINE_TIMEOUT_S = int(os.environ.get("CI_SECURE_ENGINE_TIMEOUT_S", "")
+                           or _TIMEOUT_CEILING)
+except ValueError:
+    ENGINE_TIMEOUT_S = _TIMEOUT_CEILING
+if not 0 < ENGINE_TIMEOUT_S <= _TIMEOUT_CEILING:
+    ENGINE_TIMEOUT_S = _TIMEOUT_CEILING
 
 # P14.11 (impostor action SHA) is the one detector that needs network and a
 # GitHub token, so whether it runs is a property of the JOB, not of this script:
@@ -105,7 +148,12 @@ ENGINE_TIMEOUT_S = 420
 # run?" a property of the runner image - one rebuild away from silently
 # stopping. A typo is red for the same reason: a check that quietly turned
 # itself off looks exactly like a check that passed.
-IMPOSTOR = os.environ.get("CI_SECURE_GH_IMPOSTOR", "off").strip().lower()
+# No default. Defaulting to "off" made UNSET the one value that skipped the
+# refusal below - so deleting the `env:` block from a scan job would quietly
+# turn the network-gated check off, which is exactly the outcome this variable
+# exists to make impossible, and the refusal message right below claimed was
+# already impossible.
+IMPOSTOR = os.environ.get("CI_SECURE_GH_IMPOSTOR", "").strip().lower()
 ENGINE_ARGS = ["--gh-impostor", IMPOSTOR]
 
 # Anything short of a completed network check is disclosed everywhere; whether
@@ -113,7 +161,15 @@ ENGINE_ARGS = ["--gh-impostor", IMPOSTOR]
 # someone else's rate limit, so there it warns. The scheduled run against the
 # default branch has no deadline and nothing to race, so there it is red - and
 # it is the run that catches a pin that rots after merge.
-STRICT_GH = os.environ.get("CI_SECURE_GH_STRICT", "").strip() == "1"
+#
+# Unset is allowed and means lax, because the fork job deliberately does not set
+# it and lax still DISCLOSES on both surfaces - the dial changes severity, not
+# coverage. An unrecognised value is refused, though: `true`, `yes` and
+# `schedule` all read as "strict is on" to a human editing the YAML and all
+# silently meant lax, which would have muted the one run whose whole purpose is
+# catching a pin that rots after merge.
+STRICT_RAW = os.environ.get("CI_SECURE_GH_STRICT", "0").strip()
+STRICT_GH = STRICT_RAW == "1"
 
 # The engine's own vocabulary for a completed network check. `partial:` (some
 # pins unverified) and `skipped:` (never ran) are the two it uses for anything
@@ -241,14 +297,23 @@ def main() -> int:
     # prevent: a second definition of "which outcomes block" that drifts from
     # the engine's and is never noticed, because a build that finds it goes
     # green either way.
+    if CONFIG_ERROR is not None:
+        quote("".join(traceback.format_exception(
+            type(CONFIG_ERROR), CONFIG_ERROR, CONFIG_ERROR.__traceback__)))
+        return fail(
+            f"ci-secure rule (config.py) could not be loaded ({CONFIG_ERROR!r}) "
+            "- the gate cannot decide what blocks without one")
     if CONFIG is None:
         return fail(
             f"ci-secure rule (config.py) not found beside the engine at "
             f"{ENGINE.parent} nor at {_CONFIG_FALLBACK} - the gate cannot decide "
             "what blocks without one")
+    # `coverage_is_complete` is in this list because it is CALLED below: left
+    # out, a vendored rule missing only that name reached the crash handler and
+    # reported an AttributeError instead of the specific disagreement.
     missing = [name for name in
                ("BLOCKING_OUTCOMES", "KNOWN_OUTCOMES", "OUTCOME_MARKS",
-                "flatten_scanned")
+                "flatten_scanned", "coverage_is_complete")
                if not hasattr(CONFIG, name)]
     if missing:
         return fail(f"ci-secure rule at {CONFIG_PATH} defines no {', '.join(missing)} "
@@ -265,6 +330,12 @@ def main() -> int:
             "on this job. Leaving the variable unset lands on 'off', which is "
             "a DISCLOSED off: it is reported under 'Network-gated detectors' "
             "as a check that did not run, never as one that passed")
+
+    if STRICT_RAW not in ("0", "1"):
+        return fail(
+            f"CI_SECURE_GH_STRICT must be '0' or '1', not {STRICT_RAW!r} - a "
+            "value like 'true' reads as strict and meant lax, which would mute "
+            "the run whose purpose is catching a pin that rots after merge")
 
     try:
         result = subprocess.run(
@@ -393,8 +464,8 @@ def main() -> int:
     # A detector that did not run is reported, not omitted: "no findings from
     # P14.11" and "P14.11 never ran" must not look the same to a reader. Indexed,
     # not `.get(... ) or {}`: this gate always passes `--gh-impostor` explicitly,
-    # so the engine always has a status to report, and an absent key is drift -
-    # which would make those two cases look identical again.
+    # on or off, so the engine always has a status to report, and an absent key
+    # is schema drift - which would make those two cases look identical again.
     lines += ["", "### Network-gated detectors", ""]
     lines += [f"- `{flat(k)}`: {flat(v)}" for k, v in sorted(gh_checks.items())]
     # Individually unmeasured facts do not block - several have honest causes

--- a/skills/ci-secure/scaffold/gate.py
+++ b/skills/ci-secure/scaffold/gate.py
@@ -260,9 +260,11 @@ def main() -> int:
     if IMPOSTOR not in ("on", "off"):
         return fail(
             f"CI_SECURE_GH_IMPOSTOR must be 'on' or 'off', not {IMPOSTOR!r} - "
-            "'auto' and an unset value are refused on purpose, because they make "
-            "whether the network-gated check runs depend on the runner image "
-            "rather than on this job")
+            "'auto' is refused on purpose, because it makes whether the "
+            "network-gated check runs depend on the runner image rather than "
+            "on this job. Leaving the variable unset lands on 'off', which is "
+            "a DISCLOSED off: it is reported under 'Network-gated detectors' "
+            "as a check that did not run, never as one that passed")
 
     try:
         result = subprocess.run(
@@ -390,8 +392,8 @@ def main() -> int:
                   f"{esc(f.get('title', ''))}")
     # A detector that did not run is reported, not omitted: "no findings from
     # P14.11" and "P14.11 never ran" must not look the same to a reader. Indexed,
-    # not `.get(... ) or {}`: this gate always passes `--gh-impostor off`, so the
-    # engine always has a status to report, and an absent key is schema drift -
+    # not `.get(... ) or {}`: this gate always passes `--gh-impostor` explicitly,
+    # so the engine always has a status to report, and an absent key is drift -
     # which would make those two cases look identical again.
     lines += ["", "### Network-gated detectors", ""]
     lines += [f"- `{flat(k)}`: {flat(v)}" for k, v in sorted(gh_checks.items())]

--- a/skills/ci-secure/scaffold/gate.py
+++ b/skills/ci-secure/scaffold/gate.py
@@ -327,9 +327,12 @@ def main() -> int:
             f"CI_SECURE_GH_IMPOSTOR must be 'on' or 'off', not {IMPOSTOR!r} - "
             "'auto' is refused on purpose, because it makes whether the "
             "network-gated check runs depend on the runner image rather than "
-            "on this job. Leaving the variable unset lands on 'off', which is "
-            "a DISCLOSED off: it is reported under 'Network-gated detectors' "
-            "as a check that did not run, never as one that passed")
+            "on this job. An UNSET value is refused for the same reason and "
+            "reaches you as this same error: deleting the `env:` block must "
+            "not be a way to turn the check off. Set it to 'off' explicitly "
+            "if you want it off - that is a DISCLOSED off, reported under "
+            "'Network-gated detectors' as a check that did not run, never as "
+            "one that passed")
 
     if STRICT_RAW not in ("0", "1"):
         return fail(

--- a/skills/ci-secure/scaffold/gate.py
+++ b/skills/ci-secure/scaffold/gate.py
@@ -86,56 +86,13 @@ def load_config():
     return None, None
 
 
-# Loading the rule EXECUTES code - `spec.loader.exec_module` - and in a vendored
-# layout that code sits beside the engine rather than in this tree, which makes
-# this the likeliest line in the file to raise, not the least. It runs at module
-# scope, OUTSIDE main()'s handler, so a config.py with a syntax error or an
-# import-time raise used to exit non-zero with a bare traceback and no
-# `::error::` - the "unexplained red" this file argues against everywhere else.
-# The failure is captured here and re-reported as a stated verdict in main().
-#
-# `BaseException`, not `Exception`, and that is the load-bearing part rather
-# than defensive habit: `SystemExit` is not an `Exception`, so a config.py whose
-# module body called `sys.exit(0)` ENDED THIS PROCESS RIGHT HERE with status 0
-# and no output - a green gate over a scan that never ran. Narrowing this clause
-# is a natural-looking tidy-up that brings that forged pass straight back, which
-# is why `test_a_rule_that_exits_cleanly_on_load_cannot_forge_a_pass` pins it.
-#
-# Deliberately unannotated: a PEP 604 `BaseException | None` here would be
-# evaluated at module scope, and this file is vendored into adopters' repos
-# where python3 is whatever they have. That is the same break this PR fixed in
-# the skill's own config.py.
-try:
-    CONFIG, CONFIG_PATH = load_config()
-    CONFIG_ERROR = None
-except BaseException as _exc:                                 # noqa: BLE001
-    CONFIG, CONFIG_PATH, CONFIG_ERROR = None, None, _exc
+CONFIG, CONFIG_PATH = load_config()
 
 # The job's own timeout-minutes would eventually catch a hung engine, but only
 # as an unexplained cancellation; failing here names the cause on the check run.
 # It must therefore fire FIRST: at parity with the job's 10 minutes this path was
 # unreachable, because checkout and pip had already spent a minute of that clock.
-#
-# Overridable by env so the timeout can be exercised for real in a test rather
-# than trusted. A test that has to sleep 420s does not get written, and an
-# untested timeout is how this constant sat at parity with the job clock -
-# unreachable - in the first place.
-#
-# The override can only ever SHORTEN the wait, and the clamp is what makes that
-# true rather than a comment hoping it is. Without it a workflow could set the
-# variable high enough to put the timeout back out of reach, which is exactly
-# the regression this constant exists to prevent - and the invariant test reads
-# the source literal, so it would not notice. A zero, a negative or a
-# non-numeric falls back to the default, since "no timeout at all" is the
-# failure being prevented, not a way to ask for one.
-_TIMEOUT_CEILING = 420
-try:
-    ENGINE_TIMEOUT_S = int(os.environ.get("CI_SECURE_ENGINE_TIMEOUT_S", "")
-                           or _TIMEOUT_CEILING)
-except ValueError:
-    ENGINE_TIMEOUT_S = _TIMEOUT_CEILING
-if not 0 < ENGINE_TIMEOUT_S <= _TIMEOUT_CEILING:
-    ENGINE_TIMEOUT_S = _TIMEOUT_CEILING
+ENGINE_TIMEOUT_S = 420
 
 # P14.11 (impostor action SHA) is the one detector that needs network and a
 # GitHub token, so whether it runs is a property of the JOB, not of this script:
@@ -148,12 +105,7 @@ if not 0 < ENGINE_TIMEOUT_S <= _TIMEOUT_CEILING:
 # run?" a property of the runner image - one rebuild away from silently
 # stopping. A typo is red for the same reason: a check that quietly turned
 # itself off looks exactly like a check that passed.
-# No default. Defaulting to "off" made UNSET the one value that skipped the
-# refusal below - so deleting the `env:` block from a scan job would quietly
-# turn the network-gated check off, which is exactly the outcome this variable
-# exists to make impossible, and the refusal message right below claimed was
-# already impossible.
-IMPOSTOR = os.environ.get("CI_SECURE_GH_IMPOSTOR", "").strip().lower()
+IMPOSTOR = os.environ.get("CI_SECURE_GH_IMPOSTOR", "off").strip().lower()
 ENGINE_ARGS = ["--gh-impostor", IMPOSTOR]
 
 # Anything short of a completed network check is disclosed everywhere; whether
@@ -161,15 +113,7 @@ ENGINE_ARGS = ["--gh-impostor", IMPOSTOR]
 # someone else's rate limit, so there it warns. The scheduled run against the
 # default branch has no deadline and nothing to race, so there it is red - and
 # it is the run that catches a pin that rots after merge.
-#
-# Unset is allowed and means lax, because the fork job deliberately does not set
-# it and lax still DISCLOSES on both surfaces - the dial changes severity, not
-# coverage. An unrecognised value is refused, though: `true`, `yes` and
-# `schedule` all read as "strict is on" to a human editing the YAML and all
-# silently meant lax, which would have muted the one run whose whole purpose is
-# catching a pin that rots after merge.
-STRICT_RAW = os.environ.get("CI_SECURE_GH_STRICT", "0").strip()
-STRICT_GH = STRICT_RAW == "1"
+STRICT_GH = os.environ.get("CI_SECURE_GH_STRICT", "").strip() == "1"
 
 # The engine's own vocabulary for a completed network check. `partial:` (some
 # pins unverified) and `skipped:` (never ran) are the two it uses for anything
@@ -297,23 +241,14 @@ def main() -> int:
     # prevent: a second definition of "which outcomes block" that drifts from
     # the engine's and is never noticed, because a build that finds it goes
     # green either way.
-    if CONFIG_ERROR is not None:
-        quote("".join(traceback.format_exception(
-            type(CONFIG_ERROR), CONFIG_ERROR, CONFIG_ERROR.__traceback__)))
-        return fail(
-            f"ci-secure rule (config.py) could not be loaded ({CONFIG_ERROR!r}) "
-            "- the gate cannot decide what blocks without one")
     if CONFIG is None:
         return fail(
             f"ci-secure rule (config.py) not found beside the engine at "
             f"{ENGINE.parent} nor at {_CONFIG_FALLBACK} - the gate cannot decide "
             "what blocks without one")
-    # `coverage_is_complete` is in this list because it is CALLED below: left
-    # out, a vendored rule missing only that name reached the crash handler and
-    # reported an AttributeError instead of the specific disagreement.
     missing = [name for name in
                ("BLOCKING_OUTCOMES", "KNOWN_OUTCOMES", "OUTCOME_MARKS",
-                "flatten_scanned", "coverage_is_complete")
+                "flatten_scanned")
                if not hasattr(CONFIG, name)]
     if missing:
         return fail(f"ci-secure rule at {CONFIG_PATH} defines no {', '.join(missing)} "
@@ -328,12 +263,6 @@ def main() -> int:
             "'auto' and an unset value are refused on purpose, because they make "
             "whether the network-gated check runs depend on the runner image "
             "rather than on this job")
-
-    if STRICT_RAW not in ("0", "1"):
-        return fail(
-            f"CI_SECURE_GH_STRICT must be '0' or '1', not {STRICT_RAW!r} - a "
-            "value like 'true' reads as strict and meant lax, which would mute "
-            "the run whose purpose is catching a pin that rots after merge")
 
     try:
         result = subprocess.run(
@@ -461,9 +390,9 @@ def main() -> int:
                   f"{esc(f.get('title', ''))}")
     # A detector that did not run is reported, not omitted: "no findings from
     # P14.11" and "P14.11 never ran" must not look the same to a reader. Indexed,
-    # not `.get(... ) or {}`: this gate always passes `--gh-impostor` explicitly,
-    # on or off, so the engine always has a status to report, and an absent key
-    # is schema drift - which would make those two cases look identical again.
+    # not `.get(... ) or {}`: this gate always passes `--gh-impostor off`, so the
+    # engine always has a status to report, and an absent key is schema drift -
+    # which would make those two cases look identical again.
     lines += ["", "### Network-gated detectors", ""]
     lines += [f"- `{flat(k)}`: {flat(v)}" for k, v in sorted(gh_checks.items())]
     # Individually unmeasured facts do not block - several have honest causes

--- a/skills/ci-secure/scripts/vendor.py
+++ b/skills/ci-secure/scripts/vendor.py
@@ -140,57 +140,129 @@ def _previously_vendored(dest: Path) -> list[str]:
         return []
 
 
-def _refuse_destinations_outside(repo: Path, dest: Path) -> None:
-    """Refuse, before writing anything, if any destination leaves the repository.
+def _refuse_a_subdirectory(repo: Path) -> None:
+    """Refuse `--into` a subdirectory of a repository rather than its root.
+
+    `services/api/.github/workflows/ci-secure.yml` is a file GitHub never
+    reads. The install otherwise prints exactly what a correct one prints, so
+    the adopter is told they have a gate and every pull request merges
+    unscanned — worse than no install, because it stops them installing again.
+
+    Only a path that IS inside a git work tree but is not its root is refused.
+    A directory that is not in a repository at all is left alone: vendoring
+    into a tree before `git init` is a legitimate order to do things in, and
+    guessing at intent there would refuse work that is fine.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):     # no git to ask
+        return
+    if out.returncode != 0:                           # not in a repository
+        return
+
+    root = Path(out.stdout.strip())
+    if not root.name or root.resolve() == repo.resolve():
+        return
+    raise SystemExit(
+        f"refusing to install: {repo} is inside the repository at {root}, not "
+        "its root. A workflow written here is one GitHub never runs, and the "
+        "install would look like it had worked. Run this again with "
+        f"--into {root}")
+
+
+def _refuse_a_destination_in_use(dest: Path) -> None:
+    """Refuse a first install into a `ci-secure/` directory someone else owns.
+
+    `ci-secure/` is a plausible name for a directory an adopter already keeps,
+    and copying in beside what is there exits 0 while the manifest lists only
+    our files — so their own CI reds on `--verify` with "not in the manifest",
+    on the first run and every run after it, before the gate is reached.
+    Neither documented remedy applies: `--advisory` downgrades failed FACTS,
+    and this is not a fact. Refusing while the adopter is still looking at the
+    install is the only moment this is cheap to resolve.
+
+    Only a FIRST install is refused. A refresh is expected to find our files
+    there, and drift in a copy we did install is what `--verify` is for.
+    """
+    if not dest.exists():
+        return
+    if not dest.is_dir():
+        raise SystemExit(
+            f"refusing to install: {dest} already exists and is not a "
+            "directory, so there is nowhere to put the vendored copy. Move it "
+            "aside, then run this again.")
+    intruders = sorted(path.relative_to(dest).as_posix()
+                       for path in dest.rglob("*") if path.is_file())
+    if not intruders:
+        return
+    shown = ", ".join(intruders[:5])
+    more = f" (and {len(intruders) - 5} more)" if len(intruders) > 5 else ""
+    raise SystemExit(
+        f"refusing to install: {dest} already holds files that are not "
+        f"ci-secure's - {shown}{more}. The vendored copy has to be the only "
+        "thing in that directory, because the workflow re-checks it against a "
+        "manifest on every run and would red on anything else it finds. Move "
+        "them somewhere else, then run this again.")
+
+
+def _refuse_redirected_destinations(repo: Path, dest: Path) -> None:
+    """Refuse, before writing anything, if any destination has been redirected.
 
     A symlink is ordinary repository content: it survives a clone, a pull
     request checkout and a fork, and it costs an attacker one committed file.
-    One at `ci-secure/`, at any directory beneath it, or at `.github/` is
-    followed by `mkdir` and `copy2` exactly as a real directory would be, so
-    without this the engine, the gate and a live workflow land somewhere the
-    adopter never looked while this prints success — and the repository it was
-    aimed at ends up with no gate at all.
+    One at `ci-secure/`, at any directory beneath it, at a single vendored
+    file, or at `.github/` is followed by `mkdir` and `copy2` exactly as a real
+    directory would be.
+
+    Two different harms, so two tests. A destination that leaves the repository
+    puts the engine, the gate and a live workflow somewhere the adopter never
+    looked while this prints success, and the repository it was aimed at comes
+    away with no gate. A destination redirected to somewhere else INSIDE the
+    repository stays contained and is worse in a different way: a symlink at
+    `ci-secure/LICENSE` pointing at `.github/workflows/release.yml` passes any
+    containment test and then has the licence text written over the adopter's
+    release workflow, on a refresh that reports success. Containment alone is
+    not the property wanted; "this path is what it appears to be" is.
 
     Every destination is checked, not just the vendored root, because the
-    escape can sit at any component of any path, or at a single file. Resolving
-    each one and requiring it to stay under the resolved repository covers all
-    of those in one test, including `..` inside a path and a symlink loop.
+    redirect can sit at any component of any path. The directories this would
+    `mkdir` are destinations too, which also keeps the refusal pointed at the
+    one symlink to remove rather than at the six files under it.
     """
     root = repo.resolve()
     targets = [dest, dest / MANIFEST_NAME, dest / GATE_DEST, dest / LICENSE_DEST,
                repo / WORKFLOW_DEST, (repo / WORKFLOW_DEST).parent]
     targets += [dest / rel for rel in VENDORED_FILES]
-    # Directories this will `mkdir` are destinations too, and naming them keeps
-    # the refusal pointed at the one symlink to remove rather than at the six
-    # files under it.
     targets += [parent for target in list(targets)
                 for parent in target.parents if repo in parent.parents]
 
-    escaped = []
+    bad: dict[Path, str] = {}
     for target in targets:
+        if target.is_symlink():
+            bad.setdefault(target, "is a symlink, so writing it would write "
+                                   "somewhere else")
+            continue
         try:
             resolved = target.resolve()
         except OSError:                          # symlink loop, unreadable path
-            escaped.append(target)
+            bad.setdefault(target, "cannot be resolved")
             continue
         if not resolved.is_relative_to(root):
-            escaped.append(target)
+            bad.setdefault(target, "resolves outside the repository")
 
-    if escaped:
-        # One symlink at `ci-secure/` escapes every destination beneath it.
-        # Naming all ten obscures the single thing the adopter has to fix, so
-        # only the shallowest offender on each branch is reported.
-        shallowest = [path for path in escaped
-                      if not any(other != path and other in path.parents
-                                 for other in escaped)]
-        listed = "\n  ".join(
-            f"{path.relative_to(repo)} -> outside the repository"
-            for path in sorted(set(shallowest)))
+    if bad:
+        # One symlink at `ci-secure/` redirects every destination beneath it.
+        # Naming all ten obscures the single thing the adopter has to fix.
+        shallowest = sorted(path for path in bad
+                            if not any(other in path.parents for other in bad))
+        listed = "\n  ".join(f"{path.relative_to(repo)} {bad[path]}"
+                             for path in shallowest)
         raise SystemExit(
-            "refusing to install: these destinations resolve outside "
-            f"{root}, so installing would write the gate somewhere this "
-            "repository's pull requests would never see it:\n  "
-            f"{listed}\n"
+            "refusing to install: these destinations are not the plain paths "
+            "they look like, so installing would write somewhere other than "
+            f"where this says it writes:\n  {listed}\n"
             "A symlink on one of those paths is almost certainly not what you "
             "want under a security gate. Remove it, then run this again.")
 
@@ -224,9 +296,12 @@ def install(repo: Path) -> Path:
             "licence violation, so this refuses rather than shipping one")
 
     dest = repo / VENDOR_DIRNAME
-    _refuse_destinations_outside(repo, dest)
+    _refuse_a_subdirectory(repo)
+    _refuse_redirected_destinations(repo, dest)
 
     first_install = not (dest / MANIFEST_NAME).is_file()
+    if first_install:
+        _refuse_a_destination_in_use(dest)
     stale = set(_previously_vendored(dest)) - set(vendored_paths())
 
     for rel in VENDORED_FILES:
@@ -277,17 +352,24 @@ def install(repo: Path) -> Path:
     write_manifest(dest)
 
     workflow = repo / WORKFLOW_DEST
-    if workflow.exists():
-        if first_install:
-            print(f"::warning::{WORKFLOW_DEST} already existed and was NOT "
-                  "replaced, so nothing here runs the gate yet. Compare it "
-                  f"against {WORKFLOW_SOURCE} in the skill and merge what you "
-                  "need, or move it aside and run this again.")
-        else:
-            print(f"left the workflow at {WORKFLOW_DEST} exactly as it is - it "
-                  f"is yours to tune. To take up template changes, diff it "
-                  f"against {WORKFLOW_SOURCE} in the skill and apply what you "
-                  "want.")
+    if not first_install:
+        # A refresh writes NO workflow, whether or not one is sitting at that
+        # path. "Do not overwrite what is there" was a narrower promise than
+        # the one made: an adopter who RENAMED the file to fit their
+        # conventions, or deleted it while backing the gate out, got the
+        # advisory template silently re-added beside their blocking one -
+        # reaching the same "quietly back to advisory" outcome by adding
+        # rather than overwriting, with two jobs then publishing the required
+        # check name.
+        print("this is a refresh, so the workflow was not touched - it is "
+              "yours, including where it lives. To take up template changes, "
+              f"diff yours against {WORKFLOW_SOURCE} in the skill and apply "
+              "what you want.")
+    elif workflow.exists():
+        print(f"::warning::{WORKFLOW_DEST} already existed and was NOT "
+              "replaced, so nothing here runs the gate yet. Compare it "
+              f"against {WORKFLOW_SOURCE} in the skill and merge what you "
+              "need, or move it aside and run this again.")
     else:
         workflow.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(workflow_source, workflow)
@@ -328,11 +410,21 @@ def verify(dest: Path) -> int:
         print(f"::error::{MANIFEST_NAME} is missing from {dest} - cannot tell "
               "what this copy of ci-secure was supposed to be")
         return 1
+    # `VENDORED.json` is repository content, so its SHAPE is untrusted too. A
+    # `files` that is a list, a string or null used to red with a bare
+    # traceback: a security check failing inside someone's pull request with no
+    # stated cause, in a tool whose whole argument is that a red says what is
+    # wrong and what to do about it.
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         recorded = manifest["files"]
-    except (ValueError, KeyError) as exc:
+    except (ValueError, KeyError, TypeError, AttributeError) as exc:
         print(f"::error::{MANIFEST_NAME} is unreadable ({exc!r})")
+        return 1
+    if not isinstance(manifest, dict) or not isinstance(recorded, dict):
+        print(f"::error::{MANIFEST_NAME} does not have the shape of a "
+              "manifest - `files` must be a mapping of path to hash. Ask "
+              "ci-secure to refresh the vendored copy, which rewrites it.")
         return 1
 
     drift = []
@@ -344,12 +436,12 @@ def verify(dest: Path) -> int:
             drift.append(f"{rel}: modified")
     for path in dest.rglob("*"):
         rel = path.relative_to(dest).as_posix()
-        if not path.is_file() or rel == MANIFEST_NAME or rel in recorded:
-            continue
-        # Bytecode gets its OWN message, not an exemption. A `.pyc` written
-        # with an unchecked hash is never validated against its source: Python
-        # loads it as-is, which is how the gate loads `config.py`. So one
-        # planted here can empty the set of outcomes that block while every
+        # Bytecode gets its OWN message, not an exemption - and the test comes
+        # BEFORE the manifest short-circuit below, because the manifest is
+        # repository content and cannot be allowed to bless a `.pyc`. A `.pyc`
+        # written with an unchecked hash is never validated against its source:
+        # Python loads it as-is, which is how the gate loads `config.py`. So
+        # one planted here can empty the set of outcomes that block while every
         # source file still hashes correctly - a green check over a repository
         # with failing facts, and nothing else would ever see it. The innocent
         # cause is a local run, which the shipped workflow prevents outright by
@@ -359,6 +451,19 @@ def verify(dest: Path) -> int:
                 f"{rel}: compiled bytecode, which can override the source file "
                 "verified above - delete ci-secure/**/__pycache__, and do not "
                 "commit it")
+            continue
+        # A symlink is drift whatever it points at. The walk does not descend
+        # one, so a `__pycache__` symlinked to a build directory elsewhere in
+        # the repository would otherwise hide planted bytecode from the test
+        # above without the manifest being touched at all; and a vendored file
+        # replaced by a symlink is not the file that was reviewed.
+        if path.is_symlink():
+            drift.append(
+                f"{rel}: a symlink, which a vendored copy never contains - it "
+                "makes the verified path and the file that is actually read "
+                "two different things")
+            continue
+        if not path.is_file() or rel == MANIFEST_NAME or rel in recorded:
             continue
         drift.append(f"{rel}: not in the manifest")
 

--- a/skills/ci-secure/scripts/vendor.py
+++ b/skills/ci-secure/scripts/vendor.py
@@ -122,28 +122,44 @@ def _license_source() -> Path | None:
     return None
 
 
+def _previously_vendored(dest: Path) -> list[str]:
+    """What the last install put here, according to its own manifest.
+
+    A refresh needs this so it can REMOVE what this version no longer vendors.
+    A dropped file is not inert: `--verify` reds on anything under the vendored
+    directory the manifest does not list, so leaving it behind would hand the
+    adopter a failing required check for a file they never touched, on a
+    refresh that was otherwise correct.
+    """
+    path = dest / MANIFEST_NAME
+    if not path.is_file():
+        return []
+    try:
+        return sorted(json.loads(path.read_text(encoding="utf-8"))["files"])
+    except (ValueError, KeyError, TypeError):
+        return []
+
+
 def install(repo: Path) -> Path:
-    """Copy the engine, the gate and the licence into `repo/ci-secure/`."""
-    if not (_SKILL / GATE_SOURCE).is_file():
+    """Copy the engine, the gate and the licence into `repo/ci-secure/`.
+
+    Everything that can refuse refuses BEFORE anything is written. A partial
+    install is not a tidy failure: it is a live workflow in the adopter's
+    repository beside a vendored tree with no manifest, whose first CI run reds
+    with "cannot tell what this copy was supposed to be".
+    """
+    gate = _SKILL / GATE_SOURCE
+    workflow_source = _SKILL / WORKFLOW_SOURCE
+    if not gate.is_file() or not workflow_source.is_file():
         raise SystemExit(
             "this looks like a VENDORED copy of ci-secure, which can verify "
             "itself but cannot install: the scaffold and the rest of the skill "
             "are not here. Run --into from an installed ci-secure skill, or ask "
             "ci-secure to refresh this copy.")
-    dest = repo / VENDOR_DIRNAME
-    for rel in VENDORED_FILES:
-        target = dest / rel
-        target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(_SKILL / rel, target)
 
-    gate = _SKILL / GATE_SOURCE
-    if not gate.is_file():                       # pragma: no cover - defensive
-        raise SystemExit(f"gate not found at {gate}")
-    shutil.copy2(gate, dest / GATE_DEST)
-
-    workflow = repo / WORKFLOW_DEST
-    workflow.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(_SKILL / WORKFLOW_SOURCE, workflow)
+    missing = [rel for rel in VENDORED_FILES if not (_SKILL / rel).is_file()]
+    if missing:                                  # pragma: no cover - defensive
+        raise SystemExit(f"ci-secure is incomplete, cannot vendor: {missing}")
 
     # The licence travels with the code or the copy is a licence violation.
     licence = _license_source()
@@ -151,13 +167,45 @@ def install(repo: Path) -> Path:
         raise SystemExit(
             "no LICENSE found to vendor; copying the code without it would be a "
             "licence violation, so this refuses rather than shipping one")
+
+    dest = repo / VENDOR_DIRNAME
+    stale = set(_previously_vendored(dest)) - set(vendored_paths())
+
+    for rel in VENDORED_FILES:
+        target = dest / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(_SKILL / rel, target)
+    shutil.copy2(gate, dest / GATE_DEST)
     shutil.copy2(licence, dest / LICENSE_DEST)
+
+    for rel in sorted(stale):
+        old = dest / rel
+        if old.is_file():
+            old.unlink()
+            print(f"removed {rel}, which this version no longer vendors")
+
+    # The workflow belongs to the adopter. They are invited to change the
+    # runner and the triggers, and — the entire point of the ramp — to delete
+    # `--advisory` once the first run's findings are burned down. Copying the
+    # template back over it on every refresh would quietly return a blocking
+    # gate to advisory, and because the workflow is deliberately not
+    # checksummed, nothing downstream would catch it. So it is written once and
+    # never rewritten.
+    workflow = repo / WORKFLOW_DEST
+    if workflow.exists():
+        print(f"left the workflow at {WORKFLOW_DEST} exactly as it is - it is "
+              f"yours to tune. To take up template changes, diff it against "
+              f"{WORKFLOW_SOURCE} in the skill and apply what you want.")
+    else:
+        workflow.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(workflow_source, workflow)
+        print(f"wrote the workflow to {WORKFLOW_DEST}")
 
     write_manifest(dest)
     return dest
 
 
-def vendored_paths(dest: Path) -> list[str]:
+def vendored_paths() -> list[str]:
     return sorted([*VENDORED_FILES, GATE_DEST, LICENSE_DEST])
 
 
@@ -167,7 +215,7 @@ def write_manifest(dest: Path) -> Path:
         "skill_version": skill_version(),
         "source_commit": source_commit(),
         "source_repo": "https://github.com/starslingdev/skills",
-        "files": {rel: sha256(dest / rel) for rel in vendored_paths(dest)},
+        "files": {rel: sha256(dest / rel) for rel in vendored_paths()},
         "note": (
             "Written by ci-secure's install step. `vendor.py --verify` "
             "recomputes these hashes. To update the vendored copy, ask "
@@ -205,8 +253,16 @@ def verify(dest: Path) -> int:
             drift.append(f"{rel}: modified")
     for path in dest.rglob("*"):
         rel = path.relative_to(dest).as_posix()
-        if path.is_file() and rel != MANIFEST_NAME and rel not in recorded:
-            drift.append(f"{rel}: not in the manifest")
+        if not path.is_file() or rel == MANIFEST_NAME or rel in recorded:
+            continue
+        # Bytecode is not a tampered gate. The engine is imported as modules,
+        # so any local run of the gate leaves `__pycache__/` behind, and this
+        # command is one the adopter is told to run. An alarm that fires on a
+        # `.pyc` the tool wrote itself is an alarm nobody reads by the third
+        # time, which costs more than the case it would ever catch.
+        if "__pycache__" in path.parts or path.suffix == ".pyc":
+            continue
+        drift.append(f"{rel}: not in the manifest")
 
     if not drift:
         print(f"ci-secure vendored copy matches {MANIFEST_NAME} "

--- a/skills/ci-secure/scripts/vendor.py
+++ b/skills/ci-secure/scripts/vendor.py
@@ -140,6 +140,61 @@ def _previously_vendored(dest: Path) -> list[str]:
         return []
 
 
+def _refuse_destinations_outside(repo: Path, dest: Path) -> None:
+    """Refuse, before writing anything, if any destination leaves the repository.
+
+    A symlink is ordinary repository content: it survives a clone, a pull
+    request checkout and a fork, and it costs an attacker one committed file.
+    One at `ci-secure/`, at any directory beneath it, or at `.github/` is
+    followed by `mkdir` and `copy2` exactly as a real directory would be, so
+    without this the engine, the gate and a live workflow land somewhere the
+    adopter never looked while this prints success — and the repository it was
+    aimed at ends up with no gate at all.
+
+    Every destination is checked, not just the vendored root, because the
+    escape can sit at any component of any path, or at a single file. Resolving
+    each one and requiring it to stay under the resolved repository covers all
+    of those in one test, including `..` inside a path and a symlink loop.
+    """
+    root = repo.resolve()
+    targets = [dest, dest / MANIFEST_NAME, dest / GATE_DEST, dest / LICENSE_DEST,
+               repo / WORKFLOW_DEST, (repo / WORKFLOW_DEST).parent]
+    targets += [dest / rel for rel in VENDORED_FILES]
+    # Directories this will `mkdir` are destinations too, and naming them keeps
+    # the refusal pointed at the one symlink to remove rather than at the six
+    # files under it.
+    targets += [parent for target in list(targets)
+                for parent in target.parents if repo in parent.parents]
+
+    escaped = []
+    for target in targets:
+        try:
+            resolved = target.resolve()
+        except OSError:                          # symlink loop, unreadable path
+            escaped.append(target)
+            continue
+        if not resolved.is_relative_to(root):
+            escaped.append(target)
+
+    if escaped:
+        # One symlink at `ci-secure/` escapes every destination beneath it.
+        # Naming all ten obscures the single thing the adopter has to fix, so
+        # only the shallowest offender on each branch is reported.
+        shallowest = [path for path in escaped
+                      if not any(other != path and other in path.parents
+                                 for other in escaped)]
+        listed = "\n  ".join(
+            f"{path.relative_to(repo)} -> outside the repository"
+            for path in sorted(set(shallowest)))
+        raise SystemExit(
+            "refusing to install: these destinations resolve outside "
+            f"{root}, so installing would write the gate somewhere this "
+            "repository's pull requests would never see it:\n  "
+            f"{listed}\n"
+            "A symlink on one of those paths is almost certainly not what you "
+            "want under a security gate. Remove it, then run this again.")
+
+
 def install(repo: Path) -> Path:
     """Copy the engine, the gate and the licence into `repo/ci-secure/`.
 
@@ -169,6 +224,8 @@ def install(repo: Path) -> Path:
             "licence violation, so this refuses rather than shipping one")
 
     dest = repo / VENDOR_DIRNAME
+    _refuse_destinations_outside(repo, dest)
+
     first_install = not (dest / MANIFEST_NAME).is_file()
     stale = set(_previously_vendored(dest)) - set(vendored_paths())
 

--- a/skills/ci-secure/scripts/vendor.py
+++ b/skills/ci-secure/scripts/vendor.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Copy ci-secure into a repository, and check later that it is still what was copied.
+
+Installing ci-secure as a CI gate VENDORS it: the engine, the gate and the
+licence are copied into the adopter's repository and reviewed in a pull request
+like any other code. Nothing is fetched and executed at CI time — a pin can be
+moved or deleted in a repository the adopter does not control, and a job that
+fetches and runs code is one upstream compromise away from running whatever
+arrives. We ship a detector for that shape; we should not be the ones asking
+people to run it.
+
+What that buys, and what it costs: the adopter can read every line that will
+judge their pull requests, and it never changes underneath them. In exchange
+the copy goes stale, so this script also writes VENDORED.json — the skill
+version, the source commit, and a hash per file — which turns "is our copy
+current, and has anyone edited it?" into a command instead of a visual diff.
+
+    vendor.py --into <repo>     copy in (or refresh) and write the manifest
+    vendor.py --verify <dir>    recompute the hashes and compare
+
+What the manifest is NOT is a tamper seal. Anyone who can edit the vendored
+gate can edit the manifest in the same commit, and no amount of hashing changes
+that. It catches the accident — a local edit made to debug something, still
+sitting there six months later, quietly weakening a check nobody re-read — and
+the accident is the case that actually happens.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_SKILL = _HERE.parent
+
+MANIFEST_NAME = "VENDORED.json"
+VENDOR_DIRNAME = "ci-secure"
+
+# The engine's own layout is preserved rather than flattened: scan.py finds its
+# pattern catalog at `<root>/references/security-patterns.md`, relative to its
+# own directory, so `scripts/` and `references/` have to stay siblings.
+#
+# Only what the GATE needs. report.py, run.py and record_timing.py belong to the
+# interactive skill — a human reading a rendered report — and shipping them
+# would enlarge the adopter's supply-chain surface for nothing.
+VENDORED_FILES = (
+    "scripts/scan.py",
+    "scripts/config.py",
+    "scripts/config_facts.py",
+    "scripts/gh_utils.py",
+    "references/security-patterns.md",
+    # Travels with the copy so the adopter's own CI can run `--verify` against
+    # the manifest. The vendored copy can check itself; it cannot install, since
+    # the scaffold and the rest of the skill are not there.
+    "scripts/vendor.py",
+)
+
+# The gate travels beside the engine, so `config.py` resolves next to the
+# resolved engine exactly as it does in this repository.
+#
+# It is copied from `scaffold/`, not from `.github/scripts/`, because an
+# INSTALLED skill is just this directory — there is no `.github/` to read. That
+# makes `scaffold/gate.py` a second copy of a security-critical file, which is
+# a real cost, so the repository holds the two byte-identical and fails its own
+# build if they ever diverge. A vendored gate weaker than the one we run on
+# ourselves would be the worst possible thing to ship.
+GATE_SOURCE = "scaffold/gate.py"
+GATE_DEST = "scripts/gate.py"
+
+# The workflow the adopter gets. One hosted scan job and one always-running
+# verdict job; see the file itself for why the verdict job cannot be a copy of
+# ours.
+WORKFLOW_SOURCE = "scaffold/ci-secure.yml"
+WORKFLOW_DEST = ".github/workflows/ci-secure.yml"
+
+LICENSE_DEST = "LICENSE"
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def source_commit() -> str:
+    """The commit this copy was taken from, or a marker that says we cannot tell.
+
+    An installed skill has no .git, so this is often genuinely unknowable. It
+    says so rather than inventing a value: "unknown" is a worse answer than a
+    sha and a much better one than a plausible wrong sha.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(_SKILL), "rev-parse", "HEAD"],
+            capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return "unknown (no git available)"
+    if out.returncode != 0:
+        return "unknown (not a git checkout)"
+    sha = out.stdout.strip()
+    dirty = subprocess.run(
+        ["git", "-C", str(_SKILL), "status", "--porcelain"],
+        capture_output=True, text=True).stdout.strip()
+    return f"{sha}-dirty" if dirty else sha
+
+
+def skill_version() -> str:
+    sys.path.insert(0, str(_HERE))
+    try:
+        import config  # noqa: PLC0415
+        return str(config.__version__)
+    finally:
+        sys.path.pop(0)
+
+
+def _license_source() -> Path | None:
+    for candidate in (_SKILL / "LICENSE", _SKILL.parent.parent / "LICENSE"):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def install(repo: Path) -> Path:
+    """Copy the engine, the gate and the licence into `repo/ci-secure/`."""
+    if not (_SKILL / GATE_SOURCE).is_file():
+        raise SystemExit(
+            "this looks like a VENDORED copy of ci-secure, which can verify "
+            "itself but cannot install: the scaffold and the rest of the skill "
+            "are not here. Run --into from an installed ci-secure skill, or ask "
+            "ci-secure to refresh this copy.")
+    dest = repo / VENDOR_DIRNAME
+    for rel in VENDORED_FILES:
+        target = dest / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(_SKILL / rel, target)
+
+    gate = _SKILL / GATE_SOURCE
+    if not gate.is_file():                       # pragma: no cover - defensive
+        raise SystemExit(f"gate not found at {gate}")
+    shutil.copy2(gate, dest / GATE_DEST)
+
+    workflow = repo / WORKFLOW_DEST
+    workflow.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(_SKILL / WORKFLOW_SOURCE, workflow)
+
+    # The licence travels with the code or the copy is a licence violation.
+    licence = _license_source()
+    if licence is None:                          # pragma: no cover - defensive
+        raise SystemExit(
+            "no LICENSE found to vendor; copying the code without it would be a "
+            "licence violation, so this refuses rather than shipping one")
+    shutil.copy2(licence, dest / LICENSE_DEST)
+
+    write_manifest(dest)
+    return dest
+
+
+def vendored_paths(dest: Path) -> list[str]:
+    return sorted([*VENDORED_FILES, GATE_DEST, LICENSE_DEST])
+
+
+def write_manifest(dest: Path) -> Path:
+    manifest = {
+        "skill": "ci-secure",
+        "skill_version": skill_version(),
+        "source_commit": source_commit(),
+        "source_repo": "https://github.com/starslingdev/skills",
+        "files": {rel: sha256(dest / rel) for rel in vendored_paths(dest)},
+        "note": (
+            "Written by ci-secure's install step. `vendor.py --verify` "
+            "recomputes these hashes. To update the vendored copy, ask "
+            "ci-secure to refresh it; hand edits show up as that pull "
+            "request's diff, for you to resolve — they are never silently "
+            "overwritten outside a pull request."
+        ),
+    }
+    path = dest / MANIFEST_NAME
+    path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8")
+    return path
+
+
+def verify(dest: Path) -> int:
+    """Compare the vendored files against the manifest. 0 if they agree."""
+    manifest_path = dest / MANIFEST_NAME
+    if not manifest_path.is_file():
+        print(f"::error::{MANIFEST_NAME} is missing from {dest} - cannot tell "
+              "what this copy of ci-secure was supposed to be")
+        return 1
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        recorded = manifest["files"]
+    except (ValueError, KeyError) as exc:
+        print(f"::error::{MANIFEST_NAME} is unreadable ({exc!r})")
+        return 1
+
+    drift = []
+    for rel, expected in sorted(recorded.items()):
+        path = dest / rel
+        if not path.is_file():
+            drift.append(f"{rel}: missing")
+        elif sha256(path) != expected:
+            drift.append(f"{rel}: modified")
+    for path in dest.rglob("*"):
+        rel = path.relative_to(dest).as_posix()
+        if path.is_file() and rel != MANIFEST_NAME and rel not in recorded:
+            drift.append(f"{rel}: not in the manifest")
+
+    if not drift:
+        print(f"ci-secure vendored copy matches {MANIFEST_NAME} "
+              f"(skill v{manifest.get('skill_version', '?')}, "
+              f"from {manifest.get('source_commit', '?')})")
+        return 0
+
+    for item in drift:
+        print(f"::error::vendored ci-secure has drifted - {item}")
+    print("::error::the vendored gate is no longer the code that was reviewed. "
+          "Ask ci-secure to refresh the vendored copy, which opens a pull "
+          "request with the differences, or revert the local edit.")
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--into", metavar="REPO",
+                       help="repository root to vendor ci-secure into")
+    group.add_argument("--verify", metavar="DIR",
+                       help="vendored ci-secure directory to check")
+    args = parser.parse_args(argv)
+
+    if args.verify:
+        return verify(Path(args.verify).resolve())
+
+    dest = install(Path(args.into).resolve())
+    print(f"vendored ci-secure into {dest}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/ci-secure/scripts/vendor.py
+++ b/skills/ci-secure/scripts/vendor.py
@@ -169,6 +169,7 @@ def install(repo: Path) -> Path:
             "licence violation, so this refuses rather than shipping one")
 
     dest = repo / VENDOR_DIRNAME
+    first_install = not (dest / MANIFEST_NAME).is_file()
     stale = set(_previously_vendored(dest)) - set(vendored_paths())
 
     for rel in VENDORED_FILES:
@@ -178,8 +179,28 @@ def install(repo: Path) -> Path:
     shutil.copy2(gate, dest / GATE_DEST)
     shutil.copy2(licence, dest / LICENSE_DEST)
 
+    # The manifest is repository content - it arrives with a branch, a pull
+    # request checkout or a fork clone - and this loop DELETES. A `files` entry
+    # of `../.github/workflows/release.yml` would otherwise be repo-controlled
+    # file deletion aimed at the very directory this tool exists to protect, and
+    # a merely corrupt manifest would do the same damage by accident. Only paths
+    # that stay inside the vendored directory are ever touched.
+    resolved_dest = dest.resolve()
     for rel in sorted(stale):
+        candidate = Path(rel)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            print(f"::warning::ignoring manifest entry {rel!r}, which points "
+                  "outside the vendored directory")
+            continue
         old = dest / rel
+        try:
+            inside = old.resolve().is_relative_to(resolved_dest)
+        except OSError:                          # pragma: no cover - defensive
+            inside = False
+        if not inside:
+            print(f"::warning::ignoring manifest entry {rel!r}, which resolves "
+                  "outside the vendored directory")
+            continue
         if old.is_file():
             old.unlink()
             print(f"removed {rel}, which this version no longer vendors")
@@ -191,17 +212,30 @@ def install(repo: Path) -> Path:
     # gate to advisory, and because the workflow is deliberately not
     # checksummed, nothing downstream would catch it. So it is written once and
     # never rewritten.
+    # The manifest is written BEFORE the workflow. It is the last thing that
+    # can fail - it hashes every file and reads the skill version - and a
+    # workflow already on disk when it fails is a live check beside a tree with
+    # no manifest, whose first run reds with "cannot tell what this copy was
+    # supposed to be".
+    write_manifest(dest)
+
     workflow = repo / WORKFLOW_DEST
     if workflow.exists():
-        print(f"left the workflow at {WORKFLOW_DEST} exactly as it is - it is "
-              f"yours to tune. To take up template changes, diff it against "
-              f"{WORKFLOW_SOURCE} in the skill and apply what you want.")
+        if first_install:
+            print(f"::warning::{WORKFLOW_DEST} already existed and was NOT "
+                  "replaced, so nothing here runs the gate yet. Compare it "
+                  f"against {WORKFLOW_SOURCE} in the skill and merge what you "
+                  "need, or move it aside and run this again.")
+        else:
+            print(f"left the workflow at {WORKFLOW_DEST} exactly as it is - it "
+                  f"is yours to tune. To take up template changes, diff it "
+                  f"against {WORKFLOW_SOURCE} in the skill and apply what you "
+                  "want.")
     else:
         workflow.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(workflow_source, workflow)
         print(f"wrote the workflow to {WORKFLOW_DEST}")
 
-    write_manifest(dest)
     return dest
 
 
@@ -255,12 +289,19 @@ def verify(dest: Path) -> int:
         rel = path.relative_to(dest).as_posix()
         if not path.is_file() or rel == MANIFEST_NAME or rel in recorded:
             continue
-        # Bytecode is not a tampered gate. The engine is imported as modules,
-        # so any local run of the gate leaves `__pycache__/` behind, and this
-        # command is one the adopter is told to run. An alarm that fires on a
-        # `.pyc` the tool wrote itself is an alarm nobody reads by the third
-        # time, which costs more than the case it would ever catch.
+        # Bytecode gets its OWN message, not an exemption. A `.pyc` written
+        # with an unchecked hash is never validated against its source: Python
+        # loads it as-is, which is how the gate loads `config.py`. So one
+        # planted here can empty the set of outcomes that block while every
+        # source file still hashes correctly - a green check over a repository
+        # with failing facts, and nothing else would ever see it. The innocent
+        # cause is a local run, which the shipped workflow prevents outright by
+        # telling Python not to write bytecode at all.
         if "__pycache__" in path.parts or path.suffix == ".pyc":
+            drift.append(
+                f"{rel}: compiled bytecode, which can override the source file "
+                "verified above - delete ci-secure/**/__pycache__, and do not "
+                "commit it")
             continue
         drift.append(f"{rel}: not in the manifest")
 

--- a/skills/ci-secure/scripts/vendor.py
+++ b/skills/ci-secure/scripts/vendor.py
@@ -12,8 +12,11 @@ people to run it.
 What that buys, and what it costs: the adopter can read every line that will
 judge their pull requests, and it never changes underneath them. In exchange
 the copy goes stale, so this script also writes VENDORED.json — the skill
-version, the source commit, and a hash per file — which turns "is our copy
-current, and has anyone edited it?" into a command instead of a visual diff.
+version, the source commit, and a hash per file — which turns "has anyone
+edited our copy?" into a command instead of a visual diff. It does NOT
+answer "is our copy current": `--verify` compares the copy against its own
+manifest, never against this skill, so the recorded version is the only
+staleness signal and reading it is a human step.
 
     vendor.py --into <repo>     copy in (or refresh) and write the manifest
     vendor.py --verify <dir>    recompute the hashes and compare
@@ -29,6 +32,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -84,6 +88,40 @@ def sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def esc(value: object) -> str:
+    """Neutralise workflow commands in anything read out of the repository.
+
+    `VENDORED.json` arrives with a branch, a pull request checkout or a fork
+    clone, and every string in it is printed into a step's log - which is a
+    command sink, not a text field. A newline in the recorded version forges a
+    `::notice::all clear` on the check run; a newline in a `files` key emits
+    `::stop-commands::`, which swallows every drift reason printed after it and
+    turns a stated red into an unexplained one. The gate escapes engine output
+    for exactly this reason; `--verify` reads from the same trust class and
+    runs in the step above it.
+    """
+    return (str(value).replace("%", "%25")
+            .replace("\r", "%0D").replace("\n", "%0A"))
+
+
+def _git(*args: str, timeout: int = 10) -> subprocess.CompletedProcess:
+    """Run git with the ambient GIT_* variables stripped.
+
+    `GIT_DIR` OVERRIDES `-C`, so `-C <dir> rev-parse` is not actually a question
+    about `<dir>` when one is exported - by a hook, a `rebase -x`, or a
+    worktree-driven session. Left alone it makes the subdirectory guard read an
+    unrelated repository's toplevel and refuse a correct install, telling the
+    adopter to vendor a live workflow into that other repository instead: the
+    "written somewhere you never looked" outcome the guards exist to prevent,
+    arrived at THROUGH a guard. It also makes `source_commit` stamp the
+    manifest with a stranger's HEAD - the plausible wrong sha this file says is
+    worse than saying nothing.
+    """
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    return subprocess.run(["git", *args], capture_output=True, text=True,
+                          timeout=timeout, env=env)
+
+
 def source_commit() -> str:
     """The commit this copy was taken from, or a marker that says we cannot tell.
 
@@ -92,18 +130,26 @@ def source_commit() -> str:
     sha and a much better one than a plausible wrong sha.
     """
     try:
-        out = subprocess.run(
-            ["git", "-C", str(_SKILL), "rev-parse", "HEAD"],
-            capture_output=True, text=True, timeout=10)
+        out = _git("-C", str(_SKILL), "rev-parse", "HEAD")
     except (OSError, subprocess.SubprocessError):
         return "unknown (no git available)"
     if out.returncode != 0:
         return "unknown (not a git checkout)"
     sha = out.stdout.strip()
-    dirty = subprocess.run(
-        ["git", "-C", str(_SKILL), "status", "--porcelain"],
-        capture_output=True, text=True).stdout.strip()
-    return f"{sha}-dirty" if dirty else sha
+    # The dirty test gets the same timeout and the same return-code check as
+    # the call above it. Unguarded, ANY failure of `git status` - a held index
+    # lock, EACCES, a wedged process - yields empty stdout, which reads as
+    # "clean" and stamps the manifest with a bare sha: an assertion that this
+    # copy is byte-for-byte the published commit, over a copy that is not. That
+    # is the plausible wrong sha, manufactured by the one path that was not
+    # checked.
+    try:
+        status = _git("-C", str(_SKILL), "status", "--porcelain")
+    except (OSError, subprocess.SubprocessError):
+        return f"{sha} (working tree state unknown)"
+    if status.returncode != 0:
+        return f"{sha} (working tree state unknown)"
+    return f"{sha}-dirty" if status.stdout.strip() else sha
 
 
 def skill_version() -> str:
@@ -154,9 +200,7 @@ def _refuse_a_subdirectory(repo: Path) -> None:
     guessing at intent there would refuse work that is fine.
     """
     try:
-        out = subprocess.run(
-            ["git", "-C", str(repo), "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, timeout=10)
+        out = _git("-C", str(repo), "rev-parse", "--show-toplevel")
     except (OSError, subprocess.SubprocessError):     # no git to ask
         return
     if out.returncode != 0:                           # not in a repository
@@ -270,9 +314,11 @@ def _refuse_redirected_destinations(repo: Path, dest: Path) -> None:
 def install(repo: Path) -> Path:
     """Copy the engine, the gate and the licence into `repo/ci-secure/`.
 
-    Everything that can refuse refuses BEFORE anything is written. A partial
-    install is not a tidy failure: it is a live workflow in the adopter's
-    repository beside a vendored tree with no manifest, whose first CI run reds
+    Every REFUSAL happens before anything is written. That is not the same as
+    "nothing can fail after the first write" — `write_manifest` runs last and
+    can still raise — and the ordering below is chosen for exactly that case.
+    A partial install is not a tidy failure: a live workflow in the adopter's
+    repository beside a vendored tree with no manifest reds their first CI run
     with "cannot tell what this copy was supposed to be".
     """
     gate = _SKILL / GATE_SOURCE
@@ -321,7 +367,7 @@ def install(repo: Path) -> Path:
     for rel in sorted(stale):
         candidate = Path(rel)
         if candidate.is_absolute() or ".." in candidate.parts:
-            print(f"::warning::ignoring manifest entry {rel!r}, which points "
+            print(f"::warning::ignoring manifest entry {esc(rel)!r}, which points "
                   "outside the vendored directory")
             continue
         old = dest / rel
@@ -330,12 +376,12 @@ def install(repo: Path) -> Path:
         except OSError:                          # pragma: no cover - defensive
             inside = False
         if not inside:
-            print(f"::warning::ignoring manifest entry {rel!r}, which resolves "
+            print(f"::warning::ignoring manifest entry {esc(rel)!r}, which resolves "
                   "outside the vendored directory")
             continue
         if old.is_file():
             old.unlink()
-            print(f"removed {rel}, which this version no longer vendors")
+            print(f"removed {esc(rel)}, which this version no longer vendors")
 
     # The workflow belongs to the adopter. They are invited to change the
     # runner and the triggers, and — the entire point of the ramp — to delete
@@ -390,11 +436,11 @@ def write_manifest(dest: Path) -> Path:
         "source_repo": "https://github.com/starslingdev/skills",
         "files": {rel: sha256(dest / rel) for rel in vendored_paths()},
         "note": (
-            "Written by ci-secure's install step. `vendor.py --verify` "
+            "Written by the ci-secure setup you ran. `vendor.py --verify` "
             "recomputes these hashes. To update the vendored copy, ask "
-            "ci-secure to refresh it; hand edits show up as that pull "
-            "request's diff, for you to resolve — they are never silently "
-            "overwritten outside a pull request."
+            "ci-secure to refresh it. A refresh OVERWRITES the files listed "
+            "here, so any hand edit to them is replaced and shows up in "
+            "`git diff` — review that before you commit."
         ),
     }
     path = dest / MANIFEST_NAME
@@ -419,7 +465,7 @@ def verify(dest: Path) -> int:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         recorded = manifest["files"]
     except (ValueError, KeyError, TypeError, AttributeError) as exc:
-        print(f"::error::{MANIFEST_NAME} is unreadable ({exc!r})")
+        print(f"::error::{MANIFEST_NAME} is unreadable ({esc(repr(exc))})")
         return 1
     if not isinstance(manifest, dict) or not isinstance(recorded, dict):
         print(f"::error::{MANIFEST_NAME} does not have the shape of a "
@@ -428,6 +474,19 @@ def verify(dest: Path) -> int:
         return 1
 
     drift = []
+    # What the manifest must LIST, before what it happens to list is checked.
+    # Every hash agreeing is not the property wanted - the manifest defines its
+    # own domain, so a file removed from the copy AND from `files` leaves every
+    # remaining hash correct and verifies clean. That is not the acknowledged
+    # "anyone who can edit the gate can edit the manifest" caveat: nothing is
+    # edited-with-a-matching-hash, the copy is simply made smaller than the
+    # thing that was reviewed. It matters most for `config.py`, the rule that
+    # says which outcomes block: with the vendored one gone the gate falls back
+    # to a path inside the repository being audited, so a pull request that
+    # deletes it here and adds it there runs a rule it wrote itself.
+    for rel in sorted(set(vendored_paths()) - set(recorded)):
+        drift.append(f"{rel}: no longer listed in {MANIFEST_NAME}, so the copy "
+                     "cannot be checked against what was reviewed")
     for rel, expected in sorted(recorded.items()):
         path = dest / rel
         if not path.is_file():
@@ -469,15 +528,15 @@ def verify(dest: Path) -> int:
 
     if not drift:
         print(f"ci-secure vendored copy matches {MANIFEST_NAME} "
-              f"(skill v{manifest.get('skill_version', '?')}, "
-              f"from {manifest.get('source_commit', '?')})")
+              f"(skill v{esc(manifest.get('skill_version', '?'))}, "
+              f"from {esc(manifest.get('source_commit', '?'))})")
         return 0
 
     for item in drift:
-        print(f"::error::vendored ci-secure has drifted - {item}")
+        print(f"::error::vendored ci-secure has drifted - {esc(item)}")
     print("::error::the vendored gate is no longer the code that was reviewed. "
-          "Ask ci-secure to refresh the vendored copy, which opens a pull "
-          "request with the differences, or revert the local edit.")
+          "Ask ci-secure to refresh the vendored copy, then review the "
+          "resulting diff, or revert the local edit.")
     return 1
 
 

--- a/skills/ci-secure/tests/test_python_compat.py
+++ b/skills/ci-secure/tests/test_python_compat.py
@@ -31,10 +31,19 @@ from pathlib import Path
 import pytest
 
 SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+SCAFFOLD = Path(__file__).resolve().parents[1] / "scaffold"
 
 
 def _modules() -> list[Path]:
-    return sorted(p for p in SCRIPTS.glob("*.py"))
+    # `scaffold/` as well as `scripts/`, because `scaffold/gate.py` is the file
+    # with the LEAST say over its interpreter: it is copied into adopters'
+    # repositories and run by whatever `python3` they have. Its own comment
+    # argues the point at length — "this file is vendored into adopters' repos
+    # where python3 is whatever they have" — and then nothing checked it, so
+    # one `-> str | None` in a signature would have broken every adopter below
+    # 3.10 with this suite green, and the byte-identity test would have carried
+    # the break from the gate we run on ourselves straight into the copy.
+    return sorted([*SCRIPTS.glob("*.py"), *SCAFFOLD.glob("*.py")])
 
 
 def _has_future_annotations(tree: ast.Module) -> bool:

--- a/tests/test_ci_secure_gate.py
+++ b/tests/test_ci_secure_gate.py
@@ -58,7 +58,8 @@ def _scan(**overrides) -> dict:
 
 
 def run_gate(tmp_path: Path, *, stdout: str, returncode: int = 0,
-             engine: str | None = None, env_extra: dict[str, str] | None = None):
+             engine: str | None = None, env_extra: dict[str, str] | None = None,
+             args: tuple[str, ...] = ()):
     """Run the real gate against a stub engine that prints `stdout` and exits `returncode`."""
     stub = tmp_path / "stub_engine.py"
     stub.write_text(
@@ -85,7 +86,7 @@ def run_gate(tmp_path: Path, *, stdout: str, returncode: int = 0,
     # "the job did not decide" rather than merely "the job decided badly".
     env = {k: v for k, v in env.items() if v is not None}
     proc = subprocess.run(
-        [sys.executable, str(_GATE)],
+        [sys.executable, str(_GATE), *args],
         capture_output=True, text=True, env=env,
     )
     proc.summary = summary.read_text(encoding="utf-8") if summary.exists() else ""
@@ -893,3 +894,124 @@ def test_a_rule_that_exits_cleanly_on_load_cannot_forge_a_pass(tmp_path: Path) -
         "a rule file that called sys.exit(0) produced a GREEN gate with no scan")
     assert "::error::" in proc.stdout, "the forged pass was turned red with no stated cause"
     assert "could not be loaded" in proc.stdout
+
+
+# --------------------------------------------------------------------------
+# `--advisory`: a ramp for findings, never a mute button for a broken scan
+# --------------------------------------------------------------------------
+#
+# The flag ships ON in the workflow every adopter installs, so its SCOPE is the
+# most load-bearing untested thing about it. Three separate surfaces promise
+# that it downgrades failed FACTS and nothing else. Until these tests existed
+# that promise was held up by a coincidence: the flag defaults off, so the
+# blocking-mode tests above passed no matter how wide advisory's reach was.
+# Widening it - `red = not ADVISORY` in the degraded loop, or gating STRICT_GH
+# on it - left the whole suite green, which is exactly how a ramp becomes a mute
+# button. `ADVISORY = False` (the flag as a silent no-op) was equally invisible.
+
+_A_FAILED_FACT = _scan(security_score={
+    "facts": [{"fact_id": "sec.codeowners.workflows", "outcome": "fail",
+               "evidence": "no CODEOWNERS entry for .github/"}],
+    "score": 0, "passed": 0, "scored_count": 1, "applicable_count": 1,
+})
+
+
+def test_advisory_downgrades_a_failed_fact_and_still_reports_it(
+        tmp_path: Path) -> None:
+    """The whole point of the flag: day one does not brick the merge path.
+
+    Reported at full volume, just not blocking - "this passed" and "this failed
+    and you have chosen not to be stopped by it yet" must stay distinguishable,
+    or the ramp has quietly become a clean bill of health.
+    """
+    blocking = run_scan(tmp_path, _A_FAILED_FACT)
+    assert blocking.returncode == 1, "without the flag a failed fact must block"
+
+    proc = run_scan(tmp_path, _A_FAILED_FACT, args=("--advisory",))
+
+    assert proc.returncode == 0, (
+        "--advisory must downgrade a failed FACT, or the flag does nothing and "
+        "the install bricks the adopter's merges on day one:\n" + proc.stdout)
+    assert "::warning::" in proc.stdout and "advisory" in proc.stdout, (
+        "a downgraded fact still has to be reported, loudly:\n" + proc.stdout)
+    assert "sec.codeowners.workflows" in proc.stdout, (
+        "the downgraded fact must still be named")
+    assert "::error::" not in proc.stdout, (
+        "nothing else in this scan is wrong, so nothing may red")
+    assert "Advisory mode" in proc.summary, (
+        "the summary a human reads must say the verdict was downgraded")
+
+
+@pytest.mark.parametrize("label,scan,engine_rc", [
+    ("the facts layer crashed to empty",
+     _scan(security_score={"facts": [], "score": None, "passed": 0,
+                           "scored_count": 0, "applicable_count": 0}), 0),
+    ("nothing was scanned", _scan(scanned_workflows=0), 0),
+    ("an outcome the rule cannot classify",
+     _scan(security_score={
+         "facts": [{"fact_id": "sec.demo", "outcome": "probably-fine",
+                    "evidence": "x"}],
+         "score": 100, "passed": 1, "scored_count": 1, "applicable_count": 1}), 0),
+    ("the scan was incomplete", _scan(scan_incomplete=["ci.yml: unparseable"]), 0),
+    ("a match was dropped", _scan(dropped_matches=["P14.1: regex timeout"]), 0),
+    ("the engine crashed", _CLEAN, 3),
+])
+def test_advisory_never_downgrades_a_scan_that_cannot_be_trusted(
+        tmp_path: Path, label: str, scan: dict, engine_rc: int) -> None:
+    """Every shape that means the scan itself is untrustworthy stays red.
+
+    These and a failed fact look identical from outside - a red check - and
+    only one of them is safe to ignore. If advisory covered both, an adopter
+    burning down findings would be silencing a broken scanner at the same time
+    and could not tell.
+    """
+    proc = run_scan(tmp_path, scan, returncode=engine_rc, args=("--advisory",))
+
+    assert proc.returncode == 1, (
+        f"--advisory must NOT downgrade {label!r} - advisory is a ramp for "
+        "findings, never a mute button for a broken scan:\n" + proc.stdout)
+    assert "::error::" in proc.stdout, (
+        "a red with no stated cause is the thing this gate argues against")
+
+
+def test_advisory_never_downgrades_the_weekly_networks_completeness_demand(
+        tmp_path: Path) -> None:
+    """The one run that must not be silenceable by burning API quota.
+
+    `CI_SECURE_GH_STRICT=1` is set only on the schedule trigger, whose whole
+    job is catching a pin that ROTS. Letting `--advisory` reach it would mean
+    an adopter still ramping their findings had no rot detection at all, and
+    nothing would say so.
+    """
+    partial = _scan(gh_checks={"P14.11": "partial: rate limit exhausted"})
+
+    proc = run_scan(tmp_path, partial, args=("--advisory",),
+                    env_extra={"CI_SECURE_GH_STRICT": "1"})
+
+    assert proc.returncode == 1, (
+        "--advisory must not reach the weekly run's completeness demand:\n"
+        + proc.stdout)
+    assert "::error::" in proc.stdout
+
+
+@pytest.mark.parametrize("argv", [
+    ("--advisery",),               # the typo that must not silently block
+    ("--advisory", "--no-block"),  # a second flag that must not be ignored
+    ("-a",),
+    ("--advisory=true",),
+])
+def test_the_gate_refuses_an_argument_it_does_not_recognise(
+        tmp_path: Path, argv: tuple[str, ...]) -> None:
+    """An unrecognised flag is a decision that did not land, so it reds.
+
+    Without this, `--advisery` runs the gate in BLOCKING mode while the adopter
+    believes they are ramping, and `--advisory --no-block` silently ignores the
+    half the author cared about. Both are quiet, and both are wrong.
+    """
+    proc = run_scan(tmp_path, _CLEAN, args=argv)
+
+    assert proc.returncode == 1, (
+        f"the gate accepted {argv!r} instead of refusing it:\n" + proc.stdout)
+    assert "unrecognised argument" in proc.stdout
+    assert argv[-1] in proc.stdout or argv[0] in proc.stdout, (
+        "the refusal has to name what it did not understand")

--- a/tests/test_ci_secure_scaffold.py
+++ b/tests/test_ci_secure_scaffold.py
@@ -201,6 +201,13 @@ def _evaluate(expr: str, context: dict) -> str:
     x` does not yield the empty string when `cond` holds; the empty middle is
     falsy, the `||` takes over, and the answer is always `x`. Asserting that an
     expression mentions the right condition cannot see that. Evaluating it can.
+
+    This models `&&`, `||`, `==`, `!=` and parentheses over context values and
+    single-quoted literals, which is all the two expressions here use. It does
+    NOT model `!`, the functions, or Actions' type coercion and case-insensitive
+    string comparison. Anything it cannot parse RAISES rather than guessing, so
+    an expression written in a shape this does not cover fails the test instead
+    of quietly passing it.
     """
     body = expr.strip()
     assert body.startswith("${{") and body.endswith("}}"), body
@@ -250,11 +257,19 @@ def _evaluate(expr: str, context: dict) -> str:
 
     def term(token: str) -> str:
         token = token.strip()
-        while token.startswith("(") and token.endswith(")"):
-            inner = token[1:-1]
-            if split_top(inner, ")") and inner.count("(") == inner.count(")"):
-                return evaluate(inner)
-            break
+        # A fully parenthesised group — `(a && b)`. Equal counts are NOT proof
+        # of that: `(a) == (b)` also balances, and stripping its outer
+        # characters yields `a) == (b`. The test is that depth never returns to
+        # zero before the end, which is what makes the outer pair a matched
+        # pair rather than two adjacent groups.
+        if token.startswith("(") and token.endswith(")"):
+            depth = 0
+            for i, char in enumerate(token):
+                depth += (char == "(") - (char == ")")
+                if depth == 0 and i < len(token) - 1:
+                    break
+            else:
+                return evaluate(token[1:-1])
         if token.startswith("'") and token.endswith("'"):
             return token[1:-1]
         if token in context:
@@ -368,10 +383,33 @@ def test_nothing_in_the_template_can_swallow_a_failing_gate(
 
     verdict = template["jobs"]["verdict"]
     assert "continue-on-error" not in verdict
-    script = verdict["steps"][-1]["run"]
-    assert "exit 1" in script, (
-        "the verdict's not-success branch has no non-zero exit, so the "
-        "required check is green whatever the scan did")
+
+
+@pytest.mark.parametrize(
+    ("scan_result", "expected_zero"),
+    [("success", True), ("failure", False), ("cancelled", False),
+     ("skipped", False), ("", False)],
+)
+def test_the_verdict_script_is_run_not_read(
+        template: dict, scan_result: str, expected_zero: bool) -> None:
+    """Grepping the script for `exit 1` is not the same as it exiting 1.
+
+    An `exit 0` inserted anywhere above the check satisfies every substring
+    assertion — `needs`, `always()`, the predicate, no `${{`, an `exit 1`
+    present somewhere — while the required check greens over a scan that
+    failed. The script is plain bash with one input, so the honest test runs
+    it, on every result GitHub can report.
+    """
+    script = template["jobs"]["verdict"]["steps"][-1]["run"]
+    proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True,
+                          env={"PATH": "/usr/bin:/bin", "SCAN": scan_result})
+    if expected_zero:
+        assert proc.returncode == 0, (
+            f"the verdict reds on scan={scan_result!r}:\n{proc.stdout}{proc.stderr}")
+    else:
+        assert proc.returncode != 0, (
+            f"the verdict PASSES on scan={scan_result!r} - a scan that did not "
+            f"run, was cancelled or failed is not a pass:\n{proc.stdout}")
 
 
 def test_the_template_triggers_carry_no_narrowing_filter(template: dict) -> None:
@@ -555,14 +593,18 @@ def test_refresh_leaves_the_adopters_own_workflow_alone(tmp_path: Path) -> None:
         "skip is indistinguishable from an update that happened")
 
 
-def test_verify_ignores_the_bytecode_running_the_gate_creates(
+def test_committed_bytecode_is_drift_and_says_what_to_do_about_it(
         tmp_path: Path) -> None:
-    """A `.pyc` is not a tampered gate, and crying drift over one trains it out.
+    """A `.pyc` beside a verified source file is not noise — it OVERRIDES it.
 
-    The engine is imported as modules, so any local run leaves
-    `ci-secure/scripts/__pycache__/`. SKILL.md hands `--verify` to the adopter
-    as a command they can run; if it accuses them of editing the gate the first
-    time they try it, the real drift signal is noise from then on.
+    Python does not always re-derive bytecode from source: a `.pyc` written
+    with an unchecked hash is loaded as-is, which is exactly how the gate loads
+    `config.py`. So a planted one can empty the set of outcomes that block
+    while every source file still hashes correctly and the manifest is
+    untouched — a green required check over a repository with failing facts.
+    Exempting bytecode to quieten the alarm would remove the only thing that
+    catches it. It is reported, with the fix, and the workflow stops the gate
+    writing any in the first place.
     """
     repo = tmp_path / "acme-app"
     (repo / ".github" / "workflows").mkdir(parents=True)
@@ -574,8 +616,25 @@ def test_verify_ignores_the_bytecode_running_the_gate_creates(
     (cache / "config.cpython-312.pyc").write_bytes(b"\x00compiled")
 
     check = _verify(vendored)
-    assert check.returncode == 0, (
-        "verify red on bytecode the gate itself writes:\n" + check.stdout)
+    assert check.returncode == 1, (
+        "bytecode that can override a hash-verified source file was accepted "
+        "as a clean copy:\n" + check.stdout)
+    assert "__pycache__" in check.stdout, (
+        "the report does not name the bytecode, so the reader cannot act on it")
+
+
+def test_the_template_stops_the_gate_writing_bytecode(template: dict) -> None:
+    """The noise the exemption would have papered over is removable at source.
+
+    Committed bytecode is drift and reds. Bytecode the gate wrote a second
+    earlier is the same file with an innocent cause, so the workflow tells
+    Python not to produce it — which is what makes reporting it affordable.
+    """
+    gate_step = next(s for s in template["jobs"]["scan"]["steps"]
+                     if "gate.py" in s.get("run", ""))
+    assert gate_step.get("env", {}).get("PYTHONDONTWRITEBYTECODE") == "1", (
+        "the gate step may leave __pycache__ in the vendored tree, which the "
+        "next --verify correctly reds - stop it being written at all")
 
 
 def test_refresh_removes_a_file_a_later_version_stopped_vendoring(
@@ -607,6 +666,40 @@ def test_refresh_removes_a_file_a_later_version_stopped_vendoring(
         "run reds with 'not in the manifest'")
     check = _verify(vendored)
     assert check.returncode == 0, check.stdout
+
+
+def test_pruning_cannot_reach_outside_the_vendored_directory(
+        tmp_path: Path) -> None:
+    """The manifest is repository content, so it is untrusted input to a delete.
+
+    It arrives with a branch, a pull request checkout or a fork clone, and the
+    refresh runs on someone's machine with their privileges. A `files` entry of
+    `../.github/workflows/release.yml` would otherwise be repo-controlled
+    arbitrary file deletion, aimed at exactly the directory this tool exists to
+    protect — and a merely CORRUPT manifest would do the same damage.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    assert _vendor(repo).returncode == 0
+
+    bystander = repo / ".github" / "workflows" / "release.yml"
+    bystander.write_text("name: release\n", encoding="utf-8")
+    outsider = tmp_path / "outside.txt"
+    outsider.write_text("not ours\n", encoding="utf-8")
+
+    manifest_path = repo / "ci-secure" / "VENDORED.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["files"]["../.github/workflows/release.yml"] = "0" * 64
+    manifest["files"][str(outsider)] = "0" * 64
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+                             encoding="utf-8")
+
+    assert _vendor(repo).returncode == 0
+    assert bystander.is_file(), (
+        "a refresh deleted a workflow because the manifest named it - the "
+        "manifest is repository content and must never steer a delete")
+    assert outsider.is_file(), (
+        "a refresh deleted a file outside the repository entirely")
 
 
 def test_an_install_that_cannot_finish_writes_nothing(tmp_path: Path) -> None:

--- a/tests/test_ci_secure_scaffold.py
+++ b/tests/test_ci_secure_scaffold.py
@@ -1,4 +1,4 @@
-"""What an outside repository gets when ci-secure installs itself as a gate.
+"""What an outside repository gets when someone sets ci-secure up as a gate.
 
 The scaffold vendors the engine, the gate and the licence into the adopter's
 repository and adds one workflow. That copy has to be as strong as the check we
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -382,8 +383,31 @@ def test_nothing_in_the_template_can_swallow_a_failing_gate(
                     f"`{swallow}` in {run!r} can turn a non-zero exit into a "
                     "passing step")
 
+    # The verdict job's own STEPS, not just the job. This is the job whose name
+    # branch protection requires, and the sweep above stopped at the job key:
+    # `continue-on-error: true` on the single step that computes the verdict
+    # let it fail without failing the job, so `ci-secure` reported green over a
+    # failed scan - the bypass this test is named for, one level further down
+    # than it was looking, in the one job that matters most.
     verdict = template["jobs"]["verdict"]
     assert "continue-on-error" not in verdict
+    for step in verdict["steps"]:
+        assert "continue-on-error" not in step, (
+            f"continue-on-error on {step.get('name')} lets the REQUIRED check's "
+            "own step fail while the check still reports success")
+        assert "if" not in step, (
+            f"a condition on {step.get('name')} lets the required check green "
+            "by skipping the step that decides the verdict")
+        for swallow in ("|| true", "|| exit 0", "set +e"):
+            assert swallow not in step.get("run", ""), (
+                f"`{swallow}` in the verdict step turns its exit 1 into a pass")
+
+    # `always()` is what stops a cancelled or skipped scan reporting green, so
+    # the verdict job's condition is load-bearing rather than incidental.
+    assert str(verdict.get("if")).strip() == "always()", (
+        "the verdict job must run unconditionally: `!cancelled()` reports it "
+        "as skipped on a cancelled run, which a required-check rule reads as "
+        f"green - found {verdict.get('if')!r}")
 
 
 @pytest.mark.parametrize(
@@ -551,6 +575,51 @@ def test_vendoring_produces_a_working_gate_and_a_manifest_that_verifies(
          "--verify", str(vendored)],
         capture_output=True, text=True)
     assert check.returncode == 0, check.stdout + check.stderr
+
+    # RUN the vendored gate, which is what this test's name has always claimed
+    # and what nothing in the suite actually did. Placement and hashes are not
+    # the property that matters: the adopter's first run either reaches a
+    # verdict or it does not. Checking only the file list let the vendored set
+    # be shrunk - dropping `scripts/gh_utils.py`, which `config_facts.py` loads
+    # by location from beside the engine, shipped an install whose engine died
+    # on import for every adopter with the whole suite green.
+    gate = subprocess.run(
+        [sys.executable, str(vendored / "scripts" / "gate.py")],
+        cwd=repo, capture_output=True, text=True,
+        env={"PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+             "GITHUB_WORKSPACE": str(repo),
+             "CI_SECURE_ENGINE": "ci-secure/scripts/scan.py",
+             "CI_SECURE_GH_IMPOSTOR": "off",
+             "PYTHONDONTWRITEBYTECODE": "1"})
+
+    assert "engine failed to run" not in gate.stdout, (
+        "the vendored engine could not start - the vendored file set is not "
+        "closed under the engine's imports:\n" + gate.stdout + gate.stderr)
+    assert "rule (config.py)" not in gate.stdout, (
+        "the vendored gate looked for its rule at a path that only exists in "
+        "OUR tree:\n" + gate.stdout)
+    assert "no readable verdict" not in gate.stdout, gate.stdout
+    assert gate.returncode == 1, (
+        "a repository that has never been scanned reds on its first blocking "
+        "run - a 0 here means the gate reached no verdict at all:\n"
+        + gate.stdout + gate.stderr)
+
+    # The same scan, ramped: this is the mode the shipped workflow installs.
+    ramped = subprocess.run(
+        [sys.executable, str(vendored / "scripts" / "gate.py"), "--advisory"],
+        cwd=repo, capture_output=True, text=True,
+        env={"PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+             "GITHUB_WORKSPACE": str(repo),
+             "CI_SECURE_ENGINE": "ci-secure/scripts/scan.py",
+             "CI_SECURE_GH_IMPOSTOR": "off",
+             "PYTHONDONTWRITEBYTECODE": "1"})
+    assert ramped.returncode == 0, (
+        "the flag the template ships did not clear the first-run facts:\n"
+        + ramped.stdout + ramped.stderr)
+
+    assert not list(vendored.rglob("__pycache__")), (
+        "the gate wrote bytecode into the vendored tree, which its own drift "
+        "check reds on")
 
 
 def _vendor(repo: Path) -> subprocess.CompletedProcess:
@@ -846,12 +915,27 @@ def test_the_template_stops_the_gate_writing_bytecode(template: dict) -> None:
     Committed bytecode is drift and reds. Bytecode the gate wrote a second
     earlier is the same file with an innocent cause, so the workflow tells
     Python not to produce it — which is what makes reporting it affordable.
+
+    Asserted on the JOB, not on the gate step. Scoped to that one step the
+    guard stopped one step short of the drift check, which runs python first:
+    the step whose whole purpose is rejecting bytecode was the step free to
+    write it. Safe today only because `--verify` happens to import nothing,
+    which is a property of one function's import graph holding up a stated
+    invariant about the whole job.
     """
-    gate_step = next(s for s in template["jobs"]["scan"]["steps"]
-                     if "gate.py" in s.get("run", ""))
-    assert gate_step.get("env", {}).get("PYTHONDONTWRITEBYTECODE") == "1", (
-        "the gate step may leave __pycache__ in the vendored tree, which the "
-        "next --verify correctly reds - stop it being written at all")
+    scan = template["jobs"]["scan"]
+    assert scan.get("env", {}).get("PYTHONDONTWRITEBYTECODE") == "1", (
+        "set this on the scan JOB: any python step here may otherwise leave "
+        "__pycache__ in the vendored tree, which the next --verify correctly "
+        "reds - stop it being written at all")
+
+    for step in scan["steps"]:
+        if "python" not in step.get("run", ""):
+            continue
+        effective = dict(scan.get("env", {}), **step.get("env", {}))
+        assert effective.get("PYTHONDONTWRITEBYTECODE") == "1", (
+            f"{step.get('name', step.get('run'))!r} runs python without the "
+            "no-bytecode guard in effect")
 
 
 def test_refresh_removes_a_file_a_later_version_stopped_vendoring(
@@ -1004,3 +1088,134 @@ def test_a_hand_edited_vendored_file_is_caught(tmp_path: Path) -> None:
     assert check.returncode == 1
     assert "scripts/gate.py: modified" in check.stdout
     assert "refresh" in check.stdout
+
+
+# --------------------------------------------------------------------------
+# The manifest defines what must be there, not merely what happens to be there
+# --------------------------------------------------------------------------
+
+def test_a_file_dropped_from_the_copy_AND_the_manifest_is_still_drift(
+        tmp_path: Path) -> None:
+    """Deleting a vendored file and its manifest entry must not verify clean.
+
+    This is the hole the "anyone who can edit the gate can edit the manifest"
+    caveat does NOT cover. Nothing here is edited-with-a-matching-hash: a file
+    is removed from the manifest's DOMAIN, so every remaining hash still agrees
+    and the drift check - sold as the thing that notices the vendored copy is
+    no longer what was reviewed - reports a match.
+
+    It is not cosmetic. `config.py` is the rule that says which outcomes block,
+    and the gate resolves a fallback rule from `<gate>/../../skills/ci-secure/
+    scripts/config.py`, which in the vendored layout is a path INSIDE the
+    repository being audited. Delete the vendored `config.py` plus its manifest
+    entry, add that path in the same pull request, and the gate executes a rule
+    the pull request wrote - with a green drift check above it.
+    """
+    repo = tmp_path / "acme-app"
+    repo.mkdir()
+    assert _vendor(repo).returncode == 0
+    vendored = repo / "ci-secure"
+
+    (vendored / "scripts" / "config.py").unlink()
+    manifest_path = vendored / "VENDORED.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    del manifest["files"]["scripts/config.py"]
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+                             encoding="utf-8")
+
+    check = _verify(vendored)
+
+    assert check.returncode == 1, (
+        "a manifest that no longer lists config.py verified CLEAN - the copy "
+        "can be shrunk out from under the check that exists to notice it:\n"
+        + check.stdout)
+    assert "scripts/config.py" in check.stdout, (
+        "the red has to name the file that went missing from the manifest")
+
+
+def test_a_vendored_file_deleted_while_the_manifest_still_lists_it_is_drift(
+        tmp_path: Path) -> None:
+    """The other half: listed but absent. `--verify` must not read that as clean."""
+    repo = tmp_path / "acme-app"
+    repo.mkdir()
+    assert _vendor(repo).returncode == 0
+    vendored = repo / "ci-secure"
+
+    (vendored / "scripts" / "config.py").unlink()
+
+    check = _verify(vendored)
+    assert check.returncode == 1, check.stdout
+    assert "scripts/config.py: missing" in check.stdout
+
+
+def test_verify_cannot_be_made_to_forge_or_silence_its_own_annotations(
+        tmp_path: Path) -> None:
+    """`VENDORED.json` is repository content, and it is printed into a log sink.
+
+    The gate escapes everything it reads out of the repository for exactly this
+    reason, and says so at length. `--verify` reads from the same trust class -
+    a pull request checkout, including a fork's - and runs in the step ABOVE
+    the gate. Unescaped, a newline in the recorded version forges a `::notice::`
+    on the check run, and a newline in a manifest key emits `::stop-commands::`,
+    which swallows every drift reason printed after it: the step reds with no
+    stated cause, which is the unexplained red this codebase argues against.
+    """
+    repo = tmp_path / "acme-app"
+    repo.mkdir()
+    assert _vendor(repo).returncode == 0
+    vendored = repo / "ci-secure"
+    manifest_path = vendored / "VENDORED.json"
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["skill_version"] = "0.2.0\n::notice::all clear"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+                             encoding="utf-8")
+    forged = _verify(vendored)
+    assert "\n::notice::" not in forged.stdout, (
+        "repository content emitted a workflow command of its own:\n"
+        + forged.stdout)
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["files"]["\n::stop-commands::deadbeef\nzzz.py"] = "0" * 64
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+                             encoding="utf-8")
+    silenced = _verify(vendored)
+    assert silenced.returncode == 1
+    assert "\n::stop-commands::" not in silenced.stdout, (
+        "a manifest key stopped the workflow commands that report the drift:\n"
+        + silenced.stdout)
+
+
+def test_the_installer_ignores_an_ambient_git_environment(tmp_path: Path) -> None:
+    """`GIT_DIR` overrides `-C`, so the guards must not ask the ambient git.
+
+    Every `git` call here is asking about a SPECIFIC directory - is this the
+    root of its repository, what commit is this skill at - and `-C` is not
+    enough to make that true: an exported `GIT_DIR` (a hook, a `rebase -x`, a
+    worktree-driven session) silently redirects the answer to an unrelated
+    repository. The subdirectory guard then refuses a perfectly good install
+    and tells the adopter to vendor a live workflow into that other repository
+    instead, which is the "wrote it somewhere you never looked" outcome the
+    sibling guard exists to prevent, reached THROUGH a guard.
+    """
+    repo = tmp_path / "acme-app"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True,
+                   capture_output=True)
+    elsewhere = tmp_path / "unrelated"
+    elsewhere.mkdir()
+    subprocess.run(["git", "init", "-q", str(elsewhere)], check=True,
+                   capture_output=True)
+
+    env = dict(os.environ, GIT_DIR=str(elsewhere / ".git"),
+               GIT_WORK_TREE=str(elsewhere))
+    install = subprocess.run(
+        [sys.executable, str(_VENDOR), "--into", str(repo)],
+        capture_output=True, text=True, env=env)
+
+    assert install.returncode == 0, (
+        "an unrelated GIT_DIR in the environment made the install refuse:\n"
+        + install.stdout + install.stderr)
+    assert (repo / "ci-secure" / "VENDORED.json").is_file()
+    assert not (elsewhere / "ci-secure").exists(), (
+        "the install must never touch the repository GIT_DIR pointed at")

--- a/tests/test_ci_secure_scaffold.py
+++ b/tests/test_ci_secure_scaffold.py
@@ -1,0 +1,314 @@
+"""What an outside repository gets when ci-secure installs itself as a gate.
+
+The scaffold vendors the engine, the gate and the licence into the adopter's
+repository and adds one workflow. That copy has to be as strong as the check we
+run on ourselves, and there is no way to notice from inside our own CI if it
+stops being — nobody here runs it. So these tests do three separate jobs:
+
+1. **Identity.** The vendored gate is byte-for-byte the gate this repository
+   runs. Two copies of a security-critical file exist because an installed
+   skill has no `.github/` to read from; the cost of that is drift, and this is
+   what refuses to let it happen.
+
+2. **The declared delta.** The template is allowed to differ from our workflow
+   in specific, enumerated ways — paths, runner topology, the advisory default.
+   Anything else is a difference nobody decided on. The most dangerous one is
+   the verdict job: ours arbitrates between two mutually exclusive scans and an
+   adopter has one, so a verbatim copy would `needs:` a job that does not
+   exist. The test asserts the predicate is well-formed against the template's
+   OWN job set, which is what a "same shape" check would miss.
+
+3. **Cleanliness.** The template is a workflow file, installed into
+   `.github/workflows/`, and therefore scanned by the gate it just installed.
+   If it trips a fact, every adopter reds the moment they go blocking — on a
+   file we wrote. Delta conformance does not imply this: the declared delta
+   itself could be the thing that trips a fact.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+_REPO = Path(__file__).resolve().parents[1]
+_SKILL = _REPO / "skills" / "ci-secure"
+_SCAFFOLD = _SKILL / "scaffold"
+_TEMPLATE = _SCAFFOLD / "ci-secure.yml"
+_OUR_WORKFLOW = _REPO / ".github" / "workflows" / "ci-secure-check.yml"
+_OUR_GATE = _REPO / ".github" / "scripts" / "ci_secure_gate.py"
+_VENDOR = _SKILL / "scripts" / "vendor.py"
+
+
+@pytest.fixture(scope="module")
+def template() -> dict:
+    return yaml.safe_load(_TEMPLATE.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def ours() -> dict:
+    return yaml.safe_load(_OUR_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict) -> dict:
+    # PyYAML parses a bare `on:` key as the boolean True.
+    return workflow[True] if True in workflow else workflow["on"]
+
+
+# --------------------------------------------------------------------------
+# 1. Identity
+# --------------------------------------------------------------------------
+
+def test_the_vendored_gate_is_byte_identical_to_the_one_we_run() -> None:
+    """One gate, two locations. The day they differ, an adopter runs the weaker one."""
+    assert _SCAFFOLD.joinpath("gate.py").read_bytes() == _OUR_GATE.read_bytes(), (
+        "skills/ci-secure/scaffold/gate.py has drifted from "
+        ".github/scripts/ci_secure_gate.py — copy the one we run on ourselves "
+        "over the one we hand to other people, never the other way round")
+
+
+# --------------------------------------------------------------------------
+# 2. The declared delta
+# --------------------------------------------------------------------------
+
+def test_the_template_runs_the_gate_and_never_the_engine(template: dict) -> None:
+    """`scan.py` exits 0 whatever it finds, so calling it directly is green forever."""
+    steps = template["jobs"]["scan"]["steps"]
+    run = [s["run"] for s in steps if "run" in s][-1]
+    assert run.startswith("python3 ci-secure/scripts/gate.py"), run
+    assert "scan.py" not in run, (
+        "the engine reports; the gate decides. A step that calls the engine "
+        "directly passes no matter what the scan found")
+    assert steps[-1]["env"]["CI_SECURE_ENGINE"] == "ci-secure/scripts/scan.py", (
+        "the vendored layout needs the engine pointer set; our in-tree default "
+        "resolves to a path an adopter does not have")
+
+
+def test_the_adopters_verdict_job_is_well_formed_against_its_own_jobs(
+        template: dict) -> None:
+    """The collapsed shape, checked against the template's real job set.
+
+    Our verdict job `needs: [scan, scan-fork]` and passes when exactly one of
+    them succeeded while the other skipped. Copied verbatim into a repository
+    with one scan job, `needs.scan-fork.result` is empty, the arithmetic never
+    matches, and the required check reds forever or the workflow is invalid.
+    """
+    jobs = template["jobs"]
+    verdict = jobs["verdict"]
+
+    assert verdict["name"] == "ci-secure", "the verdict job owns the required name"
+    assert set(verdict["needs"]) <= set(jobs), (
+        f"the verdict job needs {set(verdict['needs']) - set(jobs)}, which this "
+        "template does not define")
+    assert set(verdict["needs"]) == {"scan"}
+    assert " ".join(str(verdict["if"]).split()) == "always()", (
+        "a verdict job that does not always run is a required check that can be "
+        "skipped, which GitHub reads as green")
+
+    script = verdict["steps"][-1]["run"]
+    assert 'if [ "${SCAN}" = "success" ]' in script, (
+        "the pass condition must be scan-succeeded, not scan-did-not-fail: "
+        "skipped and cancelled are not passes")
+    assert "${{" not in script, "job results are read through env, never interpolated"
+
+    # And no scan job may claim the required name for itself.
+    for name, job in jobs.items():
+        if name != "verdict":
+            assert job.get("name") != "ci-secure"
+
+
+def test_the_template_differs_from_ours_only_where_declared(
+        template: dict, ours: dict) -> None:
+    """Everything outside the enumerated delta must match, or nobody decided it.
+
+    The declared delta, in full:
+      - paths          the gate and engine live in a vendored `ci-secure/` dir
+      - topology       one hosted scan job, not our self-hosted + fork pair, so
+                       one `needs:` in the verdict job
+      - advisory       the template ships `--advisory`; we do not
+      - judge-from-main  absent: that is our-repo hardening, and an adopter's
+                       fork exposure is theirs to decide
+      - impostor check conditional on the event, because one job serves both
+                       fork and non-fork pull requests
+      - drift check    the template verifies its vendored copy; we have no
+                       vendored copy to verify
+    """
+    assert set(_triggers(template)) == set(_triggers(ours)), (
+        "the trigger sets are NOT part of the declared delta: an adopter gets "
+        "the same weekly rot check we do")
+    assert _triggers(template)["push"]["branches"] == ["main"]
+    assert [e["cron"] for e in _triggers(template)["schedule"]], "no cron expression"
+
+    assert template["permissions"] == ours["permissions"] == {"contents": "read"}
+    assert "github.event_name" in template["concurrency"]["group"], (
+        "without the event in the key, a push can cancel the weekly run")
+    assert template["concurrency"]["cancel-in-progress"] is True
+
+    # Topology: exactly the declared difference, nothing more.
+    assert set(template["jobs"]) == {"scan", "verdict"}
+    assert set(ours["jobs"]) == {"scan", "scan-fork", "verdict"}
+    assert template["jobs"]["scan"]["runs-on"] == "ubuntu-latest", (
+        "an adopter has no StarSling runners")
+
+    # Every action pinned to a full SHA, same as ours — a template that
+    # installed a floating tag would fail the check it installs.
+    for job in template["jobs"].values():
+        for step in job.get("steps", []):
+            if "uses" in step:
+                assert "@" in step["uses"] and len(step["uses"].split("@")[1]) == 40, (
+                    f"unpinned action in the template: {step['uses']}")
+
+    assert "--advisory" in template["jobs"]["scan"]["steps"][-1]["run"], (
+        "the template ships advisory so the installing pull request does not "
+        "brick the adopter's merge path on day one")
+
+
+def test_the_template_never_hands_fork_code_a_token(template: dict) -> None:
+    """One job serves fork and non-fork pull requests; only one of them gets a token."""
+    env = template["jobs"]["scan"]["steps"][-1]["env"]
+
+    for key in ("CI_SECURE_GH_IMPOSTOR", "GH_TOKEN"):
+        expr = " ".join(str(env[key]).split())
+        assert "head.repo.full_name != github.repository" in expr, (
+            f"{key} is not conditioned on the pull request being from a fork: "
+            f"{expr}")
+    assert "'auto'" not in str(env["CI_SECURE_GH_IMPOSTOR"]), (
+        "`auto` makes a security check's presence depend on the runner image")
+
+
+def test_the_template_verifies_its_own_vendored_copy(template: dict) -> None:
+    """Drift in the vendored gate must be loud, not discovered at the next refresh."""
+    runs = [s.get("run", "") for s in template["jobs"]["scan"]["steps"]]
+    assert any("vendor.py --verify" in r for r in runs), (
+        "nothing checks the vendored files against VENDORED.json, so a local "
+        "edit to the gate would weaken it invisibly")
+
+
+# --------------------------------------------------------------------------
+# 3. Cleanliness — the template passes the gate it installs
+# --------------------------------------------------------------------------
+
+# Facts a repository that has never been scanned is expected to red or be
+# unable to measure on its FIRST run. They are the reason `--advisory` exists;
+# they are not licence for the template itself to be dirty.
+_FIRST_RUN_FACTS = {
+    "sec.codeowners.workflows",          # no CODEOWNERS entry yet
+    "sec.permissions.workflow-declares",  # the adopter's OTHER workflows
+    "sec.required-checks.skippable",     # admin-scoped API, unmeasurable in CI
+    "sec.fork-approval.effective",       # admin-scoped API, unmeasurable in CI
+}
+
+
+def test_the_installed_template_passes_the_gate_it_installs(tmp_path: Path) -> None:
+    """Scan a repository whose only workflow is the one we ship.
+
+    Whatever the template does becomes every adopter's `.github/workflows`, and
+    the gate scans exactly that. If the template trips a fact, the adopter's
+    first blocking run reds on a file they did not write — and they would be
+    right to conclude the tool is broken.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    shutil.copy2(_TEMPLATE, repo / ".github" / "workflows" / "ci-secure.yml")
+
+    proc = subprocess.run(
+        [sys.executable, str(_SKILL / "scripts" / "scan.py"), "--root", str(repo),
+         "--gh-impostor", "off"],
+        capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr[-2000:]
+
+    scan = json.loads(proc.stdout)
+    failed = [f["fact_id"] for f in scan["security_score"]["facts"]
+              if f["outcome"] == "fail"]
+    unexpected = sorted(set(failed) - _FIRST_RUN_FACTS)
+    assert not unexpected, (
+        f"the workflow we hand to adopters fails {unexpected} against the gate "
+        "it installs")
+
+    assert not scan["scan_incomplete"], scan["scan_incomplete"]
+    assert not scan["dropped_matches"], scan["dropped_matches"]
+
+    findings = [f"{f['pattern']}: {f['title']}" for f in scan["findings"]]
+    assert not findings, (
+        f"the template trips pattern findings an adopter would have to triage "
+        f"on day one: {findings}")
+
+
+# --------------------------------------------------------------------------
+# The install itself
+# --------------------------------------------------------------------------
+
+def test_vendoring_produces_a_working_gate_and_a_manifest_that_verifies(
+        tmp_path: Path) -> None:
+    """End to end: vendor into an empty repo, then run the vendored gate on it.
+
+    This is the adopter's first five minutes, and it is where a layout mistake
+    shows up — the vendored gate resolving `config.py` from a path that only
+    exists in OUR tree would red with "rule not found" on every install.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+
+    install = subprocess.run(
+        [sys.executable, str(_VENDOR), "--into", str(repo)],
+        capture_output=True, text=True)
+    assert install.returncode == 0, install.stderr
+
+    vendored = repo / "ci-secure"
+    assert (vendored / "LICENSE").is_file(), (
+        "copying the code without its licence is a licence violation")
+    assert (vendored / "scripts" / "config.py").is_file(), (
+        "config.py must land beside the engine, where the gate looks for it")
+    assert (repo / ".github" / "workflows" / "ci-secure.yml").is_file()
+
+    manifest = json.loads((vendored / "VENDORED.json").read_text(encoding="utf-8"))
+    assert manifest["skill_version"]
+    assert manifest["source_commit"]
+    assert set(manifest["files"]) >= {"scripts/scan.py", "scripts/gate.py",
+                                      "scripts/config.py", "LICENSE"}
+
+    check = subprocess.run(
+        [sys.executable, str(vendored / "scripts" / "vendor.py"),
+         "--verify", str(vendored)],
+        capture_output=True, text=True)
+    assert check.returncode == 0, check.stdout + check.stderr
+
+    # The gate runs, finds its engine and its rule, and judges the tree.
+    gate = subprocess.run(
+        [sys.executable, str(vendored / "scripts" / "gate.py"), "--advisory"],
+        capture_output=True, text=True,
+        env={"PATH": "/usr/bin:/bin",
+             "GITHUB_WORKSPACE": str(repo),
+             "CI_SECURE_ENGINE": str(vendored / "scripts" / "scan.py"),
+             "CI_SECURE_GH_IMPOSTOR": "off"})
+    assert "rule (config.py) not found" not in gate.stdout, gate.stdout
+    assert "engine not found" not in gate.stdout, gate.stdout
+    assert gate.returncode == 0, (
+        "a freshly vendored gate must not red on the workflow it installed, in "
+        f"advisory mode:\n{gate.stdout}\n{gate.stderr}")
+
+
+def test_a_hand_edited_vendored_file_is_caught(tmp_path: Path) -> None:
+    """The manifest earns its place only if drift actually fails something."""
+    repo = tmp_path / "acme-app"
+    repo.mkdir()
+    subprocess.run([sys.executable, str(_VENDOR), "--into", str(repo)],
+                   capture_output=True, text=True, check=True)
+    vendored = repo / "ci-secure"
+
+    gate = vendored / "scripts" / "gate.py"
+    gate.write_text(gate.read_text(encoding="utf-8").replace(
+        'BLOCKING_OUTCOMES', 'BLOCKING_OUTCOMES_DISABLED', 1), encoding="utf-8")
+
+    check = subprocess.run(
+        [sys.executable, str(vendored / "scripts" / "vendor.py"),
+         "--verify", str(vendored)],
+        capture_output=True, text=True)
+    assert check.returncode == 1
+    assert "scripts/gate.py: modified" in check.stdout
+    assert "refresh" in check.stdout

--- a/tests/test_ci_secure_scaffold.py
+++ b/tests/test_ci_secure_scaffold.py
@@ -702,6 +702,45 @@ def test_pruning_cannot_reach_outside_the_vendored_directory(
         "a refresh deleted a file outside the repository entirely")
 
 
+@pytest.mark.parametrize("link_at", ["ci-secure", "ci-secure/scripts",
+                                     "ci-secure/references",
+                                     "ci-secure/scripts/gate.py", ".github",
+                                     ".github/workflows",
+                                     ".github/workflows/ci-secure.yml"])
+def test_an_install_never_writes_outside_the_repository(
+        tmp_path: Path, link_at: str) -> None:
+    """Every destination is inside the repository, or nothing is written at all.
+
+    The install is aimed at a directory the adopter controls, and a symlink is
+    ordinary repository content — it survives a clone, a pull request checkout
+    and a fork. If one sitting at `ci-secure/`, at any directory beneath it, or
+    at `.github/` is followed, the tool writes the engine, the gate and a live
+    workflow somewhere the adopter never looked, reports success, and leaves the
+    repository with no gate at all while its own documentation states exactly
+    what it wrote and where.
+    """
+    repo = tmp_path / "acme-app"
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    link = repo / link_at
+    link.parent.mkdir(parents=True, exist_ok=True)
+    link.symlink_to(outside)
+
+    result = _vendor(repo)
+
+    assert result.returncode != 0, (
+        f"a symlink at {link_at} was followed and the install reported success")
+    assert not list(outside.rglob("*")), (
+        f"the install wrote outside the repository via {link_at}: "
+        f"{[p.name for p in outside.rglob('*')]}")
+    # `is_file`, not `exists`: in the cases where the planted symlink IS one of
+    # these two paths it already "exists", and that is the fixture, not a write.
+    assert not (repo / "ci-secure" / "VENDORED.json").is_file(), (
+        "a refused install left a vendored tree behind")
+    assert not (repo / ".github" / "workflows" / "ci-secure.yml").is_file(), (
+        "a refused install left a live ci-secure workflow behind")
+
+
 def test_an_install_that_cannot_finish_writes_nothing(tmp_path: Path) -> None:
     """Validate first, then write. A half-install is a live workflow with no gate.
 

--- a/tests/test_ci_secure_scaffold.py
+++ b/tests/test_ci_secure_scaffold.py
@@ -45,6 +45,16 @@ _OUR_GATE = _REPO / ".github" / "scripts" / "ci_secure_gate.py"
 _VENDOR = _SKILL / "scripts" / "vendor.py"
 
 
+def _load_vendor_module():
+    """Import vendor.py directly, for the paths that need to fail mid-install."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("_ci_secure_vendor", _VENDOR)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 @pytest.fixture(scope="module")
 def template() -> dict:
     return yaml.safe_load(_TEMPLATE.read_text(encoding="utf-8"))
@@ -174,11 +184,231 @@ def test_the_template_never_hands_fork_code_a_token(template: dict) -> None:
 
     for key in ("CI_SECURE_GH_IMPOSTOR", "GH_TOKEN"):
         expr = " ".join(str(env[key]).split())
-        assert "head.repo.full_name != github.repository" in expr, (
+        # Either polarity is fine here — which way round it has to be written
+        # is pinned by the evaluating test below, not by a substring.
+        assert "head.repo.full_name" in expr and "github.repository" in expr, (
             f"{key} is not conditioned on the pull request being from a fork: "
             f"{expr}")
     assert "'auto'" not in str(env["CI_SECURE_GH_IMPOSTOR"]), (
         "`auto` makes a security check's presence depend on the runner image")
+
+
+def _evaluate(expr: str, context: dict) -> str:
+    """Evaluate a `${{ COND && A || B }}` workflow expression the way Actions does.
+
+    The rule that matters here is that Actions has no ternary operator, only
+    `&&`/`||` over truthiness — and an EMPTY STRING is falsy. So `cond && '' ||
+    x` does not yield the empty string when `cond` holds; the empty middle is
+    falsy, the `||` takes over, and the answer is always `x`. Asserting that an
+    expression mentions the right condition cannot see that. Evaluating it can.
+    """
+    body = expr.strip()
+    assert body.startswith("${{") and body.endswith("}}"), body
+    body = " ".join(body[3:-2].split())
+
+    def truthy(value: str) -> bool:
+        # Actions: '' and false are falsy; every other string is truthy.
+        return value not in ("", "false")
+
+    def split_top(text: str, op: str) -> list[str]:
+        """Split on `op` at parenthesis depth 0."""
+        parts, depth, start, i = [], 0, 0, 0
+        while i < len(text):
+            char = text[i]
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+            elif depth == 0 and text.startswith(op, i):
+                parts.append(text[start:i])
+                i += len(op)
+                start = i
+                continue
+            i += 1
+        parts.append(text[start:])
+        return [p.strip() for p in parts]
+
+    def evaluate(text: str) -> str:
+        text = text.strip()
+        alternatives = split_top(text, "||")
+        if len(alternatives) > 1:
+            result = ""
+            for alternative in alternatives:
+                result = evaluate(alternative)
+                if truthy(result):
+                    return result
+            return result
+        conjuncts = split_top(text, "&&")
+        if len(conjuncts) > 1:
+            result = "true"
+            for conjunct in conjuncts:
+                result = evaluate(conjunct)
+                if not truthy(result):
+                    return result
+            return result
+        return term(text)
+
+    def term(token: str) -> str:
+        token = token.strip()
+        while token.startswith("(") and token.endswith(")"):
+            inner = token[1:-1]
+            if split_top(inner, ")") and inner.count("(") == inner.count(")"):
+                return evaluate(inner)
+            break
+        if token.startswith("'") and token.endswith("'"):
+            return token[1:-1]
+        if token in context:
+            return context[token]
+        # A comparison, `a == b` or `a != b`, over context values.
+        for op in ("!=", "=="):
+            if op in token:
+                left, right = (p.strip() for p in token.split(op, 1))
+                equal = term(left) == term(right)
+                return "true" if (equal if op == "==" else not equal) else ""
+        raise AssertionError(f"unknown token in template expression: {token!r}")
+
+    return evaluate(body)
+
+
+_FORK_PR = {
+    "github.event_name": "pull_request",
+    "github.event.pull_request.head.repo.full_name": "someone-else/skills",
+    "github.repository": "adopter/repo",
+    "github.token": "TOKEN",
+}
+_SAME_REPO_PR = {
+    "github.event_name": "pull_request",
+    "github.event.pull_request.head.repo.full_name": "adopter/repo",
+    "github.repository": "adopter/repo",
+    "github.token": "TOKEN",
+}
+_DELETED_FORK_PR = {
+    # GitHub nulls out `head.repo` once the fork is deleted; an unset context
+    # value renders as the empty string.
+    "github.event_name": "pull_request",
+    "github.event.pull_request.head.repo.full_name": "",
+    "github.repository": "adopter/repo",
+    "github.token": "TOKEN",
+}
+_PUSH = {
+    "github.event_name": "push",
+    "github.event.pull_request.head.repo.full_name": "",
+    "github.repository": "adopter/repo",
+    "github.token": "TOKEN",
+}
+_SCHEDULE = dict(_PUSH, **{"github.event_name": "schedule"})
+
+
+@pytest.mark.parametrize(
+    ("name", "context", "impostor", "token"),
+    [
+        # Fork pull request: the check is disclosed as not run, and the step
+        # gets NO credential. This is the case the whole expression exists for.
+        ("fork pull request", _FORK_PR, "off", ""),
+        ("deleted-fork pull request", _DELETED_FORK_PR, "off", ""),
+        # Everything else is the adopter's own code and gets the check.
+        ("same-repo pull request", _SAME_REPO_PR, "on", "TOKEN"),
+        ("push", _PUSH, "on", "TOKEN"),
+        ("schedule", _SCHEDULE, "on", "TOKEN"),
+    ],
+)
+def test_the_template_withholds_the_token_on_fork_runs_when_evaluated(
+    template: dict, name: str, context: dict, impostor: str, token: str,
+) -> None:
+    """Not "mentions the fork condition" — what the expression actually returns.
+
+    A previous version conditioned the token correctly and still handed it to
+    every fork pull request, because the withholding branch was an empty string
+    on the left of `||` and Actions treats that as falsy.
+    """
+    env = template["jobs"]["scan"]["steps"][-1]["env"]
+    assert _evaluate(str(env["CI_SECURE_GH_IMPOSTOR"]), context) == impostor, (
+        f"on a {name} the impostor check should be {impostor!r}")
+    assert _evaluate(str(env["GH_TOKEN"]), context) == token, (
+        f"on a {name} GH_TOKEN should evaluate to {token!r}; a fork pull "
+        f"request runs code its author wrote and must not be handed a "
+        f"credential")
+
+
+def test_nothing_in_the_template_can_swallow_a_failing_gate(
+        template: dict) -> None:
+    """The verdict is only worth what the FAILURE path is worth.
+
+    Everything else here pins which command runs and what the pass predicate
+    says. That is all satisfiable by a scaffold whose gate can never fail:
+    `continue-on-error` on the step or the job (GitHub reports a
+    continue-on-error job to `needs` as a SUCCESS), a `|| true` on the run
+    line, or a step-level `if:` that skips the gate on pull requests — the same
+    skipped-check bypass the file's own header warns about, one level down.
+    Each of those ships a green required check over an unscanned repository.
+    """
+    scan = template["jobs"]["scan"]
+    assert "continue-on-error" not in scan, (
+        "a continue-on-error scan job reports SUCCESS to `needs`, so the "
+        "verdict greens over a gate that failed")
+    assert "if" not in scan, (
+        "a condition on the scan job makes it skippable, and the verdict reads "
+        "a skipped dependency as something other than a failure")
+
+    for step in scan["steps"]:
+        assert "continue-on-error" not in step, (
+            f"continue-on-error on {step.get('name', step.get('uses'))} lets "
+            "the step fail without failing the job")
+        assert "if" not in step, (
+            f"a condition on {step.get('name', step.get('uses'))} lets the "
+            "gate be skipped while the job still reports success")
+
+    for step in scan["steps"]:
+        run = step.get("run", "")
+        if "gate.py" in run or "vendor.py" in run:
+            for swallow in ("||", "&&", ";", "| true", "set +e"):
+                assert swallow not in run, (
+                    f"`{swallow}` in {run!r} can turn a non-zero exit into a "
+                    "passing step")
+
+    verdict = template["jobs"]["verdict"]
+    assert "continue-on-error" not in verdict
+    script = verdict["steps"][-1]["run"]
+    assert "exit 1" in script, (
+        "the verdict's not-success branch has no non-zero exit, so the "
+        "required check is green whatever the scan did")
+
+
+def test_the_template_triggers_carry_no_narrowing_filter(template: dict) -> None:
+    """`pull_request:` with a filter is a gate that mostly does not run.
+
+    `types: [labeled]` or `paths: [...]` under `pull_request` leaves the check
+    reporting green on every pull request that does not match — which a
+    required-check rule cannot tell apart from a scan that passed.
+    """
+    triggers = _triggers(template)
+    assert triggers["pull_request"] is None, (
+        f"the pull_request trigger carries a filter ({triggers['pull_request']}); "
+        "every pull request has to be scanned or the required check is a "
+        "rule that can be satisfied by not matching it")
+
+
+def test_the_installer_installs_exactly_the_files_under_test(
+        tmp_path: Path) -> None:
+    """The suite inspects `scaffold/`; the installer reads two constants.
+
+    Nothing otherwise binds the two together, so repointing `GATE_SOURCE` at a
+    five-line gate that exits 0 ships that gate to every adopter with the whole
+    suite green — the reviewed file and the installed file are simply different
+    files. This is what ties them.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    assert _vendor(repo).returncode == 0
+
+    assert (repo / "ci-secure" / "scripts" / "gate.py").read_bytes() == \
+        (_SCAFFOLD / "gate.py").read_bytes(), (
+            "the gate that gets installed is not the gate the identity test "
+            "holds to the one we run on ourselves")
+    assert (repo / ".github" / "workflows" / "ci-secure.yml").read_bytes() == \
+        _TEMPLATE.read_bytes(), (
+            "the workflow that gets installed is not the template every other "
+            "test in this file inspects")
 
 
 def test_the_template_verifies_its_own_vendored_copy(template: dict) -> None:
@@ -198,10 +428,15 @@ def test_the_template_verifies_its_own_vendored_copy(template: dict) -> None:
 # they are not licence for the template itself to be dirty.
 _FIRST_RUN_FACTS = {
     "sec.codeowners.workflows",          # no CODEOWNERS entry yet
-    "sec.permissions.workflow-declares",  # the adopter's OTHER workflows
     "sec.required-checks.skippable",     # admin-scoped API, unmeasurable in CI
     "sec.fork-approval.effective",       # admin-scoped API, unmeasurable in CI
 }
+
+# `sec.permissions.workflow-declares` is deliberately NOT excused here. The
+# fixture repository's only workflow is the one we ship, so that fact is a
+# statement about OUR file and nothing else — excusing it as "the adopter's
+# other workflows" would let the template drop its `permissions:` block with
+# this test still green.
 
 
 def test_the_installed_template_passes_the_gate_it_installs(tmp_path: Path) -> None:
@@ -278,19 +513,127 @@ def test_vendoring_produces_a_working_gate_and_a_manifest_that_verifies(
         capture_output=True, text=True)
     assert check.returncode == 0, check.stdout + check.stderr
 
-    # The gate runs, finds its engine and its rule, and judges the tree.
-    gate = subprocess.run(
-        [sys.executable, str(vendored / "scripts" / "gate.py"), "--advisory"],
-        capture_output=True, text=True,
-        env={"PATH": "/usr/bin:/bin",
-             "GITHUB_WORKSPACE": str(repo),
-             "CI_SECURE_ENGINE": str(vendored / "scripts" / "scan.py"),
-             "CI_SECURE_GH_IMPOSTOR": "off"})
-    assert "rule (config.py) not found" not in gate.stdout, gate.stdout
-    assert "engine not found" not in gate.stdout, gate.stdout
-    assert gate.returncode == 0, (
-        "a freshly vendored gate must not red on the workflow it installed, in "
-        f"advisory mode:\n{gate.stdout}\n{gate.stderr}")
+
+def _vendor(repo: Path) -> subprocess.CompletedProcess:
+    return subprocess.run([sys.executable, str(_VENDOR), "--into", str(repo)],
+                          capture_output=True, text=True)
+
+
+def _verify(vendored: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(vendored / "scripts" / "vendor.py"),
+         "--verify", str(vendored)], capture_output=True, text=True)
+
+
+def test_refresh_leaves_the_adopters_own_workflow_alone(tmp_path: Path) -> None:
+    """Refreshing the vendored CODE must not rewrite the workflow they tuned.
+
+    The workflow is the one file the adopter is invited to change: their runner,
+    their triggers, and — the whole point of the ramp — deleting `--advisory`
+    once the first-run findings are burned down. Copying the template back over
+    it on refresh silently returns a blocking gate to advisory, which is the
+    worst outcome this feature can produce, and the manifest cannot catch it
+    because the workflow is deliberately not checksummed.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    assert _vendor(repo).returncode == 0
+
+    installed = repo / ".github" / "workflows" / "ci-secure.yml"
+    tuned = installed.read_text(encoding="utf-8").replace(
+        "gate.py --advisory", "gate.py")
+    assert "gate.py --advisory" not in tuned
+    installed.write_text(tuned, encoding="utf-8")
+
+    refresh = _vendor(repo)
+    assert refresh.returncode == 0, refresh.stderr
+    assert installed.read_text(encoding="utf-8") == tuned, (
+        "refresh overwrote the adopter's workflow - a gate they had taken "
+        "blocking is advisory again and nothing told them")
+    assert "workflow" in refresh.stdout.lower(), (
+        "refresh left the workflow alone but did not say so, and an unsaid "
+        "skip is indistinguishable from an update that happened")
+
+
+def test_verify_ignores_the_bytecode_running_the_gate_creates(
+        tmp_path: Path) -> None:
+    """A `.pyc` is not a tampered gate, and crying drift over one trains it out.
+
+    The engine is imported as modules, so any local run leaves
+    `ci-secure/scripts/__pycache__/`. SKILL.md hands `--verify` to the adopter
+    as a command they can run; if it accuses them of editing the gate the first
+    time they try it, the real drift signal is noise from then on.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    assert _vendor(repo).returncode == 0
+    vendored = repo / "ci-secure"
+
+    cache = vendored / "scripts" / "__pycache__"
+    cache.mkdir(parents=True, exist_ok=True)
+    (cache / "config.cpython-312.pyc").write_bytes(b"\x00compiled")
+
+    check = _verify(vendored)
+    assert check.returncode == 0, (
+        "verify red on bytecode the gate itself writes:\n" + check.stdout)
+
+
+def test_refresh_removes_a_file_a_later_version_stopped_vendoring(
+        tmp_path: Path) -> None:
+    """Otherwise the refresh that drops a file reds the adopter's next run.
+
+    `--verify` flags anything under the vendored directory that the manifest
+    does not list. A file removed from the vendored set in a later version is
+    exactly that, so a correct refresh would hand the adopter a red required
+    check for a file they never touched.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    assert _vendor(repo).returncode == 0
+    vendored = repo / "ci-secure"
+
+    # Stand in for a file an earlier version vendored and this one does not.
+    stale = vendored / "scripts" / "retired_helper.py"
+    stale.write_text("# vendored by an older ci-secure\n", encoding="utf-8")
+    manifest_path = vendored / "VENDORED.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["files"]["scripts/retired_helper.py"] = "0" * 64
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+                             encoding="utf-8")
+
+    assert _vendor(repo).returncode == 0
+    assert not stale.exists(), (
+        "refresh left behind a file it no longer vendors; the adopter's next "
+        "run reds with 'not in the manifest'")
+    check = _verify(vendored)
+    assert check.returncode == 0, check.stdout
+
+
+def test_an_install_that_cannot_finish_writes_nothing(tmp_path: Path) -> None:
+    """Validate first, then write. A half-install is a live workflow with no gate.
+
+    The workflow used to be copied in before the licence was resolved and
+    before the manifest was written, so a refusal partway through left the
+    adopter with a workflow GitHub runs, a vendored tree, and no
+    `VENDORED.json` — whose very first CI run reds on `--verify` with "cannot
+    tell what this copy was supposed to be".
+    """
+    vendor = _load_vendor_module()
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+
+    original = vendor._license_source
+    vendor._license_source = lambda: None
+    try:
+        with pytest.raises(SystemExit):
+            vendor.install(repo)
+    finally:
+        vendor._license_source = original
+
+    assert not (repo / ".github" / "workflows" / "ci-secure.yml").exists(), (
+        "a refused install left a live ci-secure workflow behind")
+    assert not (repo / "ci-secure").exists(), (
+        "a refused install left a vendored tree with no manifest behind")
 
 
 def test_a_hand_edited_vendored_file_is_caught(tmp_path: Path) -> None:

--- a/tests/test_ci_secure_scaffold.py
+++ b/tests/test_ci_secure_scaffold.py
@@ -26,6 +26,7 @@ stops being — nobody here runs it. So these tests do three separate jobs:
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import shutil
 import subprocess
@@ -591,6 +592,222 @@ def test_refresh_leaves_the_adopters_own_workflow_alone(tmp_path: Path) -> None:
     assert "workflow" in refresh.stdout.lower(), (
         "refresh left the workflow alone but did not say so, and an unsaid "
         "skip is indistinguishable from an update that happened")
+
+
+@pytest.mark.parametrize("what_they_did", ["renamed", "deleted"])
+def test_refresh_never_re_adds_the_workflow_template(
+        tmp_path: Path, what_they_did: str) -> None:
+    """"Left exactly as it is" has to hold for a workflow that MOVED, too.
+
+    The guarantee was enforced by "do not overwrite a file that is there",
+    which is a different promise. An adopter who renamed the file to fit their
+    conventions — or deleted it while backing the gate out — got the advisory
+    template silently re-added on the next refresh. That is the outcome the
+    design calls the worst thing this feature can do, reached by adding rather
+    than overwriting: two workflows both publishing the required check name
+    `ci-secure`, one of them advisory, and nothing said so.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    assert _vendor(repo).returncode == 0
+
+    workflows = repo / ".github" / "workflows"
+    installed = workflows / "ci-secure.yml"
+    blocking = installed.read_text(encoding="utf-8").replace(
+        "gate.py --advisory", "gate.py")
+    if what_they_did == "renamed":
+        (workflows / "security.yml").write_text(blocking, encoding="utf-8")
+    installed.unlink()
+
+    refresh = _vendor(repo)
+    assert refresh.returncode == 0, refresh.stderr
+    assert not installed.exists(), (
+        "a refresh re-added the advisory template at the path the adopter had "
+        "moved the workflow away from - two jobs now carry the required check "
+        "name and one of them cannot block")
+    if what_they_did == "renamed":
+        assert "gate.py --advisory" not in (workflows / "security.yml").read_text(
+            encoding="utf-8")
+
+
+def test_installing_over_someone_elses_ci_secure_directory_refuses(
+        tmp_path: Path) -> None:
+    """A destination that is already in use is refused, not merged into.
+
+    `ci-secure/` is a plausible name for a directory an adopter already keeps —
+    policies, notes — and the install used to copy in beside whatever was
+    there and exit 0. The manifest then lists only our files, so the very first
+    CI run reds on `--verify` with "not in the manifest" for the adopter's own
+    files, before the gate runs at all. Neither documented remedy reaches it:
+    `--advisory` downgrades failed FACTS, and this is not a fact. The install
+    reported success, so nobody is looking at the install.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / "ci-secure").mkdir(parents=True)
+    theirs = repo / "ci-secure" / "NOTES.md"
+    theirs.write_text("our security policies\n", encoding="utf-8")
+
+    result = _vendor(repo)
+
+    assert result.returncode != 0, (
+        "installed into a directory already holding the adopter's files, "
+        "which reds their CI on every run from the first one")
+    assert "NOTES.md" in result.stdout + result.stderr, (
+        "the refusal did not name the file in the way, so the adopter cannot "
+        "act on it")
+    assert theirs.read_text(encoding="utf-8") == "our security policies\n"
+    assert not (repo / "ci-secure" / "VENDORED.json").exists()
+    assert not (repo / ".github" / "workflows" / "ci-secure.yml").exists()
+
+
+def test_installing_into_a_subdirectory_of_a_repo_refuses(
+        tmp_path: Path) -> None:
+    """`--into` must be the repository root, and the tool can tell.
+
+    A workflow written to `services/api/.github/workflows/` is a file GitHub
+    never reads. The install printed the same success it prints for a correct
+    one, so the adopter is told they have a gate and every pull request merges
+    unscanned — the one silent failure the documentation itself calls out, left
+    to the caller to avoid when the tool has the path in hand.
+    """
+    repo = tmp_path / "acme-app"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True,
+                   capture_output=True)
+    nested = repo / "services" / "api"
+    nested.mkdir(parents=True)
+
+    result = _vendor(nested)
+
+    assert result.returncode != 0, (
+        "vendored into a subdirectory of a repository and reported success - "
+        "the workflow written there is one GitHub never runs")
+    assert not (nested / "ci-secure").exists()
+    assert not (nested / ".github").exists()
+
+
+def test_a_symlinked_destination_inside_the_repo_is_refused(
+        tmp_path: Path) -> None:
+    """Containment is not enough: a symlink can aim at a file in the same repo.
+
+    `ci-secure/LICENSE -> ../.github/workflows/release.yml` stays inside the
+    repository, so a check that only asks "does this leave the repo?" passes
+    it, and `copy2` then writes the licence text over the adopter's release
+    workflow. It is reached by an ordinary contributor pull request planting a
+    symlink under a directory reviewers read as "vendored tool, do not touch",
+    followed by the documented refresh — and the refresh reports success.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    assert _vendor(repo).returncode == 0
+
+    bystander = repo / ".github" / "workflows" / "release.yml"
+    bystander.write_text("name: release\n", encoding="utf-8")
+    licence = repo / "ci-secure" / "LICENSE"
+    licence.unlink()
+    licence.symlink_to(Path("..") / ".github" / "workflows" / "release.yml")
+
+    refresh = _vendor(repo)
+
+    assert refresh.returncode != 0, (
+        "a refresh wrote through a symlink under the vendored tree")
+    assert bystander.read_text(encoding="utf-8") == "name: release\n", (
+        "a refresh destroyed the adopter's release workflow, and said it had "
+        "succeeded")
+
+
+def test_a_destination_that_is_a_plain_file_is_refused_in_words(
+        tmp_path: Path) -> None:
+    """`ci-secure` already existing as a FILE gets a sentence, not a traceback."""
+    repo = tmp_path / "acme-app"
+    repo.mkdir()
+    (repo / "ci-secure").write_text("not a directory\n", encoding="utf-8")
+
+    result = _vendor(repo)
+
+    assert result.returncode != 0
+    assert "Traceback" not in result.stderr, (
+        "the refusal is a stack trace, in a tool whose whole argument is that "
+        f"a failure states its cause: {result.stderr}")
+    assert "ci-secure" in result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("plant", ["listed_in_manifest", "symlinked_cache"])
+def test_planted_bytecode_is_drift_even_when_the_manifest_blesses_it(
+        tmp_path: Path, plant: str) -> None:
+    """The manifest is repository content, so it cannot exempt a `.pyc`.
+
+    The gate loads `config.py` — which defines what blocks — with
+    `exec_module`, and Python runs a `.pyc` beside it without ever comparing
+    it to its source. So one planted in the vendored tree empties the set of
+    outcomes that block while every source file still hashes correctly: a
+    green required check over a repository whose own job summary says FAIL.
+
+    Two routes had to be closed. Adding the `.pyc` to `VENDORED.json` — the
+    attacker controls that file too — made it "recorded", and the recorded
+    short-circuit ran before the bytecode test. Hiding it behind a symlinked
+    `__pycache__` made it invisible to a walk that neither descends symlinks
+    nor reports them. The delete loop already refuses to let the manifest
+    steer it; this sweep was still trusting it.
+    """
+    repo = tmp_path / "acme-app"
+    repo.mkdir()
+    assert _vendor(repo).returncode == 0
+    vendored = repo / "ci-secure"
+
+    if plant == "listed_in_manifest":
+        cache = vendored / "scripts" / "__pycache__"
+        cache.mkdir()
+        pyc = cache / "config.cpython-312.pyc"
+        pyc.write_bytes(b"planted bytecode")
+        manifest_path = vendored / "VENDORED.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["files"]["scripts/__pycache__/config.cpython-312.pyc"] = (
+            hashlib.sha256(pyc.read_bytes()).hexdigest())
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8")
+    else:
+        elsewhere = tmp_path / "build-cache"
+        elsewhere.mkdir()
+        (elsewhere / "config.cpython-312.pyc").write_bytes(b"planted bytecode")
+        (vendored / "scripts" / "__pycache__").symlink_to(elsewhere)
+
+    check = _verify(vendored)
+
+    assert check.returncode == 1, (
+        f"planted bytecode ({plant}) passed --verify, so the adopter's "
+        "required check goes green while the gate executes it")
+    assert "bytecode" in check.stdout, (
+        f"--verify reds but never names the bytecode: {check.stdout}")
+
+
+@pytest.mark.parametrize("manifest_text", [
+    '{"files": []}', '{"files": "scripts/scan.py"}', '{"files": null}',
+    "[]", "null", '{"files": {"scripts/scan.py": null}}',
+])
+def test_a_type_confused_manifest_reds_with_a_reason(
+        tmp_path: Path, manifest_text: str) -> None:
+    """`VENDORED.json` is repository content, so its SHAPE is untrusted too.
+
+    Every shape already failed closed, which is the part that matters, but
+    four of them failed with a bare traceback: a security check going red in
+    someone's pull request with no stated cause, in a tool whose whole
+    argument is that a red says what is wrong and what to do about it.
+    """
+    repo = tmp_path / "acme-app"
+    repo.mkdir()
+    assert _vendor(repo).returncode == 0
+    vendored = repo / "ci-secure"
+    (vendored / "VENDORED.json").write_text(manifest_text, encoding="utf-8")
+
+    check = _verify(vendored)
+
+    assert check.returncode == 1
+    assert "Traceback" not in check.stderr, (
+        f"a malformed manifest reds with a stack trace: {check.stderr}")
+    assert "::error::" in check.stdout, (
+        f"a malformed manifest reds with no annotation: {check.stdout!r}")
 
 
 def test_committed_bytecode_is_drift_and_says_what_to_do_about_it(

--- a/tests/test_ci_secure_scaffold.py
+++ b/tests/test_ci_secure_scaffold.py
@@ -475,11 +475,79 @@ def test_the_installer_installs_exactly_the_files_under_test(
 
 
 def test_the_template_verifies_its_own_vendored_copy(template: dict) -> None:
-    """Drift in the vendored gate must be loud, not discovered at the next refresh."""
-    runs = [s.get("run", "") for s in template["jobs"]["scan"]["steps"]]
-    assert any("vendor.py --verify" in r for r in runs), (
+    """Drift in the vendored gate must be loud, not discovered at the next refresh.
+
+    Asserted as "this line RUNS the checker", not "this line mentions it". A
+    substring test is satisfied by `echo python3 ... --verify`, and the drift
+    check is the only thing between an edited `config.py` — the rule that says
+    which outcomes block — and a green required check: with the step inert, a
+    tampered rule makes the gate exit 0 while its own summary still prints
+    **FAIL** for the fact that failed.
+    """
+    steps = template["jobs"]["scan"]["steps"]
+    verify = [s for s in steps if "vendor.py --verify" in s.get("run", "")]
+    assert len(verify) == 1, (
         "nothing checks the vendored files against VENDORED.json, so a local "
         "edit to the gate would weaken it invisibly")
+    run = verify[0]["run"].strip()
+    assert run.startswith("python3 ci-secure/scripts/vendor.py --verify"), (
+        f"the drift check has to be the command, not a word inside one: {run!r}")
+
+
+def test_the_scan_job_runs_exactly_the_steps_it_declares(template: dict) -> None:
+    """No step may be inserted between the drift check and the gate.
+
+    Everything else here pins what individual steps say. None of it constrains
+    the LIST, and the drift check has already passed by the time a later step
+    runs - so a step slipped in between them can edit the vendored tree with
+    the manifest no longer looking, and the gate then runs the edited rule.
+    Pinning the sequence is what makes the drift check mean "the tree the gate
+    is about to read" rather than "the tree at some earlier moment".
+    """
+    steps = template["jobs"]["scan"]["steps"]
+    shape = [s.get("uses", "").split("@")[0] or s.get("run", "").split()[0]
+             for s in steps]
+    assert shape == ["actions/checkout", "actions/setup-python", "pip",
+                     "python3", "python3"], (
+        f"the scan job's step list changed: {shape}. Every step here runs "
+        "before a verdict that judges the tree, so an addition is a decision, "
+        "not a detail - add it to this list deliberately")
+
+    assert "vendor.py --verify" in steps[-2].get("run", ""), (
+        "the drift check must be the step IMMEDIATELY before the gate")
+    assert steps[-1]["run"].strip().startswith(
+        "python3 ci-secure/scripts/gate.py"), "the gate must be the last step"
+
+
+def test_the_template_keeps_the_pins_and_hardening_it_argues_for(
+        template: dict) -> None:
+    """Three values the file's own comments call load-bearing, and nothing held.
+
+    Each of these could be changed to its weaker form with the whole suite
+    green, while the header went on explaining why it mattered: the weekly run
+    is the only one that demands a COMPLETE network check ("the run that must
+    not be mutable by exhausting API quota"), PyYAML sits "inside the verdict's
+    trust path" because the engine parses workflows with it, and the checkout
+    has no reason to carry a credential.
+    """
+    scan = template["jobs"]["scan"]
+    gate_env = scan["steps"][-1]["env"]
+
+    strict = gate_env["CI_SECURE_GH_STRICT"]
+    assert "github.event_name == 'schedule'" in strict and "'1'" in strict, (
+        "the weekly run must demand a complete network check; a constant here "
+        f"silences it on every trigger: {strict!r}")
+
+    pip = next(s["run"] for s in scan["steps"] if "pip install" in s.get("run", ""))
+    assert "pyyaml==" in pip, (
+        f"PyYAML is what the engine parses workflows with - pin it: {pip!r}")
+
+    checkout = next(s for s in scan["steps"]
+                    if "actions/checkout" in s.get("uses", ""))
+    assert checkout["with"]["persist-credentials"] is False, (
+        "the scan reads the tree and has no reason to hold a credential - and "
+        "the scan itself will not tell you if this is flipped, because the "
+        "credentials fact only looks at untrusted triggers")
 
 
 # --------------------------------------------------------------------------
@@ -1219,3 +1287,108 @@ def test_the_installer_ignores_an_ambient_git_environment(tmp_path: Path) -> Non
     assert (repo / "ci-secure" / "VENDORED.json").is_file()
     assert not (elsewhere / "ci-secure").exists(), (
         "the install must never touch the repository GIT_DIR pointed at")
+
+
+def test_a_file_planted_under_the_vendored_tree_is_drift(tmp_path: Path) -> None:
+    """The manifest says what belongs there, so an ADDITION is drift too.
+
+    This arm is what two of the installer's refusals are built on - the
+    occupied-directory refusal exists precisely because `--verify` reds on
+    anything the manifest does not list. Without it a pull request can add a
+    second `config.py`, or a shim beside the engine, and the drift check that
+    exists to notice the copy is not what was reviewed says it matches.
+    """
+    repo = tmp_path / "acme-app"
+    repo.mkdir()
+    assert _vendor(repo).returncode == 0
+    vendored = repo / "ci-secure"
+
+    (vendored / "scripts" / "sitecustomize.py").write_text(
+        "# not ours\n", encoding="utf-8")
+
+    check = _verify(vendored)
+    assert check.returncode == 1, (
+        "a file added under the vendored tree verified clean:\n" + check.stdout)
+    assert "scripts/sitecustomize.py" in check.stdout
+    assert "not in the manifest" in check.stdout
+
+
+def test_a_bare_pyc_beside_its_source_is_drift(tmp_path: Path) -> None:
+    """Bytecode does not have to sit in `__pycache__` to be loaded first.
+
+    The existing cases all plant under `__pycache__`, so the `.pyc` SUFFIX arm
+    of the same test carried nothing: a manifest-listed
+    `ci-secure/scripts/config.pyc` would have been covered by neither.
+    """
+    repo = tmp_path / "acme-app"
+    repo.mkdir()
+    assert _vendor(repo).returncode == 0
+    vendored = repo / "ci-secure"
+
+    (vendored / "scripts" / "config.pyc").write_bytes(b"\x00compiled")
+
+    check = _verify(vendored)
+    assert check.returncode == 1, check.stdout
+    assert "config.pyc" in check.stdout
+    assert "bytecode" in check.stdout, (
+        "a bare .pyc has to be reported as bytecode that can override its "
+        "source, not merely as an unexpected file")
+
+
+def test_a_manifest_entry_that_escapes_through_a_symlink_is_not_deleted(
+        tmp_path: Path) -> None:
+    """The prune loop's two guards are separate, and each needs its own case.
+
+    The `..`/absolute test and the resolve-containment test were only ever
+    exercised together, so either could be deleted silently. This entry has no
+    `..` and is not absolute - it escapes because a directory in the middle of
+    it is a symlink - so only the second guard can stop it.
+    """
+    repo = tmp_path / "acme-app"
+    repo.mkdir()
+    assert _vendor(repo).returncode == 0
+    vendored = repo / "ci-secure"
+
+    outside = tmp_path / "precious"
+    outside.mkdir()
+    victim = outside / "release.yml"
+    victim.write_text("name: theirs\n", encoding="utf-8")
+    (vendored / "escape").symlink_to(outside, target_is_directory=True)
+
+    manifest_path = vendored / "VENDORED.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["files"]["escape/release.yml"] = "0" * 64
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+                             encoding="utf-8")
+
+    refresh = _vendor(repo)
+
+    assert victim.is_file(), (
+        "a manifest entry deleted a file outside the vendored tree, reached "
+        "through a symlinked directory rather than through `..`:\n"
+        + refresh.stdout)
+    assert victim.read_text(encoding="utf-8") == "name: theirs\n"
+
+
+def test_the_recorded_source_commit_is_a_sha_or_says_why_it_is_not(
+        tmp_path: Path) -> None:
+    """"Which commit is this copy from?" is the manifest's stated reason to exist.
+
+    Asserting only that the field is truthy accepts every `unknown (...)`
+    marker, so provenance could silently become unavailable for every adopter
+    with the suite green - and this repo's rule is that provenance is honest,
+    including the `-dirty` suffix, or it is not recorded at all.
+    """
+    import re
+    repo = tmp_path / "acme-app"
+    repo.mkdir()
+    assert _vendor(repo).returncode == 0
+
+    manifest = json.loads(
+        (repo / "ci-secure" / "VENDORED.json").read_text(encoding="utf-8"))
+    recorded = manifest["source_commit"]
+
+    assert re.fullmatch(r"[0-9a-f]{40}(-dirty| \(working tree state unknown\))?",
+                        recorded), (
+        "vendoring from this source checkout must record its real commit, "
+        f"not a marker: {recorded!r}")


### PR DESCRIPTION
## TL;DR

Today ci-secure tells you what's wrong with your GitHub Actions workflows once, when you ask. Nothing stops the same problem coming back next week. This lets you turn it into a check that runs on every pull request, so a change that weakens CI security shows up before it lands.

**How you use it:** you say *"install ci-secure as a CI check"*. It copies the scanner into your repo and adds one workflow, as a pull request you review and merge. The first run reports findings without blocking anything, so it can't brick your merge path on day one. Once you've fixed them, you delete one flag and add `ci-secure` to your required checks — and from then on a failed security check stops the merge.

Nothing happens on its own: it runs when you ask, it blocks only after *you* make it required, and the scanner lives in your repo rather than being downloaded at build time, so the code judging your pull requests is code you can read and it never changes underneath you.

## Why copy instead of fetch

The obvious design is a workflow that downloads a pinned version of the scanner and runs it. We ship a detector that flags exactly that shape in other people's workflows: a pin can be moved or deleted in a repository you do not control, so a job that fetches and executes code is one upstream compromise away from running whatever arrives. Recommending it to adopters while flagging it in their repos was not defensible, so the setup copies instead.

Copying costs staleness, so the setup writes a manifest — version, source commit, a hash per file — and your CI re-checks it every run. That catches the local edit somebody made while debugging and never removed, which is the failure that actually happens. It is not a tamper seal: anyone who can edit the copied gate can edit the manifest in the same commit, and the docs say so rather than implying more.

```
setup:     you ask  ──>  scanner copied into repo/ci-secure/  +  one workflow  ──>  PR you review
every run: workflow ──verify──> manifest ──> scan ──> verdict ──> check
update:    you ask  ──>  pull request showing exactly what changed
```

## What's in the PR

Every file in the diff, and why it is here.

**The setup itself**
- **`skills/ci-secure/scripts/vendor.py`** (new) — copies the engine, gate and licence into a repository, writes `VENDORED.json`, and re-verifies it later. It is also copied in, because it is what your CI runs to check the copy has not drifted.
- **`skills/ci-secure/scaffold/ci-secure.yml`** (new) — the workflow you get: one scan job, one always-running verdict job carrying the check name. Deliberately not a copy of ours, which arbitrates between two mutually exclusive scan jobs your repo does not have.
- **`skills/ci-secure/scaffold/gate.py`** (new) — the gate. A second copy exists because an installed skill is only `skills/ci-secure/` — there is no `.github/` to copy from. A test holds it byte-identical to the one this repo runs on itself.
- **`skills/ci-secure/LICENSE`** (new) — the same MIT notice as the repo root. The setup copies our code into someone else's repository, and MIT requires the notice to travel with copies; the root file is not inside the installed skill, so without this the setup would have nothing to ship and refuses rather than committing a licence violation. It is a duplicate of the root file with nothing holding the two identical — noted as a follow-up below.

**The gate**
- **`.github/scripts/ci_secure_gate.py`** — gains `--advisory`, which downgrades failed FACTS only; every degraded path stays red. It also now refuses unrecognised arguments instead of ignoring them, and an unset network-check setting instead of silently treating it as off.

**Docs**
- **`skills/ci-secure/SKILL.md`** — the setup section: what to check before writing anything, what gets written, going blocking, updating, rollback.
- **`README.md`** — a section for the feature, since the README previously described only what the scanner finds, making the check undiscoverable.
- **`skills/ci-secure/CHANGELOG.md`** — the entry.

**Tests**
- **`tests/test_ci_secure_scaffold.py`** (new, ~1,400 lines) — identity of the two gate copies, conformance to the declared delta between the template and our workflow, that the template passes the gate it sets up, and the refusal and drift behaviour.
- **`tests/test_ci_secure_gate.py`** — covers the new gate flags and refusals.
- **`skills/ci-secure/tests/test_python_compat.py`** — extended to cover `scaffold/`, not just `scripts/`. The copied gate runs on whatever `python3` an adopter has, so it is the file with the least say over its interpreter and had nothing checking it; one `-> str | None` would have broken every adopter below 3.10 with this suite green.

## What review found

Every serious defect here was the same shape: **a trust boundary documented in a comment and not enforced in code.** Worth stating plainly, because it is the thing to look for in the next change to these files rather than a list of one-off fixes.

**Fork pull requests were handed a token.** The template read `is-a-fork && '' || github.token`. Actions has no ternary — it evaluates `&&`/`||` over truthiness — and the empty string is falsy, so the withholding branch could never be taken and every fork run fell through to the token. The job running pull-request-authored code got the credential the comment directly above it says it must not have. The test meant to cover this only grepped the expression for a substring; it now evaluates it under Actions' own truthiness rules across fork, deleted-fork, same-repo, push and schedule.

**The setup could write outside the repository.** A symlink at `ci-secure` in the target repo was followed by the copy path, which used unresolved paths, while the containment checks guarded only the later delete path. Reproduced: exit 0, nine files written outside the repo, silently. The fix widened into refusing every destination that is not what you think it is — a `ci-secure` directory that already belongs to something else, a setup aimed at a subdirectory of a repo (which produces a workflow in a path GitHub never reads while every step reports success), a redirect that stays inside the repo, and a destination that is a plain file.

**Updating overwrote your workflow file**, silently returning anyone who had gone blocking to advisory — and because that file is deliberately not checksummed, nothing downstream would have caught it. Updates now leave it alone.

**A planted `.pyc` could override a verified source file.** Bytecode is loaded without being compared to its source, so one sitting beside a hash-verified `config.py` wins. It is reported as drift rather than ignored, and the template tells Python not to write bytecode at all.

**Eight one-line edits shipped a gate that could never fail** while every test stayed green — `|| true`, `continue-on-error` on the step or the job (GitHub reports a continue-on-error job to `needs` as success), a step-level `if:` skipping the gate on pull requests, the verdict's `exit 1` flipped to `exit 0`, and repointing the copy's source constants at files no test inspects. All eight now go red.

**The manifest was allowed to define its own domain.** Deleting a vendored file *and* its entry in `VENDORED.json` left every remaining hash correct, so the drift check reported a match. That is not the "anyone who can edit the gate can edit the manifest" caveat this PR already discloses — nothing is edited-with-a-matching-hash, the copy is simply made smaller than the one that was reviewed. It matters most for the file that defines which outcomes block: with the vendored copy gone the gate falls back to a path inside the repository being audited, so one pull request could delete the rule here, add its own there, and be judged by a rule it wrote, under a green drift check.

**The setup asked the wrong repository whether a destination was a repository root.** An exported `GIT_DIR` overrides `git -C`, so under a hook or a rebase the guard read an unrelated repository's toplevel, refused a correct install, and told the adopter to vendor the gate and a live workflow into *that other repository* — the "written somewhere you never looked" outcome the guards exist to prevent, reached through a guard. The same variable made the recorded source commit a stranger's HEAD.

**Repository content reached a log unescaped.** `VENDORED.json` arrives with a fork clone, and the drift step printed its strings straight out: a newline in the recorded version forged an "all clear" annotation on the check run, and one in a file key emitted the command that swallows every drift reason after it, so the step went red with no stated cause.

**Five more tests could not fail**, each proven by mutation rather than argued. `--advisory` ships ON in the workflow every adopter gets, and its scope — failed facts only — was held up entirely by the flag defaulting off: making it a silent no-op, or widening it over the degraded shapes, left the whole suite green. `continue-on-error` on the verdict job's own step, in the one job branch protection requires, was likewise green; the sweep that exists for exactly that stopped at the job. Dropping a file from the vendored set shipped an install whose engine died on import for every adopter, because the end-to-end test never ran the gate its docstring promised to run. And the gate — the file with the least say over its interpreter — sat outside the Python 3.9 compatibility check that covers every file beside it.

Also: PyYAML was fetched unpinned on every run while three surfaces claimed it was pinned — the engine parses workflows with it, so it sits inside the verdict's trust path.

## What is deliberately not in this PR

Review raised four things worth doing that are not defects in what ships here, and folding them in would mean redesigning contracts this PR only consumes:

- The gate's verdict is a boolean accumulated next to a print helper, so "an error was reported and the check exited 0" is a representable state. A small accumulator would make recording a reason and failing the same act.
- `unmeasured` and the advisory-downgradable set are string literals in the gate, in a file whose architecture is that outcome semantics come from the rule, never from a string. They want to be named tables beside the three that already exist.
- Nothing enforces a CODEOWNERS entry on the vendored directory, which the workflow header itself calls half the trust path.
- A hardlinked destination is written through, and a git submodule root passes the "is this a repository root" guard. Neither is reachable through a pull request — git preserves neither across a clone.


## Notes for review

The test with real load is that the workflow we hand people **passes the gate it sets up** — it lands in `.github/workflows/`, so the scanner reads it. Conformance to the declared delta does not imply that; the delta itself could be what trips a fact.

Two facts stay **unmeasured** on any CI token — whether required checks are skippable, and the fork-PR approval policy. Both are admin-scoped API reads, disclosed as a coverage gap and dropped from the score rather than counted as passes.

Requires Python 3.12 and PyYAML, both pinned in the template. The gate itself is stdlib only and must import on 3.9, since it runs on whatever interpreter the adopter has.

**Dogfooded end to end on a real repository**, private, on real GitHub Actions — following this SKILL.md's own instructions rather than calling the script directly:

| step | result |
|---|---|
| setup on a repo that had never been scanned | wrote exactly the documented file list; manifest self-verified against its source commit |
| first run, advisory | `4/6 facts pass of 8 applicable` — two real findings reported as warnings, check green, merge path not bricked |
| burn down, then drop `--advisory` | `6/6 facts pass`, green in blocking mode |
| require the check, then break a fact | merge state `BLOCKED` |
| rollback: un-require the check | no longer blocked, one API call |
| refresh onto a newer version | the adopter's workflow untouched — `--advisory` stayed off, local cron tuning preserved; a committed hand edit to a vendored file appeared in the refresh diff rather than vanishing |
| drift detection | a hand-edited vendored file is caught; so is a file deleted along with its manifest entry |




