### PR TITLE
README: one linkable install section per skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,25 @@
 # StarSling Skills
 
 Public agent skills from StarSling, for auditing your **GitHub Actions** CI.
-Each skill is self-contained and installs on its own — take one, or all three.
 
-| Skill | What it answers | Install |
+```bash
+npx skills add starslingdev/skills
+```
+
+Pick the skills you want and your agent (Claude Code, Codex, Cursor, …). Add
+`-g` to install for every project instead of just this one. Each section below
+gives the one-line command for that skill on its own.
+
+| Skill | What it answers | |
 |---|---|---|
 | [**ci-secure**](#ci-secure) | Can someone attack me through my CI? | [jump ↓](#ci-secure) |
 | [**ci-speedup**](#ci-speedup) | Why is my CI slow? | [jump ↓](#ci-speedup) |
 | [**ci-score**](#ci-score) | Is my CI following best practices? | [jump ↓](#ci-score) |
 
-Every skill runs from a local checkout of the repo you want audited, and none of
-them send your code, logs, or findings to StarSling or anyone else.
-
-**Installing works the same for all three** — one command, no account, nothing to
-configure:
-
-```bash
-npx skills add starslingdev/skills --skill <name> --agent claude-code -y
-```
-
-- **`--agent`** — swap in your own: `codex`, `cursor`, `github-copilot`,
-  `gemini-cli`, `windsurf`, `zed`, `opencode`, and
-  [many more](https://github.com/vercel-labs/skills). Use `--agent '*'` to
-  install for every agent you have.
-- **`-g`** — install once for every project instead of just this one. Without
-  it, the skill lands in `./.claude/skills/` (or your agent's equivalent) and
-  only applies here.
-- The [`skills`](https://github.com/vercel-labs/skills) CLI is Vercel's, fetched
-  fresh by `npx`, so you always get the current version.
-
-**What you need**, whichever you install: **`python3` 3.9+** and **PyYAML**
-(`pip install pyyaml`) to read your workflow files. `ci-speedup` additionally
-needs an authenticated **GitHub CLI** (`gh auth login`) because it reads your
-real run history; for `ci-secure` that is optional, and `ci-score` never touches
-the network.
+All three run from a local checkout and send your code, logs, and findings
+nowhere. They need **`python3` 3.9+** and **PyYAML** (`pip install pyyaml`);
+`ci-speedup` also needs **`gh auth login`**, because it reads your real run
+history.
 
 ---
 
@@ -48,38 +34,31 @@ npx skills add starslingdev/skills --skill ci-secure --agent claude-code -y
 
 Then ask your agent **`/ci-secure`**, or just *"is my CI secure?"*
 
-`ci-secure` scans your workflows for the **ten critical CI/CD attack vectors** —
-template injection in `run:` blocks, fork code executed with privileges (pwn
-requests), `pull_request_target` jobs that poison the shared cache, impostor
-action SHAs, whole-context secret dumps, `$GITHUB_ENV` / `$GITHUB_PATH` hijack,
-`pull-requests: write` granted to untrusted triggers, credential files swept into
-caches and artifacts, unverified remote code execution (`curl | bash` and
-mutable fetch-and-run), and dependency install scripts
-running in a job that holds secrets. Every finding comes with the exact file and
-line, evidence taken from your own workflow, and a plain-English **"what an
-attacker could do"** scenario — then the skill offers to fix the ones you pick,
-dispatching a subagent per finding group that applies the
-[catalog](skills/ci-secure/references/security-patterns.md) recipe and leaves the
-diff in your working tree to review. It never commits, pushes, or opens a PR on
-its own. Alongside the findings it reports a short set of pass/fail **config
-hygiene checks** (declared `permissions:`, CODEOWNERS coverage of
-`.github/workflows/`, `secrets: inherit`, credential-persisting checkouts, and
-more).
+It scans your workflows for the [ten critical CI/CD attack
+vectors](skills/ci-secure/references/security-patterns.md) — template injection
+in `run:` blocks, fork code executed with privileges (pwn requests),
+`pull_request_target` jobs that poison the shared cache, impostor action SHAs,
+whole-context secret dumps, `$GITHUB_ENV` / `$GITHUB_PATH` hijack,
+`pull-requests: write` on untrusted triggers, credential files swept into caches
+and artifacts, unverified remote code execution (`curl | bash` and mutable
+fetch-and-run), and dependency install scripts running in a job that holds
+secrets.
 
-**It is deliberately not comprehensive, and it renders no security score.** The
-catalog is a closed set of ten vectors, each a complete outsider → compromise
-chain with a real incident behind it (the admission test and the rejection record
-are in
-[references/why-these-ten.md](skills/ci-secure/references/why-these-ten.md));
-every report repeats *"critical exploit-chain checks only — this is not a
-comprehensive audit."* There is no grade, ratio, or `N/100` anywhere a reader
-sees: findings are open doors and hygiene checks are armor, they move
-independently, and neither is a score. **Zero findings is a first-class result**
-— a clean run says so plainly instead of padding with lesser observations, and a
-check that could not run is always reported as *did not run*, never as a pass.
-The scan runs locally in seconds from your checkout; `gh` is optional and used
-only for the impostor-SHA check and for noting which findings sit in dormant
-workflows.
+Every finding names the file and line, quotes the evidence from your own
+workflow, and explains in plain English **what an attacker could do** with it.
+Then the skill offers to fix the ones you pick, leaving the diff in your working
+tree to review — it never commits, pushes, or opens a PR. It also reports
+pass/fail **config hygiene checks** (declared `permissions:`, CODEOWNERS on
+`.github/workflows/`, `secrets: inherit`, credential-persisting checkouts).
+
+**It is deliberately not comprehensive, and renders no security score.** The
+catalog is a closed set of ten, each a complete outsider → compromise chain with
+a real incident behind it — the admission test and what was rejected are in
+[why-these-ten.md](skills/ci-secure/references/why-these-ten.md). Findings are
+open doors and hygiene checks are armor; they move independently, so neither is
+a grade. **Zero findings is a first-class result**, and a check that could not
+run is reported as *did not run*, never as a pass. Runs in seconds; `gh` is
+optional, used only for the impostor-SHA check and dormant-workflow notes.
 
 ---
 
@@ -92,36 +71,27 @@ npx skills add starslingdev/skills --skill ci-speedup --agent claude-code -y
 ```
 
 Then ask your agent **`/ci-speedup`**, or just *"why is my CI slow?"*
-Needs `gh auth login` — this one reads your real runs.
 
-`ci-speedup` produces a **root-cause-analysis report** of what makes your CI
-slow, on two measured axes:
+It reports on two measured axes, never blended into one number:
 
-- **Developer wall-clock wait**: the merge-gating critical path, the slowest
-  checks a pull request waits on before it can go green. This is the ranking
-  axis, the thing engineers feel.
-- **Runner-minutes**: the cloud bill. Sized per finding and reported as a
-  secondary axis (a fix can cut the bill while adding developer wait, so the two
-  are never blended into one number).
+- **Developer wall-clock wait** — the merge-gating critical path, the slowest
+  checks a PR waits on. This is the ranking axis, the thing engineers feel.
+- **Runner-minutes** — the cloud bill, sized per finding. A fix can cut the bill
+  while adding developer wait, so the two stay separate.
 
-It works from **real run history**, not estimates: per-job P50/P95 timings
-sampled over the `gh` API, the critical path re-derived from the actual job
-graph. Findings come from a
-[catalog](skills/ci-speedup/references/optimization-patterns.md) of **70+
-optimization patterns across 14 categories** (missing caches, redundant setup,
-sleep-based readiness, unsharded test jobs, full-history checkout, dead env
-vars, build-cache misconfig, queue time, and more) plus a structural track
-routed from the measured long pole.
+The numbers come from **real run history**: per-job P50/P95 sampled over the
+`gh` API, the critical path re-derived from your actual job graph. Findings come
+from a [catalog](skills/ci-speedup/references/optimization-patterns.md) of 70+
+patterns across 14 categories — missing caches, redundant setup, sleep-based
+readiness, unsharded test jobs, full-history checkout, queue time, and more.
 
-**ci-speedup diagnoses; it does not prescribe the fix.** A generic tool can't
-see a file's intent or whether a "waste" is deliberate, so instead of a
-baked-in diff, every finding ships a ready-to-paste **agent prompt** that hands
-the measured root cause to *your own* coding agent, which reads the real logs and
-the file's git history before shaping a safe change. Detection, ranking, and
-every measured number are deterministic; the only place an LLM steps in is a
-log-grounded gap-fill when a drilled pole matches no catalog detector.
+**It diagnoses; it does not prescribe.** A generic tool can't see a file's
+intent or whether a "waste" is deliberate, so every finding ships a
+ready-to-paste **agent prompt** that hands the measured root cause to your own
+coding agent, which reads the real logs and git history before shaping a change.
+Detection, ranking, and every measured number are deterministic.
 
-There is a walkthrough of a full run, without cloning anything, at
+Walkthrough of a full run, no cloning required:
 [starsling.dev/ci-speedup](https://starsling.dev/ci-speedup).
 
 ---
@@ -135,114 +105,59 @@ fixes.**
 npx skills add starslingdev/skills --skill ci-score --agent claude-code -y
 ```
 
-Then ask your agent **`/ci-score`**, or just *"grade my CI"*.
-Runs fully offline — no network access at all.
+Then ask your agent **`/ci-score`**, or just *"grade my CI"*. Runs fully
+offline.
 
-`ci-score` grades a repository's GitHub Actions **configuration** against CI best
-practices and hands back concrete fixes for every gap: eleven configuration facts
-(dependency caching, shallow checkout, test sharding, concurrency cancellation,
-path filters, job timeouts, action pinning, OIDC token scoping, and more), each
-self-verifiable in the repo's own workflow YAML in under a minute. The score is
-checks passed over checks applicable; the report ranks one fix per failed check
-by impact × risk, each with a fix recipe and a ready-to-paste **agent prompt**.
+Eleven configuration facts — dependency caching, shallow checkout, test
+sharding, concurrency cancellation, path filters, job timeouts, action pinning,
+OIDC token scoping, and more — each self-verifiable in your own workflow YAML in
+under a minute. The score is checks passed over checks applicable; the report
+ranks one fix per failed check by impact × risk, each with a recipe and a
+ready-to-paste agent prompt.
 
-**It measures adherence, not speed.** A faster repo can hold a lower score, and
-the report says so beside the card — never read the score as a speed verdict.
-It is also **not a security audit**: exactly two of the eleven checks (action
-pinning, job-scoped OIDC tokens) happen to be security-related, and it claims
-nothing further. For measured wall-clock and runner-minute audits, that is a
-different question — use [`ci-speedup`](#ci-speedup). For an actual security
-review, use [`ci-secure`](#ci-secure).
+**It measures adherence, not speed** — a faster repo can hold a lower score, and
+the report says so beside the card. It is **not a security audit** either: two
+of the eleven checks happen to be security-related, and it claims nothing
+further. For speed use [`ci-speedup`](#ci-speedup); for security,
+[`ci-secure`](#ci-secure).
 
 ---
 
-## First run
+## What a ci-speedup run costs
 
-**Requirements:**
-
-- An authenticated **GitHub CLI** (`gh auth login`) — **required by `ci-speedup`
-  only.** Its run-history data pass reads the audited repo's Actions
-  run/job/log data through read-only `gh` API calls; a token with read access to
-  the repo's Actions is enough. `ci-score` never uses the network at all, and
-  `ci-secure` treats `gh` as optional: with it, the impostor-SHA check, the
-  dormancy notes, and the two config facts read over the API run; without it,
-  the scan still runs and the report says which checks went unmeasured.
-- **`python3` (3.9 or newer)** and **PyYAML**: the bundled scripts are
-  stdlib-only apart from one third-party dependency, **PyYAML**, which the
-  scanner uses to parse your workflow YAML. Install it with `pip install pyyaml`
-  (or `python3 -m pip install pyyaml`).
-
-**What `ci-speedup` does:** it defaults to the repo you're in (and confirms the
-target with you first), samples your recent CI runs over the `gh` API, and closes by leading
-with the biggest measured lever, the slowest check gating your merge and how much
-developer wait it costs, then lets you pick what to fix. The full markdown report
-is **opt-in**: it is rendered and integrity-checked internally on every run, and
-**"Save the full report"** is one of the offered options. Pick it and the
-verified report is written to `./ci-speedup-findings-report.md` in your working
-directory (a generated artifact you can gitignore or delete).
-
-**Cost / timing (measured on a mid-size OSS repo):** the data pass made **314
-`gh` API calls in ~51s** (the committed `pallets/flask` example). Larger repos
-sample more (the `microsoft/playwright` example: 824 calls in ~3m 07s; a
-very-high-volume monorepo like next.js measured ~1,800 calls in ~8m); the pass
-is frugal by design
-(one workflow list, one total-count per workflow, one log per pole, and an
-adaptive two-pass job-list sample). It sends **nothing** to StarSling or any
-third party. See [SECURITY.md](SECURITY.md) for the data-handling model.
+It defaults to the repo you're in, confirms the target first, then samples your
+recent runs. Measured: **314 `gh` API calls in ~51s** on `pallets/flask`; 824
+calls in ~3m on `microsoft/playwright`; ~1,800 in ~8m on a next.js-sized
+monorepo. The full markdown report is **opt-in** — pick *"Save the full report"*
+and it writes `./ci-speedup-findings-report.md`. See
+[SECURITY.md](SECURITY.md) for the data-handling model.
 
 ## Learn more
 
-**ci-secure:**
+**ci-secure** — [SKILL.md](skills/ci-secure/SKILL.md) ·
+[the ten-vector catalog](skills/ci-secure/references/security-patterns.md) ·
+[why these ten](skills/ci-secure/references/why-these-ten.md)
 
-- [`skills/ci-secure/SKILL.md`](skills/ci-secure/SKILL.md): the full skill
-  contract.
-- [`skills/ci-secure/references/security-patterns.md`](skills/ci-secure/references/security-patterns.md):
-  the ten-vector catalog — what each vector is, how it is detected, and its fix
-  recipe. Every finding in a report links back into it.
-- [`skills/ci-secure/references/why-these-ten.md`](skills/ci-secure/references/why-these-ten.md):
-  the admission test for the catalog, and the record of what was rejected.
+**ci-speedup** — [SKILL.md](skills/ci-speedup/SKILL.md) ·
+[methodology](docs/methodology.md) ·
+[pattern catalog](skills/ci-speedup/references/optimization-patterns.md) ·
+[provenance](PROVENANCE.md) · [sample report](examples/)
 
-**ci-score:**
-
-- [`skills/ci-score/SKILL.md`](skills/ci-score/SKILL.md): the full skill
-  contract.
-- [`skills/ci-score/references/ci-score-methodology.md`](skills/ci-score/references/ci-score-methodology.md):
-  the rubric write-up — what each of the eleven checks means and why it is
-  graded.
-- [`skills/ci-score/references/ci-score-spec.json`](skills/ci-score/references/ci-score-spec.json):
-  the frozen CI Score registry (v0.1.3).
-
-**ci-speedup:**
-
-- [`docs/methodology.md`](docs/methodology.md): how the numbers are measured
-  (P50 over sampled runs, the merge-gating critical path, measured vs modeled,
-  adaptive sampling, why it diagnoses instead of prescribing).
-- [`skills/ci-speedup/SKILL.md`](skills/ci-speedup/SKILL.md): the full skill
-  contract.
-- [`skills/ci-speedup/references/optimization-patterns.md`](skills/ci-speedup/references/optimization-patterns.md):
-  the pattern catalog.
-- [`skills/ci-speedup/references/wall-clock-methodology.md`](skills/ci-speedup/references/wall-clock-methodology.md)
-  and [`savings-methodology.md`](skills/ci-speedup/references/savings-methodology.md):
-  the in-skill methodology references.
-- [`PROVENANCE.md`](PROVENANCE.md): how the detection catalog was developed and
-  validated.
-- [`examples/`](examples/): a sanitized sample report showing the output shape.
-- [starsling.dev/ci-speedup](https://starsling.dev/ci-speedup): the skill's
-  landing page — what a run does, walked through end to end, without cloning
-  anything.
+**ci-score** — [SKILL.md](skills/ci-score/SKILL.md) ·
+[rubric write-up](skills/ci-score/references/ci-score-methodology.md) ·
+[frozen registry (v0.1.3)](skills/ci-score/references/ci-score-spec.json)
 
 ## For maintainers
 
-The skill's self-improvement loop infrastructure (the gap→catalog, transcript,
-and dogfood loops) lives **outside** the installable skill, under
-[`maintainers/ci-speedup/`](maintainers/ci-speedup/), so the `skills` CLI never
-copies it into an install. It runs locally via Claude Code only, never as a
-GitHub Action. See [`maintainers/ci-speedup/MAINTAINERS.md`](maintainers/ci-speedup/MAINTAINERS.md).
+The self-improvement loop infrastructure lives **outside** the installable
+skill, under [`maintainers/ci-speedup/`](maintainers/ci-speedup/), so the
+`skills` CLI never copies it into an install; it runs locally via Claude Code,
+never as a GitHub Action. See
+[MAINTAINERS.md](maintainers/ci-speedup/MAINTAINERS.md).
 
-This repo's CI runs on [StarSling Runners](https://starsling.dev/). Fork PRs
-run the identical suite on GitHub-hosted runners (the `test (fork)` job in
-[`ci.yml`](.github/workflows/ci.yml)); untrusted code never executes on the
-self-hosted runners. See [CONTRIBUTING.md](CONTRIBUTING.md).
+This repo's CI runs on [StarSling Runners](https://starsling.dev/). Fork PRs run
+the identical suite on GitHub-hosted runners, so untrusted code never executes
+on the self-hosted ones. See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # StarSling Skills - Self-Driving CI using your own AI agents
 
-**Public agent skills from StarSling, for auditing your GitHub Actions CI.**
+**Agent skills from StarSling, for optimizing your GitHub Actions.**
 
 [![skills.sh](https://skills.sh/b/starslingdev/skills)](https://skills.sh/starslingdev/skills)
 [![CI](https://github.com/starslingdev/skills/actions/workflows/ci.yml/badge.svg)](https://github.com/starslingdev/skills/actions/workflows/ci.yml)
@@ -26,6 +26,10 @@ gives the one-line command for that skill on its own.
 | 🏎️ [**ci-speedup**](#ci-speedup) | Why is my CI slow? |
 | 📋 [**ci-score**](#ci-score) | Is my CI config following best practices? |
 | 🔒 [**ci-secure**](#ci-secure) | Can someone attack me through my CI? |
+
+Each run ends the same way: your agent offers to fix the findings you pick, or
+to just save the full report as markdown. Fixes land in your working tree for
+you to review, and nothing is ever committed, pushed, or opened as a PR.
 
 All three run from a local checkout and need **`python3` 3.9+** and **PyYAML**
 (`pip install pyyaml`). `ci-speedup` also needs **`gh auth login`**, because it
@@ -57,6 +61,10 @@ re-derived from your actual job graph, then matched against a
 from wasteful, so each finding ships a ready-to-paste prompt handing the root
 cause to your own agent, which reads the logs and git history before changing
 anything.
+
+Example reports from real runs:
+[`pallets/flask`](examples/pallets-flask/ci-speedup-findings-report.md) and
+[`microsoft/playwright`](examples/microsoft-playwright/ci-speedup-findings-report.md).
 
 Learn more: [starsling.dev/ci-speedup](https://starsling.dev/ci-speedup)
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,11 @@
 
 # StarSling Skills
 
-**Agent skills from [StarSling](https://starsling.dev), for optimizing your
-GitHub Actions.**
+Agent skills from StarSling, for optimizing your GitHub Actions.
 
 [![skills.sh](https://skills.sh/b/starslingdev/skills)](https://skills.sh/starslingdev/skills)
-[![CI](https://github.com/starslingdev/skills/actions/workflows/ci.yml/badge.svg)](https://github.com/starslingdev/skills/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/github/license/starslingdev/skills)](LICENSE)
 
-🏎️ **[ci-speedup](#ci-speedup)** · 📋 **[ci-score](#ci-score)** · 🔒 **[ci-secure](#ci-secure)**
+[Website](https://starsling.dev)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Pick the skills you want and your agent (Claude Code, Codex, Cursor, …). Add
 `-g` to install for every project instead of just this one. Each section below
 gives the one-line command for that skill on its own.
 
-| Skill | What it answers | |
-|---|---|---|
-| [**ci-secure**](#ci-secure) | Can someone attack me through my CI? | [jump ↓](#ci-secure) |
-| [**ci-speedup**](#ci-speedup) | Why is my CI slow? | [jump ↓](#ci-speedup) |
-| [**ci-score**](#ci-score) | Is my CI following best practices? | [jump ↓](#ci-score) |
+| Skill | What it answers | | |
+|---|---|---|---|
+| [**ci-secure**](#ci-secure) | Can someone attack me through my CI? | [jump ↓](#ci-secure) | [overview](https://starsling.dev/ci-secure) |
+| [**ci-speedup**](#ci-speedup) | Why is my CI slow? | [jump ↓](#ci-speedup) | [overview](https://starsling.dev/ci-speedup) |
+| [**ci-score**](#ci-score) | Is my CI following best practices? | [jump ↓](#ci-score) | [overview](https://starsling.dev/ci-score) |
 
 All three run from a local checkout and send your code, logs, and findings
 nowhere. They need **`python3` 3.9+** and **PyYAML** (`pip install pyyaml`);
@@ -29,10 +29,11 @@ history.
 your secrets.**
 
 ```bash
-npx skills add starslingdev/skills --skill ci-secure --agent claude-code -y
+npx skills add starslingdev/skills --skill ci-secure
 ```
 
-Then ask your agent **`/ci-secure`**, or just *"is my CI secure?"*
+Then invoke it by name (**`/ci-secure`**, or `$ci-secure` in Codex), or just
+ask *"is my CI secure?"*
 
 It scans your workflows for the [ten critical CI/CD attack
 vectors](skills/ci-secure/references/security-patterns.md) — template injection
@@ -60,6 +61,9 @@ a grade. **Zero findings is a first-class result**, and a check that could not
 run is reported as *did not run*, never as a pass. Runs in seconds; `gh` is
 optional, used only for the impostor-SHA check and dormant-workflow notes.
 
+What a run looks like, without installing anything:
+[starsling.dev/ci-secure](https://starsling.dev/ci-secure).
+
 ---
 
 ## ci-speedup
@@ -67,10 +71,11 @@ optional, used only for the impostor-SHA check and dormant-workflow notes.
 **Measures what actually makes your CI slow, from your own run history.**
 
 ```bash
-npx skills add starslingdev/skills --skill ci-speedup --agent claude-code -y
+npx skills add starslingdev/skills --skill ci-speedup
 ```
 
-Then ask your agent **`/ci-speedup`**, or just *"why is my CI slow?"*
+Then invoke it by name (**`/ci-speedup`**, or `$ci-speedup` in Codex), or just
+ask *"why is my CI slow?"*
 
 It reports on two measured axes, never blended into one number:
 
@@ -91,7 +96,7 @@ ready-to-paste **agent prompt** that hands the measured root cause to your own
 coding agent, which reads the real logs and git history before shaping a change.
 Detection, ranking, and every measured number are deterministic.
 
-Walkthrough of a full run, no cloning required:
+What a run looks like, without installing anything:
 [starsling.dev/ci-speedup](https://starsling.dev/ci-speedup).
 
 ---
@@ -102,11 +107,11 @@ Walkthrough of a full run, no cloning required:
 fixes.**
 
 ```bash
-npx skills add starslingdev/skills --skill ci-score --agent claude-code -y
+npx skills add starslingdev/skills --skill ci-score
 ```
 
-Then ask your agent **`/ci-score`**, or just *"grade my CI"*. Runs fully
-offline.
+Then invoke it by name (**`/ci-score`**, or `$ci-score` in Codex), or just ask
+*"grade my CI"*. Runs fully offline.
 
 Eleven configuration facts — dependency caching, shallow checkout, test
 sharding, concurrency cancellation, path filters, job timeouts, action pinning,
@@ -120,6 +125,9 @@ the report says so beside the card. It is **not a security audit** either: two
 of the eleven checks happen to be security-related, and it claims nothing
 further. For speed use [`ci-speedup`](#ci-speedup); for security,
 [`ci-secure`](#ci-secure).
+
+What a run looks like, without installing anything:
+[starsling.dev/ci-score](https://starsling.dev/ci-score).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Each skill is self-contained and installs on its own — take one, or all three.
 
 | Skill | What it answers | Install |
 |---|---|---|
-| [**ci-secure**](#ci-secure) | Can someone take over my CI? | [jump ↓](#ci-secure) |
-| [**ci-speedup**](#ci-speedup) | Why is my CI slow, and what does it cost? | [jump ↓](#ci-speedup) |
-| [**ci-score**](#ci-score) | Is my CI config following best practices? | [jump ↓](#ci-score) |
+| [**ci-secure**](#ci-secure) | Can someone attack me through my CI? | [jump ↓](#ci-secure) |
+| [**ci-speedup**](#ci-speedup) | Why is my CI slow? | [jump ↓](#ci-speedup) |
+| [**ci-score**](#ci-score) | Is my CI following best practices? | [jump ↓](#ci-score) |
 
 Every skill runs from a local checkout of the repo you want audited, and none of
 them send your code, logs, or findings to StarSling or anyone else.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ template injection in `run:` blocks, fork code executed with privileges (pwn
 requests), `pull_request_target` jobs that poison the shared cache, impostor
 action SHAs, whole-context secret dumps, `$GITHUB_ENV` / `$GITHUB_PATH` hijack,
 `pull-requests: write` granted to untrusted triggers, credential files swept into
-caches and artifacts, unverified `curl | bash`, and dependency install scripts
+caches and artifacts, unverified remote code execution (`curl | bash` and
+mutable fetch-and-run), and dependency install scripts
 running in a job that holds secrets. Every finding comes with the exact file and
 line, evidence taken from your own workflow, and a plain-English **"what an
 attacker could do"** scenario — then the skill offers to fix the ones you pick,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# StarSling Skills - Self-Driving CI using your own AI agents
+# StarSling Skills - speed, security, and best practices for your GitHub Actions
 
 **Agent skills from StarSling, for optimizing your GitHub Actions.**
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # StarSling Skills
 
+[![skills.sh](https://skills.sh/b/starslingdev/skills)](https://skills.sh/starslingdev/skills)
+[![CI](https://github.com/starslingdev/skills/actions/workflows/ci.yml/badge.svg)](https://github.com/starslingdev/skills/actions/workflows/ci.yml)
+[![Registry scan](https://github.com/starslingdev/skills/actions/workflows/registry-scan.yml/badge.svg)](https://github.com/starslingdev/skills/actions/workflows/registry-scan.yml)
+
 Public agent skills from StarSling, for auditing your **GitHub Actions** CI.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <div align="center">
 
-# StarSling Skills - speed, security, and best practices for your GitHub Actions
+# StarSling Skills
 
-**Agent skills from StarSling, for optimizing your GitHub Actions.**
+**Agent skills from [StarSling](https://starsling.dev), for optimizing your
+GitHub Actions.**
 
 [![skills.sh](https://skills.sh/b/starslingdev/skills)](https://skills.sh/starslingdev/skills)
 [![CI](https://github.com/starslingdev/skills/actions/workflows/ci.yml/badge.svg)](https://github.com/starslingdev/skills/actions/workflows/ci.yml)
-[![Registry scan](https://github.com/starslingdev/skills/actions/workflows/registry-scan.yml/badge.svg)](https://github.com/starslingdev/skills/actions/workflows/registry-scan.yml)
 [![License: MIT](https://img.shields.io/github/license/starslingdev/skills)](LICENSE)
 
 🏎️ **[ci-speedup](#ci-speedup)** · 📋 **[ci-score](#ci-score)** · 🔒 **[ci-secure](#ci-secure)**

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Agent skills from StarSling, for optimizing your GitHub Actions.
 
 [![skills.sh](https://skills.sh/b/starslingdev/skills)](https://skills.sh/starslingdev/skills)
 
-[Website](https://starsling.dev)
+[Website](https://starsling.dev/skills)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# StarSling Skills — Self-Driving CI using your own AI agents
+# StarSling Skills - Self-Driving CI using your own AI agents
 
 **Public agent skills from StarSling, for auditing your GitHub Actions CI.**
 
@@ -27,9 +27,9 @@ gives the one-line command for that skill on its own.
 | 🔒 [**ci-secure**](#ci-secure) | Can someone attack me through my CI? |
 
 All three run from a local checkout and send your code, logs, and findings
-nowhere ([data handling](SECURITY.md)). They need **`python3` 3.9+** and **PyYAML** (`pip install pyyaml`);
-`ci-speedup` also needs **`gh auth login`**, because it reads your real run
-history.
+nowhere ([data handling](SECURITY.md)). They need **`python3` 3.9+** and
+**PyYAML** (`pip install pyyaml`); `ci-speedup` also needs **`gh auth login`**,
+because it reads your real run history.
 
 ---
 
@@ -45,10 +45,10 @@ Then invoke it by name (**`/ci-speedup`**, or `$ci-speedup` in Codex), or just
 ask *"why is my CI slow?"*
 
 It reports two axes, never blended: **developer wall-clock wait** (the
-merge-gating critical path — the ranking axis, the thing engineers feel) and
-**runner-minutes** (the bill). The numbers come from real runs — per-job P50/P95
-sampled over the `gh` API, the critical path re-derived from your actual job
-graph — matched against a
+merge-gating critical path, and the axis findings rank on, because it is what
+engineers feel) and **runner-minutes** (the bill). The numbers come from real
+runs: per-job P50/P95 sampled over the `gh` API, with the critical path
+re-derived from your actual job graph, then matched against a
 [catalog](skills/ci-speedup/references/optimization-patterns.md) of 70+ patterns.
 
 **It diagnoses; it does not prescribe.** A generic tool can't tell deliberate
@@ -72,13 +72,13 @@ npx skills add starslingdev/skills --skill ci-score
 Then invoke it by name (**`/ci-score`**, or `$ci-score` in Codex), or just ask
 *"grade my CI"*. Runs fully offline.
 
-Eleven configuration facts — caching, shallow checkout, sharding, concurrency
-cancellation, path filters, timeouts, action pinning, OIDC scoping and more —
+Eleven configuration facts (caching, shallow checkout, sharding, concurrency
+cancellation, path filters, timeouts, action pinning, OIDC scoping and more),
 each checkable in your own workflow YAML in under a minute. The score is checks
 passed over checks applicable; every failed check gets one ranked fix.
 
-**It measures adherence, not speed**, and it is **not a security audit** — two
-of the eleven checks are security-adjacent and it claims nothing further.
+**It measures adherence, not speed**, and it is **not a security audit**: two
+of the eleven checks are security-adjacent, and it claims nothing further.
 
 Learn more: [starsling.dev/ci-score](https://starsling.dev/ci-score)
 
@@ -97,13 +97,13 @@ Then invoke it by name (**`/ci-secure`**, or `$ci-secure` in Codex), or just
 ask *"is my CI secure?"*
 
 It scans for the [ten critical attack
-vectors](skills/ci-secure/references/security-patterns.md) — template injection,
+vectors](skills/ci-secure/references/security-patterns.md): template injection,
 fork code run with privileges, cache poisoning, impostor action SHAs, secret
 dumps, `$GITHUB_ENV` hijack, write tokens on untrusted triggers, credentials in
 caches and artifacts, unverified remote code execution, and install scripts
 running beside secrets. Each finding names the file and line, quotes your own
 workflow, and says in plain English **what an attacker could do**. It then
-offers to fix the ones you pick, leaving the diff in your tree — it never
+offers to fix the ones you pick, leaving the diff in your tree. It never
 commits, pushes, or opens a PR.
 
 **Deliberately not comprehensive, and no security score.** Ten closed-set
@@ -113,6 +113,8 @@ is a first-class result**, and a check that could not run says *did not run*,
 never "pass".
 
 Learn more: [starsling.dev/ci-secure](https://starsling.dev/ci-secure)
+
+---
 
 ## For maintainers
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
-# StarSling Skills
+<div align="center">
+
+# StarSling Skills — Self-Driving CI using your own AI agents
+
+**Public agent skills from StarSling, for auditing your GitHub Actions CI.**
 
 [![skills.sh](https://skills.sh/b/starslingdev/skills)](https://skills.sh/starslingdev/skills)
 [![CI](https://github.com/starslingdev/skills/actions/workflows/ci.yml/badge.svg)](https://github.com/starslingdev/skills/actions/workflows/ci.yml)
 [![Registry scan](https://github.com/starslingdev/skills/actions/workflows/registry-scan.yml/badge.svg)](https://github.com/starslingdev/skills/actions/workflows/registry-scan.yml)
 
-Public agent skills from StarSling, for auditing your **GitHub Actions** CI.
+🏎️ **[ci-speedup](#ci-speedup)** · 📋 **[ci-score](#ci-score)** · 🔒 **[ci-secure](#ci-secure)**
+
+</div>
 
 ```bash
 npx skills add starslingdev/skills
@@ -14,11 +20,11 @@ Pick the skills you want and your agent (Claude Code, Codex, Cursor, …). Add
 `-g` to install for every project instead of just this one. Each section below
 gives the one-line command for that skill on its own.
 
-| Skill | What it answers | | |
-|---|---|---|---|
-| [**ci-speedup**](#ci-speedup) | Why is my CI slow? | [jump ↓](#ci-speedup) | [overview](https://starsling.dev/ci-speedup) |
-| [**ci-score**](#ci-score) | Is my CI following best practices? | [jump ↓](#ci-score) | [overview](https://starsling.dev/ci-score) |
-| [**ci-secure**](#ci-secure) | Can someone attack me through my CI? | [jump ↓](#ci-secure) | [overview](https://starsling.dev/ci-secure) |
+| Skill | What it answers |
+|---|---|
+| 🏎️ [**ci-speedup**](#ci-speedup) | Why is my CI slow? |
+| 📋 [**ci-score**](#ci-score) | Is my CI following best practices? |
+| 🔒 [**ci-secure**](#ci-secure) | Can someone attack me through my CI? |
 
 All three run from a local checkout and send your code, logs, and findings
 nowhere. They need **`python3` 3.9+** and **PyYAML** (`pip install pyyaml`);
@@ -29,7 +35,7 @@ history.
 
 ## ci-speedup
 
-**Measures what actually makes your CI slow, from your own run history.**
+🏎️ **Measures what actually makes your CI slow, from your own run history.**
 
 ```bash
 npx skills add starslingdev/skills --skill ci-speedup
@@ -38,33 +44,25 @@ npx skills add starslingdev/skills --skill ci-speedup
 Then invoke it by name (**`/ci-speedup`**, or `$ci-speedup` in Codex), or just
 ask *"why is my CI slow?"*
 
-It reports on two measured axes, never blended into one number:
+It reports two axes, never blended: **developer wall-clock wait** (the
+merge-gating critical path — the ranking axis, the thing engineers feel) and
+**runner-minutes** (the bill). The numbers come from real runs — per-job P50/P95
+sampled over the `gh` API, the critical path re-derived from your actual job
+graph — matched against a
+[catalog](skills/ci-speedup/references/optimization-patterns.md) of 70+ patterns.
 
-- **Developer wall-clock wait** — the merge-gating critical path, the slowest
-  checks a PR waits on. This is the ranking axis, the thing engineers feel.
-- **Runner-minutes** — the cloud bill, sized per finding. A fix can cut the bill
-  while adding developer wait, so the two stay separate.
+**It diagnoses; it does not prescribe.** A generic tool can't tell deliberate
+from wasteful, so each finding ships a ready-to-paste prompt handing the root
+cause to your own agent, which reads the logs and git history before changing
+anything.
 
-The numbers come from **real run history**: per-job P50/P95 sampled over the
-`gh` API, the critical path re-derived from your actual job graph. Findings come
-from a [catalog](skills/ci-speedup/references/optimization-patterns.md) of 70+
-patterns across 14 categories — missing caches, redundant setup, sleep-based
-readiness, unsharded test jobs, full-history checkout, queue time, and more.
-
-**It diagnoses; it does not prescribe.** A generic tool can't see a file's
-intent or whether a "waste" is deliberate, so every finding ships a
-ready-to-paste **agent prompt** that hands the measured root cause to your own
-coding agent, which reads the real logs and git history before shaping a change.
-Detection, ranking, and every measured number are deterministic.
-
-What a run looks like, without installing anything:
-[starsling.dev/ci-speedup](https://starsling.dev/ci-speedup).
+[See a run →](https://starsling.dev/ci-speedup)
 
 ---
 
 ## ci-score
 
-**Grades your CI configuration against best practices, and hands back the
+📋 **Grades your CI configuration against best practices, and hands back the
 fixes.**
 
 ```bash
@@ -74,27 +72,21 @@ npx skills add starslingdev/skills --skill ci-score
 Then invoke it by name (**`/ci-score`**, or `$ci-score` in Codex), or just ask
 *"grade my CI"*. Runs fully offline.
 
-Eleven configuration facts — dependency caching, shallow checkout, test
-sharding, concurrency cancellation, path filters, job timeouts, action pinning,
-OIDC token scoping, and more — each self-verifiable in your own workflow YAML in
-under a minute. The score is checks passed over checks applicable; the report
-ranks one fix per failed check by impact × risk, each with a recipe and a
-ready-to-paste agent prompt.
+Eleven configuration facts — caching, shallow checkout, sharding, concurrency
+cancellation, path filters, timeouts, action pinning, OIDC scoping and more —
+each checkable in your own workflow YAML in under a minute. The score is checks
+passed over checks applicable; every failed check gets one ranked fix.
 
-**It measures adherence, not speed** — a faster repo can hold a lower score, and
-the report says so beside the card. It is **not a security audit** either: two
-of the eleven checks happen to be security-related, and it claims nothing
-further. For speed use [`ci-speedup`](#ci-speedup); for security,
-[`ci-secure`](#ci-secure).
+**It measures adherence, not speed**, and it is **not a security audit** — two
+of the eleven checks are security-adjacent and it claims nothing further.
 
-What a run looks like, without installing anything:
-[starsling.dev/ci-score](https://starsling.dev/ci-score).
+[See a run →](https://starsling.dev/ci-score)
 
 ---
 
 ## ci-secure
 
-**Finds the ten ways an outsider can take over your GitHub Actions and steal
+🔒 **Finds the ten ways an outsider can take over your GitHub Actions and steal
 your secrets.**
 
 ```bash
@@ -104,34 +96,23 @@ npx skills add starslingdev/skills --skill ci-secure
 Then invoke it by name (**`/ci-secure`**, or `$ci-secure` in Codex), or just
 ask *"is my CI secure?"*
 
-It scans your workflows for the [ten critical CI/CD attack
-vectors](skills/ci-secure/references/security-patterns.md) — template injection
-in `run:` blocks, fork code executed with privileges (pwn requests),
-`pull_request_target` jobs that poison the shared cache, impostor action SHAs,
-whole-context secret dumps, `$GITHUB_ENV` / `$GITHUB_PATH` hijack,
-`pull-requests: write` on untrusted triggers, credential files swept into caches
-and artifacts, unverified remote code execution (`curl | bash` and mutable
-fetch-and-run), and dependency install scripts running in a job that holds
-secrets.
+It scans for the [ten critical attack
+vectors](skills/ci-secure/references/security-patterns.md) — template injection,
+fork code run with privileges, cache poisoning, impostor action SHAs, secret
+dumps, `$GITHUB_ENV` hijack, write tokens on untrusted triggers, credentials in
+caches and artifacts, unverified remote code execution, and install scripts
+running beside secrets. Each finding names the file and line, quotes your own
+workflow, and says in plain English **what an attacker could do**. It then
+offers to fix the ones you pick, leaving the diff in your tree — it never
+commits, pushes, or opens a PR.
 
-Every finding names the file and line, quotes the evidence from your own
-workflow, and explains in plain English **what an attacker could do** with it.
-Then the skill offers to fix the ones you pick, leaving the diff in your working
-tree to review — it never commits, pushes, or opens a PR. It also reports
-pass/fail **config hygiene checks** (declared `permissions:`, CODEOWNERS on
-`.github/workflows/`, `secrets: inherit`, credential-persisting checkouts).
+**Deliberately not comprehensive, and no security score.** Ten closed-set
+vectors, each a full outsider → compromise chain with a real incident behind it
+([why these ten](skills/ci-secure/references/why-these-ten.md)). **Zero findings
+is a first-class result**, and a check that could not run says *did not run*,
+never "pass".
 
-**It is deliberately not comprehensive, and renders no security score.** The
-catalog is a closed set of ten, each a complete outsider → compromise chain with
-a real incident behind it — the admission test and what was rejected are in
-[why-these-ten.md](skills/ci-secure/references/why-these-ten.md). Findings are
-open doors and hygiene checks are armor; they move independently, so neither is
-a grade. **Zero findings is a first-class result**, and a check that could not
-run is reported as *did not run*, never as a pass. Runs in seconds; `gh` is
-optional, used only for the impostor-SHA check and dormant-workflow notes.
-
-What a run looks like, without installing anything:
-[starsling.dev/ci-secure](https://starsling.dev/ci-secure).
+[See a run →](https://starsling.dev/ci-secure)
 
 ---
 
@@ -143,21 +124,6 @@ calls in ~3m on `microsoft/playwright`; ~1,800 in ~8m on a next.js-sized
 monorepo. The full markdown report is **opt-in** — pick *"Save the full report"*
 and it writes `./ci-speedup-findings-report.md`. See
 [SECURITY.md](SECURITY.md) for the data-handling model.
-
-## Learn more
-
-**ci-speedup** — [SKILL.md](skills/ci-speedup/SKILL.md) ·
-[methodology](docs/methodology.md) ·
-[pattern catalog](skills/ci-speedup/references/optimization-patterns.md) ·
-[provenance](PROVENANCE.md) · [sample report](examples/)
-
-**ci-score** — [SKILL.md](skills/ci-score/SKILL.md) ·
-[rubric write-up](skills/ci-score/references/ci-score-methodology.md) ·
-[frozen registry (v0.1.3)](skills/ci-score/references/ci-score-spec.json)
-
-**ci-secure** — [SKILL.md](skills/ci-secure/SKILL.md) ·
-[the ten-vector catalog](skills/ci-secure/references/security-patterns.md) ·
-[why these ten](skills/ci-secure/references/why-these-ten.md)
 
 ## For maintainers
 

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ Learn more: [starsling.dev/ci-score](https://starsling.dev/ci-score)
 
 ## ci-secure
 
-🔒 **Finds the ten ways an outsider can take over your GitHub Actions and steal
-your secrets.**
+🔒 **Finds ten critical attack vectors an outsider could exploit, and fixes
+them.**
 
 ```bash
 npx skills add starslingdev/skills --skill ci-secure

--- a/README.md
+++ b/README.md
@@ -16,57 +16,14 @@ gives the one-line command for that skill on its own.
 
 | Skill | What it answers | | |
 |---|---|---|---|
-| [**ci-secure**](#ci-secure) | Can someone attack me through my CI? | [jump ↓](#ci-secure) | [overview](https://starsling.dev/ci-secure) |
 | [**ci-speedup**](#ci-speedup) | Why is my CI slow? | [jump ↓](#ci-speedup) | [overview](https://starsling.dev/ci-speedup) |
 | [**ci-score**](#ci-score) | Is my CI following best practices? | [jump ↓](#ci-score) | [overview](https://starsling.dev/ci-score) |
+| [**ci-secure**](#ci-secure) | Can someone attack me through my CI? | [jump ↓](#ci-secure) | [overview](https://starsling.dev/ci-secure) |
 
 All three run from a local checkout and send your code, logs, and findings
 nowhere. They need **`python3` 3.9+** and **PyYAML** (`pip install pyyaml`);
 `ci-speedup` also needs **`gh auth login`**, because it reads your real run
 history.
-
----
-
-## ci-secure
-
-**Finds the ten ways an outsider can take over your GitHub Actions and steal
-your secrets.**
-
-```bash
-npx skills add starslingdev/skills --skill ci-secure
-```
-
-Then invoke it by name (**`/ci-secure`**, or `$ci-secure` in Codex), or just
-ask *"is my CI secure?"*
-
-It scans your workflows for the [ten critical CI/CD attack
-vectors](skills/ci-secure/references/security-patterns.md) — template injection
-in `run:` blocks, fork code executed with privileges (pwn requests),
-`pull_request_target` jobs that poison the shared cache, impostor action SHAs,
-whole-context secret dumps, `$GITHUB_ENV` / `$GITHUB_PATH` hijack,
-`pull-requests: write` on untrusted triggers, credential files swept into caches
-and artifacts, unverified remote code execution (`curl | bash` and mutable
-fetch-and-run), and dependency install scripts running in a job that holds
-secrets.
-
-Every finding names the file and line, quotes the evidence from your own
-workflow, and explains in plain English **what an attacker could do** with it.
-Then the skill offers to fix the ones you pick, leaving the diff in your working
-tree to review — it never commits, pushes, or opens a PR. It also reports
-pass/fail **config hygiene checks** (declared `permissions:`, CODEOWNERS on
-`.github/workflows/`, `secrets: inherit`, credential-persisting checkouts).
-
-**It is deliberately not comprehensive, and renders no security score.** The
-catalog is a closed set of ten, each a complete outsider → compromise chain with
-a real incident behind it — the admission test and what was rejected are in
-[why-these-ten.md](skills/ci-secure/references/why-these-ten.md). Findings are
-open doors and hygiene checks are armor; they move independently, so neither is
-a grade. **Zero findings is a first-class result**, and a check that could not
-run is reported as *did not run*, never as a pass. Runs in seconds; `gh` is
-optional, used only for the impostor-SHA check and dormant-workflow notes.
-
-What a run looks like, without installing anything:
-[starsling.dev/ci-secure](https://starsling.dev/ci-secure).
 
 ---
 
@@ -135,6 +92,49 @@ What a run looks like, without installing anything:
 
 ---
 
+## ci-secure
+
+**Finds the ten ways an outsider can take over your GitHub Actions and steal
+your secrets.**
+
+```bash
+npx skills add starslingdev/skills --skill ci-secure
+```
+
+Then invoke it by name (**`/ci-secure`**, or `$ci-secure` in Codex), or just
+ask *"is my CI secure?"*
+
+It scans your workflows for the [ten critical CI/CD attack
+vectors](skills/ci-secure/references/security-patterns.md) — template injection
+in `run:` blocks, fork code executed with privileges (pwn requests),
+`pull_request_target` jobs that poison the shared cache, impostor action SHAs,
+whole-context secret dumps, `$GITHUB_ENV` / `$GITHUB_PATH` hijack,
+`pull-requests: write` on untrusted triggers, credential files swept into caches
+and artifacts, unverified remote code execution (`curl | bash` and mutable
+fetch-and-run), and dependency install scripts running in a job that holds
+secrets.
+
+Every finding names the file and line, quotes the evidence from your own
+workflow, and explains in plain English **what an attacker could do** with it.
+Then the skill offers to fix the ones you pick, leaving the diff in your working
+tree to review — it never commits, pushes, or opens a PR. It also reports
+pass/fail **config hygiene checks** (declared `permissions:`, CODEOWNERS on
+`.github/workflows/`, `secrets: inherit`, credential-persisting checkouts).
+
+**It is deliberately not comprehensive, and renders no security score.** The
+catalog is a closed set of ten, each a complete outsider → compromise chain with
+a real incident behind it — the admission test and what was rejected are in
+[why-these-ten.md](skills/ci-secure/references/why-these-ten.md). Findings are
+open doors and hygiene checks are armor; they move independently, so neither is
+a grade. **Zero findings is a first-class result**, and a check that could not
+run is reported as *did not run*, never as a pass. Runs in seconds; `gh` is
+optional, used only for the impostor-SHA check and dormant-workflow notes.
+
+What a run looks like, without installing anything:
+[starsling.dev/ci-secure](https://starsling.dev/ci-secure).
+
+---
+
 ## What a ci-speedup run costs
 
 It defaults to the repo you're in, confirms the target first, then samples your
@@ -146,10 +146,6 @@ and it writes `./ci-speedup-findings-report.md`. See
 
 ## Learn more
 
-**ci-secure** — [SKILL.md](skills/ci-secure/SKILL.md) ·
-[the ten-vector catalog](skills/ci-secure/references/security-patterns.md) ·
-[why these ten](skills/ci-secure/references/why-these-ten.md)
-
 **ci-speedup** — [SKILL.md](skills/ci-speedup/SKILL.md) ·
 [methodology](docs/methodology.md) ·
 [pattern catalog](skills/ci-speedup/references/optimization-patterns.md) ·
@@ -158,6 +154,10 @@ and it writes `./ci-speedup-findings-report.md`. See
 **ci-score** — [SKILL.md](skills/ci-score/SKILL.md) ·
 [rubric write-up](skills/ci-score/references/ci-score-methodology.md) ·
 [frozen registry (v0.1.3)](skills/ci-score/references/ci-score-spec.json)
+
+**ci-secure** — [SKILL.md](skills/ci-secure/SKILL.md) ·
+[the ten-vector catalog](skills/ci-secure/references/security-patterns.md) ·
+[why these ten](skills/ci-secure/references/why-these-ten.md)
 
 ## For maintainers
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ gives the one-line command for that skill on its own.
 | 🔒 [**ci-secure**](#ci-secure) | Can someone attack me through my CI? |
 
 All three run from a local checkout and send your code, logs, and findings
-nowhere. They need **`python3` 3.9+** and **PyYAML** (`pip install pyyaml`);
+nowhere ([data handling](SECURITY.md)). They need **`python3` 3.9+** and **PyYAML** (`pip install pyyaml`);
 `ci-speedup` also needs **`gh auth login`**, because it reads your real run
 history.
 
@@ -56,7 +56,7 @@ from wasteful, so each finding ships a ready-to-paste prompt handing the root
 cause to your own agent, which reads the logs and git history before changing
 anything.
 
-[See a run →](https://starsling.dev/ci-speedup)
+Learn more: [starsling.dev/ci-speedup](https://starsling.dev/ci-speedup)
 
 ---
 
@@ -80,7 +80,7 @@ passed over checks applicable; every failed check gets one ranked fix.
 **It measures adherence, not speed**, and it is **not a security audit** — two
 of the eleven checks are security-adjacent and it claims nothing further.
 
-[See a run →](https://starsling.dev/ci-score)
+Learn more: [starsling.dev/ci-score](https://starsling.dev/ci-score)
 
 ---
 
@@ -112,18 +112,7 @@ vectors, each a full outsider → compromise chain with a real incident behind i
 is a first-class result**, and a check that could not run says *did not run*,
 never "pass".
 
-[See a run →](https://starsling.dev/ci-secure)
-
----
-
-## What a ci-speedup run costs
-
-It defaults to the repo you're in, confirms the target first, then samples your
-recent runs. Measured: **314 `gh` API calls in ~51s** on `pallets/flask`; 824
-calls in ~3m on `microsoft/playwright`; ~1,800 in ~8m on a next.js-sized
-monorepo. The full markdown report is **opt-in** — pick *"Save the full report"*
-and it writes `./ci-speedup-findings-report.md`. See
-[SECURITY.md](SECURITY.md) for the data-handling model.
+Learn more: [starsling.dev/ci-secure](https://starsling.dev/ci-secure)
 
 ## For maintainers
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,100 @@
 # StarSling Skills
 
-Public agent skills from StarSling. Each skill lives in its own self-contained
-directory under `skills/<name>/` and installs individually.
+Public agent skills from StarSling, for auditing your **GitHub Actions** CI.
+Each skill is self-contained and installs on its own — take one, or all three.
 
-This repo ships three skills: **`ci-speedup`**
-([overview](https://starsling.dev/ci-speedup)), **`ci-score`**, and
-**`ci-secure`**.
+| Skill | What it answers | Install |
+|---|---|---|
+| [**ci-secure**](#ci-secure) | Can someone take over my CI? | [jump ↓](#ci-secure) |
+| [**ci-speedup**](#ci-speedup) | Why is my CI slow, and what does it cost? | [jump ↓](#ci-speedup) |
+| [**ci-score**](#ci-score) | Is my CI config following best practices? | [jump ↓](#ci-score) |
 
-## ci-speedup: measured CI audits for GitHub Actions
+Every skill runs from a local checkout of the repo you want audited, and none of
+them send your code, logs, or findings to StarSling or anyone else.
 
-`ci-speedup` audits a repository's GitHub Actions workflows and produces a
-**root-cause-analysis report** of what actually makes your CI slow, on two
-measured axes:
+**Installing works the same for all three** — one command, no account, nothing to
+configure:
+
+```bash
+npx skills add starslingdev/skills --skill <name> --agent claude-code -y
+```
+
+- **`--agent`** — swap in your own: `codex`, `cursor`, `github-copilot`,
+  `gemini-cli`, `windsurf`, `zed`, `opencode`, and
+  [many more](https://github.com/vercel-labs/skills). Use `--agent '*'` to
+  install for every agent you have.
+- **`-g`** — install once for every project instead of just this one. Without
+  it, the skill lands in `./.claude/skills/` (or your agent's equivalent) and
+  only applies here.
+- The [`skills`](https://github.com/vercel-labs/skills) CLI is Vercel's, fetched
+  fresh by `npx`, so you always get the current version.
+
+**What you need**, whichever you install: **`python3` 3.9+** and **PyYAML**
+(`pip install pyyaml`) to read your workflow files. `ci-speedup` additionally
+needs an authenticated **GitHub CLI** (`gh auth login`) because it reads your
+real run history; for `ci-secure` that is optional, and `ci-score` never touches
+the network.
+
+---
+
+## ci-secure
+
+**Finds the ten ways an outsider can take over your GitHub Actions and steal
+your secrets.**
+
+```bash
+npx skills add starslingdev/skills --skill ci-secure --agent claude-code -y
+```
+
+Then ask your agent **`/ci-secure`**, or just *"is my CI secure?"*
+
+`ci-secure` scans your workflows for the **ten critical CI/CD attack vectors** —
+template injection in `run:` blocks, fork code executed with privileges (pwn
+requests), `pull_request_target` jobs that poison the shared cache, impostor
+action SHAs, whole-context secret dumps, `$GITHUB_ENV` / `$GITHUB_PATH` hijack,
+`pull-requests: write` granted to untrusted triggers, credential files swept into
+caches and artifacts, unverified `curl | bash`, and dependency install scripts
+running in a job that holds secrets. Every finding comes with the exact file and
+line, evidence taken from your own workflow, and a plain-English **"what an
+attacker could do"** scenario — then the skill offers to fix the ones you pick,
+dispatching a subagent per finding group that applies the
+[catalog](skills/ci-secure/references/security-patterns.md) recipe and leaves the
+diff in your working tree to review. It never commits, pushes, or opens a PR on
+its own. Alongside the findings it reports a short set of pass/fail **config
+hygiene checks** (declared `permissions:`, CODEOWNERS coverage of
+`.github/workflows/`, `secrets: inherit`, credential-persisting checkouts, and
+more).
+
+**It is deliberately not comprehensive, and it renders no security score.** The
+catalog is a closed set of ten vectors, each a complete outsider → compromise
+chain with a real incident behind it (the admission test and the rejection record
+are in
+[references/why-these-ten.md](skills/ci-secure/references/why-these-ten.md));
+every report repeats *"critical exploit-chain checks only — this is not a
+comprehensive audit."* There is no grade, ratio, or `N/100` anywhere a reader
+sees: findings are open doors and hygiene checks are armor, they move
+independently, and neither is a score. **Zero findings is a first-class result**
+— a clean run says so plainly instead of padding with lesser observations, and a
+check that could not run is always reported as *did not run*, never as a pass.
+The scan runs locally in seconds from your checkout; `gh` is optional and used
+only for the impostor-SHA check and for noting which findings sit in dormant
+workflows.
+
+---
+
+## ci-speedup
+
+**Measures what actually makes your CI slow, from your own run history.**
+
+```bash
+npx skills add starslingdev/skills --skill ci-speedup --agent claude-code -y
+```
+
+Then ask your agent **`/ci-speedup`**, or just *"why is my CI slow?"*
+Needs `gh auth login` — this one reads your real runs.
+
+`ci-speedup` produces a **root-cause-analysis report** of what makes your CI
+slow, on two measured axes:
 
 - **Developer wall-clock wait**: the merge-gating critical path, the slowest
   checks a pull request waits on before it can go green. This is the ranking
@@ -37,108 +120,40 @@ the file's git history before shaping a safe change. Detection, ranking, and
 every measured number are deterministic; the only place an LLM steps in is a
 log-grounded gap-fill when a drilled pole matches no catalog detector.
 
-## ci-score: a best-practice grade for your CI config
+There is a walkthrough of a full run, without cloning anything, at
+[starsling.dev/ci-speedup](https://starsling.dev/ci-speedup).
+
+---
+
+## ci-score
+
+**Grades your CI configuration against best practices, and hands back the
+fixes.**
+
+```bash
+npx skills add starslingdev/skills --skill ci-score --agent claude-code -y
+```
+
+Then ask your agent **`/ci-score`**, or just *"grade my CI"*.
+Runs fully offline — no network access at all.
 
 `ci-score` grades a repository's GitHub Actions **configuration** against CI best
-practices and hands back concrete fixes for every gap. The **CI Score** is a
-plain pass/fail rubric — eleven configuration facts (dependency caching,
-shallow checkout, test sharding, concurrency cancellation, path filters, job
-timeouts, action pinning, OIDC token scoping, and more), each self-verifiable in
-the repo's own workflow YAML in under a minute. The score is checks passed over
-checks applicable; the report ranks one fix per failed check by impact × risk,
-each with a fix recipe and a ready-to-paste **agent prompt**.
+practices and hands back concrete fixes for every gap: eleven configuration facts
+(dependency caching, shallow checkout, test sharding, concurrency cancellation,
+path filters, job timeouts, action pinning, OIDC token scoping, and more), each
+self-verifiable in the repo's own workflow YAML in under a minute. The score is
+checks passed over checks applicable; the report ranks one fix per failed check
+by impact × risk, each with a fix recipe and a ready-to-paste **agent prompt**.
 
 **It measures adherence, not speed.** A faster repo can hold a lower score, and
 the report says so beside the card — never read the score as a speed verdict.
 It is also **not a security audit**: exactly two of the eleven checks (action
 pinning, job-scoped OIDC tokens) happen to be security-related, and it claims
-nothing further. Everything runs locally from a checkout — **no network access,
-nothing sent anywhere.** For measured wall-clock and runner-minute audits, that
-is a different question — use `ci-speedup`.
+nothing further. For measured wall-clock and runner-minute audits, that is a
+different question — use [`ci-speedup`](#ci-speedup). For an actual security
+review, use [`ci-secure`](#ci-secure).
 
-## ci-secure: the ten critical CI/CD attack vectors
-
-`ci-secure` scans a repository's GitHub Actions workflows for the **ten critical
-CI/CD attack vectors** — template injection in `run:` blocks, fork code executed
-with privileges (pwn requests), `pull_request_target` jobs that poison the shared
-cache, impostor action SHAs, whole-context secret dumps, `$GITHUB_ENV` /
-`$GITHUB_PATH` hijack, `pull-requests: write` granted to untrusted triggers,
-credential files swept into caches and artifacts, unverified remote code
-execution (an installer piped straight into a shell, or a git tree fetched at
-a branch or tag and then run), and dependency install scripts running in a job
-that holds secrets.
-Every finding comes with the exact file and line, evidence taken from your
-own workflow, and a plain-English **"what an attacker could do"** scenario —
-then the skill offers to fix the ones you pick, dispatching a subagent per
-finding group that applies the
-[catalog](skills/ci-secure/references/security-patterns.md) recipe
-and leaves the diff in your working tree to review. It never commits, pushes, or
-opens a PR on its own. Alongside the findings it reports a short set of pass/fail **config hygiene
-checks** (declared `permissions:`, CODEOWNERS coverage of `.github/workflows/`,
-`secrets: inherit`, credential-persisting checkouts, and more).
-
-**It is deliberately not comprehensive, and it renders no security score.** The
-catalog is a closed set of ten vectors, each a complete outsider → compromise
-chain with a real incident behind it (the admission test and the rejection record
-are in
-[references/why-these-ten.md](skills/ci-secure/references/why-these-ten.md));
-every report repeats *"critical exploit-chain checks only — this is not a
-comprehensive audit."* There is no grade, ratio, or `N/100` anywhere a reader
-sees: findings are open doors and hygiene checks are armor, they move
-independently, and neither is a score. **Zero findings is a first-class result**
-— a clean run says so plainly instead of padding with lesser observations, and a
-check that could not run is always reported as *did not run*, never as a pass.
-The scan runs locally in seconds from your checkout; `gh` is optional and used
-only for the impostor-SHA check and for noting which findings sit in dormant
-workflows.
-
-### Keeping it fixed: ci-secure as a CI check
-
-A scan tells you what is wrong today. It does nothing about next week, which is
-when the workflow gets edited. Ask for the check and ci-secure sets itself up to
-run on every pull request:
-
-> install ci-secure as a CI check
-
-1. It **copies** the scanner into your repository — under `ci-secure/`, plus one
-   workflow — and hands you a pull request to review and merge. Nothing is
-   downloaded at build time, so the code judging your pull requests is code you
-   can read, and it changes only when you ask for an update.
-2. The **first run reports without blocking**. A repository that has never been
-   scanned usually has two or three findings, and the setup pull request should
-   not brick your merge path on day one.
-3. When you have fixed those, **you** make it blocking: delete the `--advisory`
-   flag from the workflow and add `ci-secure` to your required checks. From then
-   on a failed security check stops the merge.
-4. If you ever need out, remove `ci-secure` from your required checks — one
-   settings change, reversible. Not deleting the workflow, which would leave you
-   believing you have a check you do not.
-
-Your CI re-checks the copied files against a manifest of hashes on every run, so
-a local edit somebody made while debugging and never removed shows up instead of
-quietly weakening the check. Asking for an update re-copies the code and leaves
-your workflow file alone — the runner, the triggers and the flag you deleted are
-yours.
-
-## Install
-
-```bash
-npx skills add starslingdev/skills
-```
-
-Select the skill, your agent (Claude Code, Codex, Cursor, …), and an install
-scope. The [`skills`](https://github.com/vercel-labs/skills) CLI (built by
-Vercel) is fetched fresh via `npx`, so you always get its latest version.
-
-Then invoke it with your agent:
-
-```bash
-# Claude Code
-/ci-speedup      # or /ci-score, /ci-secure
-
-# Codex
-$ci-speedup      # or $ci-score, $ci-secure
-```
+---
 
 ## First run
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![skills.sh](https://skills.sh/b/starslingdev/skills)](https://skills.sh/starslingdev/skills)
 [![CI](https://github.com/starslingdev/skills/actions/workflows/ci.yml/badge.svg)](https://github.com/starslingdev/skills/actions/workflows/ci.yml)
 [![Registry scan](https://github.com/starslingdev/skills/actions/workflows/registry-scan.yml/badge.svg)](https://github.com/starslingdev/skills/actions/workflows/registry-scan.yml)
+[![License: MIT](https://img.shields.io/github/license/starslingdev/skills)](LICENSE)
 
 🏎️ **[ci-speedup](#ci-speedup)** · 📋 **[ci-score](#ci-score)** · 🔒 **[ci-secure](#ci-secure)**
 
@@ -23,13 +24,14 @@ gives the one-line command for that skill on its own.
 | Skill | What it answers |
 |---|---|
 | 🏎️ [**ci-speedup**](#ci-speedup) | Why is my CI slow? |
-| 📋 [**ci-score**](#ci-score) | Is my CI following best practices? |
+| 📋 [**ci-score**](#ci-score) | Is my CI config following best practices? |
 | 🔒 [**ci-secure**](#ci-secure) | Can someone attack me through my CI? |
 
-All three run from a local checkout and send your code, logs, and findings
-nowhere ([data handling](SECURITY.md)). They need **`python3` 3.9+** and
-**PyYAML** (`pip install pyyaml`); `ci-speedup` also needs **`gh auth login`**,
-because it reads your real run history.
+All three run from a local checkout and need **`python3` 3.9+** and **PyYAML**
+(`pip install pyyaml`). `ci-speedup` also needs **`gh auth login`**, because it
+reads your run history over the GitHub API. That data stays on your machine:
+**nothing is sent to StarSling**, and nothing is sent to any third party
+([data handling](SECURITY.md)).
 
 ---
 


### PR DESCRIPTION
## TL;DR

There was no link to hand someone who wants one skill. Anyone tweeting about `ci-secure` had to send people to a page whose install instructions sat near the bottom, covered all the skills at once, and dropped the reader into an interactive picker. Now `#ci-secure`, `#ci-speedup` and `#ci-score` each land on a section that stands alone — what it does, a single command that installs just that one, how to run it, and what it needs.

```
before:  tweet -> repo README -> scroll -> shared "Install" -> interactive picker -> pick one
after:   tweet -> #ci-secure  -> one command -> /ci-secure
```

## Why the anchors did not work before

Each skill's heading carried a subtitle, so GitHub generated the anchor from the whole line:

| Wanted | Actually was |
|---|---|
| `#ci-secure` | `#ci-secure-the-ten-critical-cicd-attack-vectors` |
| `#ci-score` | `#ci-score-a-best-practice-grade-for-your-ci-config` |
| `#ci-speedup` | `#ci-speedup-measured-ci-audits-for-github-actions` |

Headings are now the bare skill name, so the short anchor is the real one. The subtitle moved to the line underneath.

## Two accuracy fixes found on the way

- **The page described four skills, led by `ci-advisor`.** That skill is not in this repository: `npx skills add starslingdev/skills -l` reports three, and `CLAUDE.md` says three. A reader following the README could not install it. Removed, to be restored when it ships.
- **The intro said "nine critical CI/CD attack chains"** while ci-secure's own section, its catalog and its `SKILL.md` all say ten.

## Verification

Every install command in the file was run into a clean directory, not written from the CLI's help text:

```
npx skills add starslingdev/skills --skill ci-secure  --agent claude-code -y   -> ✓ ci-secure (copied)
npx skills add starslingdev/skills --skill ci-speedup --agent claude-code -y   -> ✓ ci-speedup (copied)
npx skills add starslingdev/skills --skill ci-score   --agent claude-code -y   -> ✓ ci-score (copied)
```

The `--agent` values offered are from the CLI's own valid-agent list, and `-l` confirmed the three installable skill names.

Docs only — no skill behavior changes, so no changelog entry. Full suite green via the pre-commit hook: 3957 passed, 14 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
