### PR TITLE
TEMPORARY probe: does a red ci-secure block the merge?

### DIFF
--- a/.github/workflows/gate-blocking-probe.yml
+++ b/.github/workflows/gate-blocking-probe.yml
@@ -1,0 +1,14 @@
+# TEMPORARY probe: verifies that a failed ci-secure fact actually blocks a merge,
+# not just that the check reports red. Deliberately omits the `permissions:`
+# block, which is one of the config facts ci-secure checks for. This file is
+# deleted as soon as the answer is recorded.
+name: Gate blocking probe
+
+on:
+  workflow_dispatch:
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "probe"


### PR DESCRIPTION
## TL;DR

Temporary. `ci-secure` became a required check on `main` today, but nobody has watched a red one actually disable the merge button — only that the check reports. This adds a workflow with no `permissions:` block, which is one of the config facts the scanner checks, so the check should go red. The moment the answer is recorded this PR is closed and the branch deleted.

Nothing here is meant to merge.