### PR TITLE
Run the shipped code on the oldest Python we promise

### DIFF
--- a/.github/scripts/check_python_floor.py
+++ b/.github/scripts/check_python_floor.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Import every shipped module on the OLDEST Python this repo supports.
+
+`pyproject.toml` declares `requires-python = ">=3.9"` and the README promises
+"python3 (3.9 or newer)". These skills are publicly installed and run against
+whatever `python3` a user happens to have — while every workflow here pins
+3.12. That asymmetry means CI cannot see a floor break: the version that fails
+is the one version CI never runs.
+
+There is already an AST-based guard (`skills/ci-secure/tests/test_python_compat.py`)
+and it is not enough. It catches what 3.9 cannot PARSE, and PEP 604 in
+annotations. It cannot catch code that parses fine on 3.9 and then fails when
+the module body EXECUTES — which is most of the interesting cases:
+
+    re.compile(r"(?P=x)++")   # possessive quantifiers: 3.11+, re.error on 3.9
+    X: TypeAlias = int | str  # evaluated for real, TypeError on 3.9
+    dict1 | dict2             # at module scope, TypeError on 3.8
+
+Three real breaks were found by hand on 2026-08-15 and every one of them was
+of that second kind. Only actually importing the module on a 3.9 interpreter
+finds them, which is what this does.
+
+Each module is imported in its OWN subprocess. One that dies must not take the
+run down with it — the point is to report every broken module in one pass, not
+the first one alphabetically.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+# What ships. `skills/<name>/scripts/` is the engine of each skill;
+# `skills/<name>/scaffold/` is code copied into an adopter's repository, which
+# is the code with the LEAST say over its interpreter — it runs on whatever
+# `python3` the adopter has, in a repo we will never see.
+SHIPPED_GLOBS = ("skills/*/scripts/*.py", "skills/*/scaffold/*.py")
+
+# `tests/` and `maintainers/` are deliberately out of scope: they run here,
+# under the version this repo pins, and never reach a user.
+
+
+def shipped_modules(root: Path = REPO) -> list[Path]:
+    found: list[Path] = []
+    for pattern in SHIPPED_GLOBS:
+        found.extend(root.glob(pattern))
+    return sorted(p for p in found if p.name != "__init__.py")
+
+
+def import_in_subprocess(module: Path) -> tuple[bool, str]:
+    """Import one module by file location. Returns (ok, message)."""
+    code = (
+        "import importlib.util, sys\n"
+        f"spec = importlib.util.spec_from_file_location('_floor_probe', {str(module)!r})\n"
+        "mod = importlib.util.module_from_spec(spec)\n"
+        # Registered in sys.modules BEFORE executing, which is what the real
+        # import system does and what several stdlib features assume. Without
+        # it, `@dataclass` fails with a bare `AttributeError: 'NoneType' object
+        # has no attribute '__dict__'` — dataclasses resolves a field's type by
+        # looking the defining module up as `sys.modules[cls.__module__]`, and
+        # an unregistered module is None. That is a bug in the PROBE that reads
+        # exactly like a bug in the module under test, and it fired on three
+        # healthy modules the first time this ran.
+        "sys.modules[spec.name] = mod\n"
+        # The module's own directory on sys.path: these scripts import their
+        # siblings (`from config import ...`), exactly as they do when a user
+        # runs them from an installed skill.
+        f"sys.path.insert(0, {str(module.parent)!r})\n"
+        "spec.loader.exec_module(mod)\n"
+    )
+    proc = subprocess.run([sys.executable, "-c", code],
+                          capture_output=True, text=True, timeout=120)
+    if proc.returncode == 0:
+        return True, ""
+    tail = (proc.stderr or proc.stdout).strip().splitlines()
+    return False, tail[-1] if tail else f"exited {proc.returncode}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    # `--root` exists so this guard can be pointed at a fixture tree and shown
+    # to FAIL. A guard nobody has watched go red is a guard nobody knows works.
+    parser.add_argument("--root", type=Path, default=REPO)
+    args = parser.parse_args(argv)
+
+    version = ".".join(str(n) for n in sys.version_info[:3])
+    modules = shipped_modules(args.root)
+    if not modules:
+        print("::error::found no shipped modules to check - this guard is "
+              "checking nothing, which is worse than not having it")
+        return 1
+
+    print(f"importing {len(modules)} shipped module(s) on Python {version}")
+    failures = []
+    for module in modules:
+        rel = module.relative_to(args.root)
+        ok, message = import_in_subprocess(module)
+        if ok:
+            print(f"  ok    {rel}")
+        else:
+            print(f"  FAIL  {rel}: {message}")
+            failures.append((rel, message))
+
+    if failures:
+        for rel, message in failures:
+            print(f"::error file={rel}::does not import on Python {version}, "
+                  f"the documented floor: {message}")
+        print(f"::error::{len(failures)} shipped module(s) do not import on "
+              f"Python {version}. This repo pins 3.12 everywhere else, so no "
+              "other check can see this - and a user on the floor gets an "
+              "import error, not a degraded feature.")
+        return 1
+
+    print(f"all {len(modules)} shipped module(s) import on Python {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_python_floor.py
+++ b/.github/scripts/check_python_floor.py
@@ -3,26 +3,31 @@
 
 `pyproject.toml` declares `requires-python = ">=3.9"` and the README promises
 "python3 (3.9 or newer)". These skills are publicly installed and run against
-whatever `python3` a user happens to have — while every workflow here pins
-3.12. That asymmetry means CI cannot see a floor break: the version that fails
-is the one version CI never runs.
+whatever `python3` a user happens to have — while every workflow here that
+installs Python pins 3.12. That asymmetry means CI cannot see a floor break:
+the version that fails is the one version CI never runs.
 
 There is already an AST-based guard (`skills/ci-secure/tests/test_python_compat.py`)
-and it is not enough. It catches what 3.9 cannot PARSE, and PEP 604 in
-annotations. It cannot catch code that parses fine on 3.9 and then fails when
-the module body EXECUTES — which is most of the interesting cases:
+and it is not enough, for two reasons. It reads only ci-secure — the other
+skills have no static floor coverage at all. And it catches what 3.9 cannot
+PARSE, which leaves out the code that parses fine on 3.9 and then fails when
+the module body EXECUTES:
 
-    re.compile(r"(?P=x)++")   # possessive quantifiers: 3.11+, re.error on 3.9
-    X: TypeAlias = int | str  # evaluated for real, TypeError on 3.9
-    dict1 | dict2             # at module scope, TypeError on 3.8
+    re.compile(r"(?P<c>-)(?P=c)++")   # possessive quantifier: re.error below 3.11
+    X: TypeAlias = int | str          # TypeAlias is 3.10+; the union is 3.10+ too
 
-Three real breaks were found by hand on 2026-08-15 and every one of them was
-of that second kind. Only actually importing the module on a 3.9 interpreter
-finds them, which is what this does.
+Both parse cleanly under a 3.9 grammar check and both raise on a 3.9
+interpreter. Only importing the module for real finds them, which is what this
+does. The AST guard keeps its own job: it needs no 3.9 installed, so it still
+answers on a laptop that only has a current Python.
 
 Each module is imported in its OWN subprocess. One that dies must not take the
 run down with it — the point is to report every broken module in one pass, not
 the first one alphabetically.
+
+Note that running the repository's pytest suite on 3.9 is not an alternative:
+the suite itself uses newer syntax in places. Importing the shipped modules is
+the part that has to happen on the floor.
 """
 from __future__ import annotations
 
@@ -37,10 +42,32 @@ REPO = Path(__file__).resolve().parents[2]
 # `skills/<name>/scaffold/` is code copied into an adopter's repository, which
 # is the code with the LEAST say over its interpreter — it runs on whatever
 # `python3` the adopter has, in a repo we will never see.
-SHIPPED_GLOBS = ("skills/*/scripts/*.py", "skills/*/scaffold/*.py")
+#
+# Recursive (`**`) on purpose. A skill is free to organise its engine into
+# subdirectories, and the whole of `skills/<name>/` is copied to a user's
+# machine, so a module one level deeper reaches them exactly the same way. A
+# one-level pattern would walk past it and still report a clean run.
+SHIPPED_GLOBS = (
+    "skills/*/scripts/**/*.py",
+    "skills/*/scaffold/**/*.py",
+    # `verify_report.py` sits under a skill's `tests/` but is not a test. Each
+    # skill's own instructions hand it to the reader as a step to run against
+    # their report, so it executes on a user's interpreter like anything under
+    # `scripts/` does.
+    "skills/*/tests/verify_report.py",
+)
 
-# `tests/` and `maintainers/` are deliberately out of scope: they run here,
-# under the version this repo pins, and never reach a user.
+# `maintainers/` is out of scope: it never leaves this repository, and neither
+# do the repo's own top-level `tests/`. The pytest modules under a skill's
+# `tests/` DO travel to a user — the install copies each skill directory whole
+# — but running them means having pytest and choosing to invoke it, which is a
+# maintainer's workflow and not a user's. Adding them here would install a test
+# framework on the floor to check code no reader runs.
+
+
+# Written by the probe as its final act, and looked for by the parent. See
+# `import_in_subprocess`.
+_COMPLETED = "__floor_probe_reached_the_end__"
 
 
 def shipped_modules(root: Path = REPO) -> list[Path]:
@@ -50,8 +77,15 @@ def shipped_modules(root: Path = REPO) -> list[Path]:
     return sorted(p for p in found if p.name != "__init__.py")
 
 
-def import_in_subprocess(module: Path) -> tuple[bool, str]:
-    """Import one module by file location. Returns (ok, message)."""
+def import_in_subprocess(
+    module: Path, timeout: float = 120.0
+) -> tuple[bool, str, str]:
+    """Import one module by file location.
+
+    Returns (ok, headline, full output). The headline is what goes on the
+    GitHub annotation; the full output is printed beneath it so a red job can
+    be read without reproducing it.
+    """
     code = (
         "import importlib.util, sys\n"
         f"spec = importlib.util.spec_from_file_location('_floor_probe', {str(module)!r})\n"
@@ -70,13 +104,48 @@ def import_in_subprocess(module: Path) -> tuple[bool, str]:
         # runs them from an installed skill.
         f"sys.path.insert(0, {str(module.parent)!r})\n"
         "spec.loader.exec_module(mod)\n"
+        # The verdict is "the module body ran to completion", not merely "the
+        # process did not return nonzero". A module that calls sys.exit(0) at
+        # import — one edit away from the `sys.exit(1)` several of these use
+        # when PyYAML is absent — would otherwise be reported ok while every
+        # line below the exit went unread.
+        f"sys.stdout.write({_COMPLETED!r})\n"
     )
-    proc = subprocess.run([sys.executable, "-c", code],
-                          capture_output=True, text=True, timeout=120)
+    # A module that hangs at import — waiting on stdin, or reaching for the
+    # network at module scope — is as broken on the floor as one that raises,
+    # and it is caught here rather than allowed to escape. Letting
+    # TimeoutExpired propagate would abandon the results already collected and
+    # print a traceback where the per-file annotation belongs; the whole point
+    # of a subprocess per module is that one bad module reports alongside the
+    # others instead of ending the run.
+    try:
+        proc = subprocess.run([sys.executable, "-c", code],
+                              capture_output=True, text=True,
+                              timeout=timeout, stdin=subprocess.DEVNULL)
+    except subprocess.TimeoutExpired:
+        return (False,
+                f"still had not finished importing after {timeout:g}s", "")
+    if proc.returncode == 0 and _COMPLETED in proc.stdout:
+        return True, "", ""
     if proc.returncode == 0:
-        return True, ""
+        return (False,
+                "stopped part-way through its own import without failing",
+                proc.stdout.replace(_COMPLETED, "") + proc.stderr)
     tail = (proc.stderr or proc.stdout).strip().splitlines()
-    return False, tail[-1] if tail else f"exited {proc.returncode}"
+    message = tail[-1] if tail else f"exited {proc.returncode}"
+    if message.startswith(("ModuleNotFoundError", "ImportError")):
+        # Worth separating out. This job installs one third-party package, so a
+        # module that reaches for a second one fails here looking exactly like
+        # a floor break while being nothing of the kind, and the contributor
+        # goes hunting through 3.9 release notes for an answer that is "add it
+        # to the workflow".
+        message += " (a missing dependency rather than a floor break, if this "
+        message += "module needs a package the job does not install)"
+    # The headline is the last line, which for a chained exception is the
+    # outermost one — often the least informative. The full output goes
+    # alongside it so the root cause does not have to be reproduced locally.
+    detail = "".join(part for part in (proc.stdout, proc.stderr) if part)
+    return False, message, detail.replace(_COMPLETED, "")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -84,10 +153,17 @@ def main(argv: list[str] | None = None) -> int:
     # `--root` exists so this guard can be pointed at a fixture tree and shown
     # to FAIL. A guard nobody has watched go red is a guard nobody knows works.
     parser.add_argument("--root", type=Path, default=REPO)
+    # Lowering the limit is how the hang path gets exercised without a test
+    # that takes two minutes to make its point.
+    parser.add_argument("--timeout", type=float, default=120.0,
+                        help="seconds to allow each module's import")
     args = parser.parse_args(argv)
 
+    # Resolved so a root given as a relative path, or through a symlink, still
+    # matches the discovered paths when the per-file annotation is built below.
+    root = args.root.resolve()
     version = ".".join(str(n) for n in sys.version_info[:3])
-    modules = shipped_modules(args.root)
+    modules = shipped_modules(root)
     if not modules:
         print("::error::found no shipped modules to check - this guard is "
               "checking nothing, which is worse than not having it")
@@ -96,12 +172,14 @@ def main(argv: list[str] | None = None) -> int:
     print(f"importing {len(modules)} shipped module(s) on Python {version}")
     failures = []
     for module in modules:
-        rel = module.relative_to(args.root)
-        ok, message = import_in_subprocess(module)
+        rel = module.relative_to(root)
+        ok, message, detail = import_in_subprocess(module, timeout=args.timeout)
         if ok:
             print(f"  ok    {rel}")
         else:
             print(f"  FAIL  {rel}: {message}")
+            for line in detail.strip().splitlines():
+                print(f"        | {line}")
             failures.append((rel, message))
 
     if failures:
@@ -109,9 +187,9 @@ def main(argv: list[str] | None = None) -> int:
             print(f"::error file={rel}::does not import on Python {version}, "
                   f"the documented floor: {message}")
         print(f"::error::{len(failures)} shipped module(s) do not import on "
-              f"Python {version}. This repo pins 3.12 everywhere else, so no "
-              "other check can see this - and a user on the floor gets an "
-              "import error, not a degraded feature.")
+              f"Python {version}. Every other check here runs a newer "
+              "version, so none of them can see this - and a user on the "
+              "floor gets an import error, not a degraded feature.")
         return 1
 
     print(f"all {len(modules)} shipped module(s) import on Python {version}")

--- a/.github/workflows/python-floor.yml
+++ b/.github/workflows/python-floor.yml
@@ -1,16 +1,22 @@
 # Import every shipped module on the OLDEST Python this repo supports.
 #
 # `pyproject.toml` declares `requires-python = ">=3.9"` and the README promises
-# "python3 (3.9 or newer)". Every other workflow here pins 3.12, so the one
-# version that can break is the one version CI never runs — and these skills are
-# publicly installed, executing against whatever `python3` a user happens to
-# have. Three separate floor breaks were found by hand on 2026-08-15, each one
-# invisible to a full green suite.
+# "python3 (3.9 or newer)". Every other workflow here that installs Python pins
+# 3.12, so the one version that can break is the one version CI never runs — and
+# these skills are publicly installed, executing against whatever `python3` a
+# user happens to have. Breaks of this kind have been found by reading the code
+# by hand, each one invisible to a full green suite.
 #
-# There is an AST-based guard too (`skills/*/tests/test_python_compat.py`) and it
-# is not a substitute: it catches what 3.9 cannot PARSE, while every one of those
-# three breaks parsed fine and failed when the module body EXECUTED. Only a real
-# import on a real 3.9 interpreter finds those, which is what this job does.
+# There is an AST-based guard too (`skills/ci-secure/tests/test_python_compat.py`)
+# and it is not a substitute, for two reasons: it reads only ci-secure, and it
+# catches what 3.9 cannot PARSE, while the breaks that motivated this job parsed
+# fine and failed when the module body EXECUTED. Only a real import on a real 3.9
+# interpreter finds those, which is what this job does. The static guard keeps
+# its own value — it needs no 3.9 installed, so it answers on any machine.
+#
+# Running the whole pytest suite on 3.9 is not the alternative: the suite itself
+# uses newer syntax. Importing the shipped modules is the part that must happen
+# on the floor.
 #
 # ONE hosted job, deliberately, where the rest of this repo splits fork from
 # non-fork:
@@ -21,8 +27,14 @@
 #     A fork/non-fork split would need a third always-run verdict job to be
 #     requireable at all, which is a lot of machinery for a check that reads
 #     files and imports them.
-# It does not dogfood StarSling runners for that last reason, and that is the
-# only place it departs from the convention in ci.yml.
+# That is also why it does not run on StarSling runners, and the runner is the
+# only convention it departs from — the added schedule and timeout aside.
+#
+# Being one unconditional job, it also needs no merge-queue handling beyond
+# adding the trigger, unlike the split workflows beside it.
+#
+# To enforce it, add the check named "python floor" to the required status
+# checks on main. Until someone does, it reports but does not block.
 name: Python floor
 
 on:
@@ -30,7 +42,9 @@ on:
   push:
     branches: [main]
   # A floor break can also arrive without a commit of ours — a dependency that
-  # drops 3.9 support, or a runner image change. The weekly run notices.
+  # drops 3.9 support, or a runner image change. The weekly run catches those,
+  # though it only records the red in the Actions tab; nothing here pages
+  # anyone, the same as the other scheduled workflow beside it.
   schedule:
     - cron: "31 5 * * 1"
   workflow_dispatch:
@@ -47,7 +61,11 @@ permissions:
 jobs:
   floor:
     name: python floor
-    runs-on: ubuntu-latest
+    # Pinned rather than `ubuntu-latest`: 3.9 is past end of life, so no build
+    # of it is being produced for newer images. When `ubuntu-latest` advances,
+    # an unpinned job would stop being able to install the floor at all and
+    # fail on the runner image instead of on anything about our code.
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -61,12 +79,17 @@ jobs:
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.9"
-      # The engines import PyYAML; without it every module fails for a reason
-      # that has nothing to do with the floor.
-      - run: pip install pyyaml
+      # Some engine modules import PyYAML and exit if it is absent; without it
+      # they fail for a reason that has nothing to do with the floor. It is the
+      # only third-party package anything shipped here needs.
+      - name: Install the one dependency the engines need
+        run: pip install pyyaml
       - name: Confirm the version really is the floor
         run: |
           set -euo pipefail
           python3 -c "import sys; assert sys.version_info[:2] == (3, 9), sys.version; print(sys.version)"
+      # A per-module budget well under this job's own, so that even several
+      # modules hanging at once still reach the end and report. Importing a
+      # module takes hundredths of a second; 30 is already generous.
       - name: Import every shipped module
-        run: python3 .github/scripts/check_python_floor.py
+        run: python3 .github/scripts/check_python_floor.py --timeout 30

--- a/.github/workflows/python-floor.yml
+++ b/.github/workflows/python-floor.yml
@@ -1,0 +1,72 @@
+# Import every shipped module on the OLDEST Python this repo supports.
+#
+# `pyproject.toml` declares `requires-python = ">=3.9"` and the README promises
+# "python3 (3.9 or newer)". Every other workflow here pins 3.12, so the one
+# version that can break is the one version CI never runs — and these skills are
+# publicly installed, executing against whatever `python3` a user happens to
+# have. Three separate floor breaks were found by hand on 2026-08-15, each one
+# invisible to a full green suite.
+#
+# There is an AST-based guard too (`skills/*/tests/test_python_compat.py`) and it
+# is not a substitute: it catches what 3.9 cannot PARSE, while every one of those
+# three breaks parsed fine and failed when the module body EXECUTED. Only a real
+# import on a real 3.9 interpreter finds those, which is what this job does.
+#
+# ONE hosted job, deliberately, where the rest of this repo splits fork from
+# non-fork:
+#   - it needs no secrets and no token, so there is nothing a fork PR could take;
+#   - it must behave IDENTICALLY for fork and non-fork, since the floor does not
+#     care who wrote the code;
+#   - a single unconditional job is safe to require in branch protection as-is.
+#     A fork/non-fork split would need a third always-run verdict job to be
+#     requireable at all, which is a lot of machinery for a check that reads
+#     files and imports them.
+# It does not dogfood StarSling runners for that last reason, and that is the
+# only place it departs from the convention in ci.yml.
+name: Python floor
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  # A floor break can also arrive without a commit of ours — a dependency that
+  # drops 3.9 support, or a runner image change. The weekly run notices.
+  schedule:
+    - cron: "31 5 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  # `github.event_name` in the key so an ordinary push cannot cancel the weekly
+  # run, which is the only one that catches a break nobody committed.
+  group: python-floor-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  floor:
+    name: python floor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      # THE point of this job. Pinned to the documented floor exactly, not to
+      # "3.9 or newer" — if this ever silently resolved to 3.12 the job would
+      # pass while checking nothing, which is the failure mode it exists to
+      # prevent.
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.9"
+      # The engines import PyYAML; without it every module fails for a reason
+      # that has nothing to do with the floor.
+      - run: pip install pyyaml
+      - name: Confirm the version really is the floor
+        run: |
+          set -euo pipefail
+          python3 -c "import sys; assert sys.version_info[:2] == (3, 9), sys.version; print(sys.version)"
+      - name: Import every shipped module
+        run: python3 .github/scripts/check_python_floor.py

--- a/tests/test_python_floor_guard.py
+++ b/tests/test_python_floor_guard.py
@@ -4,25 +4,33 @@
 oldest Python this repo supports. Two ways for it to be worthless, and both
 have already happened once:
 
-- **It passes over a real break.** The AST guard beside it does exactly that
-  for anything that parses on 3.9 and then fails when the module body runs —
-  a possessive quantifier in a compiled regex, a union evaluated for real.
-  That whole class shipped undetected until someone read the code by hand.
-- **It fails on healthy code.** The first version of the probe did not register
+- **It passes over a real break.** The static guard at
+  `skills/ci-secure/tests/test_python_compat.py` cannot see anything that
+  parses on 3.9 and then fails when the module body runs — a possessive
+  quantifier in a compiled regex, a union evaluated for real.
+- **It fails on healthy code.** An early version of the probe did not register
   the module in `sys.modules` before executing it, so every module using
   `@dataclass` died with `AttributeError: 'NoneType' object has no attribute
-  '__dict__'`. Three healthy modules were reported broken. A guard that cries
-  wolf gets switched off, and then it protects nothing.
+  '__dict__'`. Healthy modules were reported broken. A guard that cries wolf
+  gets switched off, and then it protects nothing.
 
 So both directions are pinned here, against fixture trees rather than against
 the repository, so the assertions are about the GUARD and not about whatever
 the shipped code happens to be today.
+
+Every fixture that must be caught fails on EVERY Python version. This suite
+runs on the version the rest of CI pins, so a fixture that only breaks below
+3.11 would leave the guard's whole failure path asserted by nothing where it
+actually runs. The floor-specific cases are marked and skipped instead.
 """
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 _REPO = Path(__file__).resolve().parents[1]
 _GUARD = _REPO / ".github" / "scripts" / "check_python_floor.py"
@@ -36,71 +44,286 @@ def _tree(root: Path, name: str, body: str) -> Path:
     return root
 
 
-def _run(root: Path):
+def _run(root: Path) -> subprocess.CompletedProcess:
     return subprocess.run(
         [sys.executable, str(_GUARD), "--root", str(root)],
         capture_output=True, text=True)
 
 
+def test_a_module_in_a_subdirectory_is_still_checked(tmp_path: Path) -> None:
+    """A skill may organise its engine into subdirectories, and all of it ships.
+
+    The whole of `skills/<name>/` is copied to a user's machine, so a module
+    at `scripts/helpers/thing.py` reaches them exactly as one at
+    `scripts/thing.py` does. A discovery pattern that only looks one level
+    deep would walk straight past it and report a clean run — the guard
+    passing while the broken file is the one it never opened.
+
+    The fixture deliberately holds a healthy top-level module too. Without
+    it a subdirectory-only tree would find nothing at all and fail for the
+    unrelated "checking nothing" reason, which would pass this test for
+    entirely the wrong cause.
+    """
+    root = _tree(tmp_path, "nested", "VALUE = 1\n")
+    deep = root / "skills" / "nested" / "scripts" / "helpers"
+    deep.mkdir(parents=True, exist_ok=True)
+    # Fails on EVERY Python, so this stays a real assertion on the 3.12
+    # interpreter the test suite runs under, not only on the floor.
+    (deep / "deep.py").write_text(
+        "raise RuntimeError('deep module is broken')\n", encoding="utf-8")
+    proc = _run(root)
+
+    assert proc.returncode == 1, (
+        "a broken module in a scripts/ subdirectory was never opened:\n"
+        + proc.stdout + proc.stderr)
+    assert "deep.py" in proc.stdout
+
+
 def test_the_guard_exists_and_is_wired_into_ci() -> None:
-    """A guard nothing invokes is a file, not a check."""
+    """A guard nothing invokes is a file, not a check.
+
+    The invocation has to be a real `run:` step. Matching the filename
+    anywhere in the file would accept a workflow that only mentions the
+    script in a comment — which is precisely the state this test exists to
+    rule out, and it would certify the guard as wired while it was deleted.
+    """
     assert _GUARD.is_file(), f"{_GUARD} is missing"
-    workflows = (_REPO / ".github" / "workflows").glob("*.yml")
+    workflow_dir = _REPO / ".github" / "workflows"
+    # Both spellings: a rename to `.yaml` is still a workflow GitHub runs, and
+    # failing this test for that alone would be a red with the wrong reason.
+    workflows = list(workflow_dir.glob("*.yml")) + list(workflow_dir.glob("*.yaml"))
     invoked = [w.name for w in workflows
-               if "check_python_floor.py" in w.read_text(encoding="utf-8")]
-    assert invoked, ("no workflow runs check_python_floor.py, so nothing "
-                     "checks the floor on a version CI actually installs")
+               if any(not line.lstrip().startswith("#")
+                      and "check_python_floor.py" in line
+                      for line in w.read_text(encoding="utf-8").splitlines())]
+    assert invoked, ("no workflow actually runs check_python_floor.py, so "
+                     "nothing checks the floor on a version CI installs")
 
 
-def test_healthy_code_passes() -> None:
+def test_healthy_code_passes(tmp_path: Path) -> None:
     """The false-positive direction. This is what broke on the first attempt."""
-    import tempfile
-    with tempfile.TemporaryDirectory() as tmp:
-        root = _tree(Path(tmp), "healthy", (
-            "from __future__ import annotations\n"
-            "from dataclasses import dataclass\n"
-            "\n"
-            "@dataclass\n"
-            "class Thing:\n"
-            "    name: str\n"
-            "    count: int = 0\n"
-        ))
-        proc = _run(root)
+    root = _tree(tmp_path, "healthy", (
+        "from __future__ import annotations\n"
+        "from dataclasses import dataclass\n"
+        "\n"
+        "@dataclass\n"
+        "class Thing:\n"
+        "    name: str\n"
+        "    count: int = 0\n"
+    ))
+    proc = _run(root)
     assert proc.returncode == 0, (
         "the guard reported healthy code as broken:\n" + proc.stdout + proc.stderr)
 
 
-def test_a_runtime_import_failure_is_caught() -> None:
-    """The direction the AST guard cannot cover, and the one that shipped.
+def test_a_module_that_exits_early_is_not_reported_clean(tmp_path: Path) -> None:
+    """Exiting zero part-way through an import is not the same as importing.
 
-    This module PARSES on every version. It fails when the body executes,
-    which is precisely why only a real import on the floor finds it.
+    Several shipped modules call `sys.exit(1)` at module scope when PyYAML is
+    missing, so a module-level exit is an idiom here and one keystroke from a
+    zero. Treating the return code as the whole verdict would mark such a
+    module ok while everything below the exit — where a floor break would
+    live — went unread.
     """
-    import tempfile
-    with tempfile.TemporaryDirectory() as tmp:
-        root = _tree(Path(tmp), "broken", (
-            "import re\n"
-            # Possessive quantifier: valid syntax everywhere, re.error below 3.11.
-            "PATTERN = re.compile(r'(?P<c>-)(?P=c)++')\n"
-        ))
-        proc = _run(root)
+    root = _tree(tmp_path, "bails", (
+        "import re, sys\n"
+        "sys.exit(0)\n"
+        "PATTERN = re.compile(r'(?P<c>-)(?P=c)++')\n"
+    ))
+    proc = _run(root)
+    assert proc.returncode == 1, (
+        "a module that exited before finishing its import was called ok:\n"
+        + proc.stdout)
+    assert "::error file=skills/bails/scripts/mod.py::" in proc.stdout, proc.stdout
 
-    if sys.version_info >= (3, 11):
-        # On a modern interpreter this pattern is legal, so there is nothing to
-        # catch — and saying so is more honest than asserting a pass that means
-        # nothing. CI runs this guard on the floor, where the assertion bites.
-        assert proc.returncode == 0
-        return
+
+def test_a_runtime_import_failure_is_caught(tmp_path: Path) -> None:
+    """The direction the AST guard cannot cover — and it must bite everywhere.
+
+    The fixture parses on every version and fails when the body executes,
+    which is the whole class only a real import can find. Deliberately NOT a
+    version-specific break: this suite runs on 3.12, so a fixture that is only
+    broken below 3.11 would leave the guard's entire failure path — the exit
+    code, the annotation, the reason — asserted by nothing on the interpreter
+    that actually runs it. A guard reporting no failure it ever finds would
+    have passed the earlier version of this test.
+    """
+    root = _tree(tmp_path, "broken", "raise ImportError('simulated floor break')\n")
+    proc = _run(root)
+
     assert proc.returncode == 1, (
         "a module that fails at import time was reported as fine:\n" + proc.stdout)
-    assert "mod.py" in proc.stdout
-    assert "::error" in proc.stdout
+    # The annotation form GitHub renders against the offending file, not a
+    # loose substring: a bare `FAIL` line leaves the reader hunting.
+    assert "::error file=skills/broken/scripts/mod.py::" in proc.stdout, proc.stdout
+    # The reason has to survive as far as the report, or the red is unactionable.
+    assert "simulated floor break" in proc.stdout, proc.stdout
 
 
-def test_an_empty_tree_is_a_failure_not_a_pass() -> None:
+@pytest.mark.skipif(sys.version_info >= (3, 11),
+                    reason="possessive quantifiers are legal here; this bites "
+                           "on the 3.9 floor the CI job runs")
+def test_the_real_break_from_the_floor_is_caught(tmp_path: Path) -> None:
+    """The actual shipped regex that started this, kept as a floor-only case."""
+    root = _tree(tmp_path, "possessive", (
+        "import re\n"
+        "PATTERN = re.compile(r'(?P<c>-)(?P=c)++')\n"
+    ))
+    proc = _run(root)
+    assert proc.returncode == 1, proc.stdout
+    assert "::error file=skills/possessive/scripts/mod.py::" in proc.stdout
+
+
+def test_a_module_importing_its_sibling_still_passes(tmp_path: Path) -> None:
+    """Shipped scripts import each other by bare name, and must keep working.
+
+    Several engines do `from config import ...` against a file beside them,
+    which resolves only because the probe puts the module's own directory on
+    `sys.path` first — exactly as an installed skill does. Drop that and the
+    guard reports healthy code as broken, which is the cry-wolf failure this
+    suite exists to prevent.
+    """
+    root = _tree(tmp_path, "siblings", "from helper import VALUE\n")
+    (root / "skills" / "siblings" / "scripts" / "helper.py").write_text(
+        "VALUE = 1\n", encoding="utf-8")
+    proc = _run(root)
+    assert proc.returncode == 0, (
+        "a module importing its sibling was reported as broken:\n"
+        + proc.stdout + proc.stderr)
+
+
+def test_one_bad_module_does_not_hide_the_others(tmp_path: Path) -> None:
+    """Every broken module in one pass, not the first one alphabetically.
+
+    This is the reason each import gets its own subprocess. Someone
+    refactoring the loop to stop at the first failure would send a
+    contributor round the same red job once per broken file.
+    """
+    root = _tree(tmp_path, "aaa", "raise ImportError('first one')\n")
+    _tree(root, "mmm", "raise ImportError('second one')\n")
+    _tree(root, "zzz", "VALUE = 1\n")
+    proc = _run(root)
+
+    assert proc.returncode == 1, proc.stdout
+    assert "::error file=skills/aaa/scripts/mod.py::" in proc.stdout, proc.stdout
+    assert "::error file=skills/mmm/scripts/mod.py::" in proc.stdout, proc.stdout
+    assert "ok    skills/zzz/scripts/mod.py" in proc.stdout, proc.stdout
+
+
+def test_a_module_that_hangs_is_reported_not_left_to_run(tmp_path: Path) -> None:
+    """A module that never finishes importing is as broken as one that raises.
+
+    It must be named like any other failure. Letting the wait escape would
+    throw away the modules already checked and print a stack trace where the
+    per-file annotation belongs.
+    """
+    root = _tree(tmp_path, "aaa-hangs", "import time\ntime.sleep(600)\n")
+    _tree(root, "zzz", "VALUE = 1\n")
+    proc = subprocess.run(
+        [sys.executable, str(_GUARD), "--root", str(root), "--timeout", "2"],
+        capture_output=True, text=True)
+
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "::error file=skills/aaa-hangs/scripts/mod.py::" in proc.stdout, proc.stdout
+    assert "Traceback" not in proc.stderr, proc.stderr
+    # The healthy module after it in the run order still got its verdict.
+    assert "ok    skills/zzz/scripts/mod.py" in proc.stdout, proc.stdout
+
+
+def test_a_module_reading_stdin_fails_fast(tmp_path: Path) -> None:
+    """Nothing may block on input that a CI runner will never provide."""
+    root = _tree(tmp_path, "asks", "ANSWER = input('are you there? ')\n")
+    proc = subprocess.run(
+        [sys.executable, str(_GUARD), "--root", str(root), "--timeout", "30"],
+        capture_output=True, text=True, timeout=60)
+    assert proc.returncode == 1, proc.stdout
+    assert "::error file=skills/asks/scripts/mod.py::" in proc.stdout, proc.stdout
+
+
+def test_the_job_installs_the_version_the_project_promises() -> None:
+    """The floor is declared in one place and must be honoured in the other.
+
+    `pyproject.toml` is where the promise lives. If someone raises it to 3.10
+    and the job keeps installing 3.9, the check drifts into testing a version
+    nobody claims; if the job's pin drifts upward, it passes while checking
+    nothing — the exact failure its own comment warns about.
+    """
+    declared = re.search(r'requires-python\s*=\s*"[><=~^]*\s*(\d+\.\d+)"',
+                         (_REPO / "pyproject.toml").read_text(encoding="utf-8"))
+    assert declared, "pyproject.toml no longer declares a requires-python floor"
+    floor = declared.group(1)
+
+    workflow = (_REPO / ".github" / "workflows" / "python-floor.yml").read_text(
+        encoding="utf-8")
+    pinned = re.search(r'python-version:\s*"([^"]+)"', workflow)
+    assert pinned, "the floor job no longer pins a python-version"
+    assert pinned.group(1) == floor, (
+        f"pyproject promises Python {floor} but the floor job installs "
+        f"{pinned.group(1)}")
+
+    major, minor = floor.split(".")
+    asserted = f"sys.version_info[:2] == ({major}, {minor})"
+    assert asserted in workflow, (
+        f"the job does not confirm the interpreter really is {floor}; without "
+        f"that it can silently resolve to a newer version and pass while "
+        f"checking nothing")
+
+
+def test_a_module_the_instructions_hand_to_a_reader_is_in_scope() -> None:
+    """Whatever a skill tells someone to run has to import on the floor.
+
+    `verify_report.py` lives under a skill's `tests/` but is not a test — the
+    skill's own instructions present it as a step. It reaches a reader's
+    interpreter like anything under `scripts/`, so leaving it out on the
+    strength of its parent directory's name would be a hole with a tidy
+    explanation.
+    """
+    sys.path.insert(0, str(_GUARD.parent))
+    try:
+        import check_python_floor
+    finally:
+        sys.path.pop(0)
+
+    covered = {p.relative_to(_REPO).as_posix()
+               for p in check_python_floor.shipped_modules(_REPO)}
+    for skill_md in (_REPO / "skills").glob("*/SKILL.md"):
+        target = skill_md.parent / "tests" / "verify_report.py"
+        if not target.is_file():
+            continue
+        if "tests/verify_report.py" not in skill_md.read_text(encoding="utf-8"):
+            continue
+        assert target.relative_to(_REPO).as_posix() in covered, (
+            f"{skill_md.name} tells a reader to run {target.name}, but the "
+            "floor check never imports it")
+
+
+def test_an_empty_tree_is_a_failure_not_a_pass(tmp_path: Path) -> None:
     """Zero modules checked must never read as zero problems found."""
-    import tempfile
-    with tempfile.TemporaryDirectory() as tmp:
-        proc = _run(Path(tmp))
+    proc = _run(tmp_path)
     assert proc.returncode == 1
     assert "checking nothing" in proc.stdout
+
+
+def test_no_shipped_module_shadows_a_standard_library_name() -> None:
+    """The probe puts a module's own directory first on the import path.
+
+    That is what lets these scripts import their siblings by bare name, and it
+    means a shipped file called `types.py` or `logging.py` would stand in
+    front of the standard library for everything imported after it — inside
+    this check and on a user's machine alike. The failure would be baffling in
+    both places.
+    """
+    sys.path.insert(0, str(_GUARD.parent))
+    try:
+        import check_python_floor
+    finally:
+        sys.path.pop(0)
+
+    stdlib = getattr(sys, "stdlib_module_names", None)
+    if stdlib is None:  # pragma: no cover - only on the 3.9 floor
+        pytest.skip("sys.stdlib_module_names arrived in 3.10")
+
+    for module in check_python_floor.shipped_modules(_REPO):
+        assert module.stem not in stdlib, (
+            f"{module.relative_to(_REPO)} shadows the standard library's "
+            f"{module.stem} module for anything imported after it")

--- a/tests/test_python_floor_guard.py
+++ b/tests/test_python_floor_guard.py
@@ -1,0 +1,106 @@
+"""The floor guard must be able to fail, and must not fire on healthy code.
+
+`.github/scripts/check_python_floor.py` imports every shipped module on the
+oldest Python this repo supports. Two ways for it to be worthless, and both
+have already happened once:
+
+- **It passes over a real break.** The AST guard beside it does exactly that
+  for anything that parses on 3.9 and then fails when the module body runs —
+  a possessive quantifier in a compiled regex, a union evaluated for real.
+  That whole class shipped undetected until someone read the code by hand.
+- **It fails on healthy code.** The first version of the probe did not register
+  the module in `sys.modules` before executing it, so every module using
+  `@dataclass` died with `AttributeError: 'NoneType' object has no attribute
+  '__dict__'`. Three healthy modules were reported broken. A guard that cries
+  wolf gets switched off, and then it protects nothing.
+
+So both directions are pinned here, against fixture trees rather than against
+the repository, so the assertions are about the GUARD and not about whatever
+the shipped code happens to be today.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+_GUARD = _REPO / ".github" / "scripts" / "check_python_floor.py"
+
+
+def _tree(root: Path, name: str, body: str) -> Path:
+    """A fixture laid out like a shipped skill: skills/<name>/scripts/*.py."""
+    d = root / "skills" / name / "scripts"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "mod.py").write_text(body, encoding="utf-8")
+    return root
+
+
+def _run(root: Path):
+    return subprocess.run(
+        [sys.executable, str(_GUARD), "--root", str(root)],
+        capture_output=True, text=True)
+
+
+def test_the_guard_exists_and_is_wired_into_ci() -> None:
+    """A guard nothing invokes is a file, not a check."""
+    assert _GUARD.is_file(), f"{_GUARD} is missing"
+    workflows = (_REPO / ".github" / "workflows").glob("*.yml")
+    invoked = [w.name for w in workflows
+               if "check_python_floor.py" in w.read_text(encoding="utf-8")]
+    assert invoked, ("no workflow runs check_python_floor.py, so nothing "
+                     "checks the floor on a version CI actually installs")
+
+
+def test_healthy_code_passes() -> None:
+    """The false-positive direction. This is what broke on the first attempt."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _tree(Path(tmp), "healthy", (
+            "from __future__ import annotations\n"
+            "from dataclasses import dataclass\n"
+            "\n"
+            "@dataclass\n"
+            "class Thing:\n"
+            "    name: str\n"
+            "    count: int = 0\n"
+        ))
+        proc = _run(root)
+    assert proc.returncode == 0, (
+        "the guard reported healthy code as broken:\n" + proc.stdout + proc.stderr)
+
+
+def test_a_runtime_import_failure_is_caught() -> None:
+    """The direction the AST guard cannot cover, and the one that shipped.
+
+    This module PARSES on every version. It fails when the body executes,
+    which is precisely why only a real import on the floor finds it.
+    """
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _tree(Path(tmp), "broken", (
+            "import re\n"
+            # Possessive quantifier: valid syntax everywhere, re.error below 3.11.
+            "PATTERN = re.compile(r'(?P<c>-)(?P=c)++')\n"
+        ))
+        proc = _run(root)
+
+    if sys.version_info >= (3, 11):
+        # On a modern interpreter this pattern is legal, so there is nothing to
+        # catch — and saying so is more honest than asserting a pass that means
+        # nothing. CI runs this guard on the floor, where the assertion bites.
+        assert proc.returncode == 0
+        return
+    assert proc.returncode == 1, (
+        "a module that fails at import time was reported as fine:\n" + proc.stdout)
+    assert "mod.py" in proc.stdout
+    assert "::error" in proc.stdout
+
+
+def test_an_empty_tree_is_a_failure_not_a_pass() -> None:
+    """Zero modules checked must never read as zero problems found."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp:
+        proc = _run(Path(tmp))
+    assert proc.returncode == 1
+    assert "checking nothing" in proc.stdout


### PR DESCRIPTION
## TL;DR

Our skills promise they run on Python 3.9 and every workflow here tests them on 3.12 — so the one version that can break is the one version CI never runs. Breaks of this kind have been caught by reading the code by hand, each against a fully green suite. This adds a job that imports every shipped module on a real 3.9 interpreter, which is the only thing that finds them.

```
before:  green suite on 3.12  ->  broken import on a user's 3.9
after:   green suite on 3.12  +  25 modules imported on 3.9  ->  red before merge
```

## Why the guard we already had doesn't cover this

`skills/ci-secure/tests/test_python_compat.py` parses each module and checks for things 3.9 cannot read. That is a real guard and it stays — it needs no 3.9 installed, so it answers on any machine. But it reads only ci-secure, and it cannot see code that parses fine on 3.9 and then fails when the module body runs:

```python
re.compile(r"(?P<c>-)(?P=c)++")    # parses everywhere; re.error below 3.11
```

No amount of static reading finds that. You have to import it on the version in question.

## What's in the PR

- **`.github/scripts/check_python_floor.py`** — imports every module that ships, each in its own subprocess so one failure reports all the others instead of stopping at the first. A module has to reach the end of its own import to count, so exiting early is not mistaken for importing cleanly. Modules that hang, and dependencies that are simply missing, are reported as what they are rather than as floor breaks. `--root` lets it be pointed at a fixture tree, so the guard itself can be shown to fail.
- **`.github/workflows/python-floor.yml`** — one hosted job pinned to 3.9 exactly, plus an assertion that the interpreter really is 3.9 (a job that silently resolved to 3.12 would pass while checking nothing). Runs on pull requests, pushes to main, and weekly — a floor break can arrive without a commit of ours, from a dependency dropping support.
- **`tests/test_python_floor_guard.py`** — pins every direction: healthy code passes, an import-time failure is caught, a module in a subdirectory is not walked past, an early exit is not read as success, a hang is reported by name, an empty tree is a failure rather than a vacuous pass, and the version the job installs matches the version `pyproject.toml` promises.

## Scope

Everything under a skill's `scripts/` and `scaffold/`, at any depth, plus `verify_report.py` — which sits under a skill's `tests/` but is not a test: each skill's instructions hand it to the reader as a step to run. 25 modules today. The pytest files are left out because running them means having pytest and choosing to invoke it, which is a maintainer's workflow rather than a reader's.

## Proof it works, against real broken code

Not a synthetic mutant — the tree from the open PR #43, which is `mergeState=CLEAN` today:

```
FAIL  skills/ci-speedup/scripts/blocking_path.py: re.error: multiple repeat at position 52
FAIL  skills/ci-speedup/scripts/untrusted_wrap.py: re.error: multiple repeat at position 52
exit=1
```

On this branch, and on every one of the last twelve commits to `main`, all shipped modules import on 3.9 and the check exits 0. So nothing currently on `main` is broken — the case above is what a break looks like when it arrives.

## One thing worth knowing

An early version of this probe reported **three healthy modules as broken**. It did not register the module in `sys.modules` before executing it, and `@dataclass` resolves a field's type through `sys.modules[cls.__module__]` — which was `None`. A guard that cries wolf gets switched off and then protects nothing, so the false-positive direction is pinned by its own tests.

## After merge

Add the check named **`python floor`** to the required status checks on `main`. Until someone does, it reports but does not block.
