### PR TITLE
ci-secure: the third-party disclosure rule, and a guard that enforces it

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,9 @@ under `maintainers/`, so the `skills` CLI never copies it into an install:
 - [`maintainers/ci-score/`](maintainers/ci-score/): maintainer notes for
   ci-score, including what was deliberately left out of the shipped skill.
   See [MAINTAINERS.md](maintainers/ci-score/MAINTAINERS.md).
-- [`maintainers/ci-secure/`](maintainers/ci-secure/): how the ten-vector
-  catalog is governed, and the disclosure rule for a scan of a repo you do not
-  own. See [MAINTAINERS.md](maintainers/ci-secure/MAINTAINERS.md).
+- [`maintainers/ci-secure/`](maintainers/ci-secure/): the disclosure rule for
+  findings from a scan of a repository you do not own, and the guard that
+  enforces it. See [MAINTAINERS.md](maintainers/ci-secure/MAINTAINERS.md).
 - [`maintainers/skills-registry-security/`](maintainers/skills-registry-security/):
   triage for a failing registry security audit, answering whether a finding
   describes the skill as it is today or a stale copy.

--- a/README.md
+++ b/README.md
@@ -180,11 +180,19 @@ Learn more: [starsling.dev/ci-secure](https://starsling.dev/ci-secure)
 
 ## For maintainers
 
-The self-improvement loop infrastructure lives **outside** the installable
-skill, under [`maintainers/ci-speedup/`](maintainers/ci-speedup/), so the
-`skills` CLI never copies it into an install; it runs locally via Claude Code,
-never as a GitHub Action. See
-[MAINTAINERS.md](maintainers/ci-speedup/MAINTAINERS.md).
+Maintainer-only infrastructure lives **outside** the installable skill trees,
+under `maintainers/`, so the `skills` CLI never copies it into an install:
+
+- [`maintainers/ci-speedup/`](maintainers/ci-speedup/): the self-improvement
+  loops, which run locally via Claude Code and never as a GitHub Action.
+  See [MAINTAINERS.md](maintainers/ci-speedup/MAINTAINERS.md).
+- [`maintainers/ci-score/`](maintainers/ci-score/): maintainer notes for
+  ci-score, including what was deliberately left out of the shipped skill.
+  See [MAINTAINERS.md](maintainers/ci-score/MAINTAINERS.md).
+- [`maintainers/skills-registry-security/`](maintainers/skills-registry-security/):
+  triage for a failing registry security audit, answering whether a finding
+  describes the skill as it is today or a stale copy.
+  See [README.md](maintainers/skills-registry-security/README.md).
 
 This repo's CI runs on [StarSling Runners](https://starsling.dev/). Fork PRs run
 the identical suite on GitHub-hosted runners, so untrusted code never executes

--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ under `maintainers/`, so the `skills` CLI never copies it into an install:
 - [`maintainers/ci-score/`](maintainers/ci-score/): maintainer notes for
   ci-score, including what was deliberately left out of the shipped skill.
   See [MAINTAINERS.md](maintainers/ci-score/MAINTAINERS.md).
+- [`maintainers/ci-secure/`](maintainers/ci-secure/): how the ten-vector
+  catalog is governed, and the disclosure rule for a scan of a repo you do not
+  own. See [MAINTAINERS.md](maintainers/ci-secure/MAINTAINERS.md).
 - [`maintainers/skills-registry-security/`](maintainers/skills-registry-security/):
   triage for a failing registry security audit, answering whether a finding
   describes the skill as it is today or a stale copy.

--- a/maintainers/ci-secure/MAINTAINERS.md
+++ b/maintainers/ci-secure/MAINTAINERS.md
@@ -1,0 +1,136 @@
+# ci-secure — maintainer notes
+
+**Maintainers only.** This file is a sibling of the installable
+`skills/ci-secure/` tree; the `skills` CLI never copies `maintainers/` into an
+end-user install. `tests/test_ci_secure_install_surface.py` makes that boundary
+a PASS/FAIL invariant, and it already expects maintainer material to land here
+rather than under the skill.
+
+## Contents
+
+- [Changing the catalog](#changing-the-catalog): the admission test, and what
+  must move with a pattern
+- [Removing a pattern](#removing-a-pattern)
+- [Third-party findings and disclosure](#third-party-findings-and-disclosure):
+  the rule for scans of repos we do not own
+- [Choosing a public example target](#choosing-a-public-example-target)
+- [Tests that govern this skill](#tests-that-govern-this-skill)
+
+## Changing the catalog
+
+The catalog is a **closed set of ten**, and that number is a promise the skill
+makes to every reader: `references/why-these-ten.md` ships with the skill so any
+finding can answer "why is this one of only ten?". Adding an eleventh is a
+product decision, not a code change.
+
+A candidate pattern is admitted **only if it passes all three tests** in
+`references/why-these-ten.md`:
+
+1. **The outsider-chain test.** Someone with no access to the repo reaches a
+   concrete compromise: code execution holding a write token, secret theft, or
+   poisoning of what the repo ships. Blast radius does not qualify. "This makes
+   a breach worse" is a different class and belongs in the rejection record.
+2. **The incident test.** The vector class has actually happened in public, and
+   the entry names its incidents. Nothing theoretical.
+3. **The same-day-fix test.** A maintainer can close it the day they read it.
+   Anything needing a hardening program fails.
+
+Severity is not the filter and never has been. Three catalog-HIGH patterns
+failed these tests; two catalog-MEDIUM patterns passed. Reaching for "but it's
+HIGH" as an argument means the case has not been made.
+
+**A pattern never travels alone.** Admitting or changing one touches, at
+minimum:
+
+- `skills/ci-secure/references/security-patterns.md` — the entry, its
+  `METADATA` block, and the five prose sections every entry must carry:
+  `**TL;DR.**`, `**What an attacker can do.**`, `**Anti-pattern**:`,
+  `**Fix recipe**`, `**Risk of the change.**`
+- `skills/ci-secure/references/why-these-ten.md` — the entry in the ten, its
+  incident grounding, and the census arithmetic in the rejection record
+- `skills/ci-secure/scripts/scan.py` — the detector
+- `skills/ci-secure/tests/` — detector tests, and the census tests below
+- `skills/ci-secure/CHANGELOG.md` — a dated entry, same PR
+
+The census tests bind these together on purpose: the catalog, the doc, the
+scanner's active pattern set, and the report manifest cannot drift apart. If a
+census test fails, the fix is almost never to relax the test.
+
+## Removing a pattern
+
+Removal has the same weight as admission. The rejection record in
+`references/why-these-ten.md` must account for it, and
+`test_the_rejection_record_accounts_for_the_catalog_size_it_claims` checks that
+the arithmetic still adds up. `test_no_shipped_doc_cites_a_removed_pattern`
+catches the dangling references a removal leaves behind.
+
+Fifteen patterns have already been removed, in two classes the record names
+and both worth reading before proposing a sixteenth: the blast-radius patterns
+(a real weakness that only makes an existing breach worse), and the
+presence-shaped hygiene observations, which either became scored config facts
+in ci-score or were dropped.
+
+## Third-party findings and disclosure
+
+**A ci-secure run against a repository we do not own can surface a live,
+undisclosed vulnerability in someone else's code.** That output is sensitive
+until its owner has had a chance to fix it, and we are the ones who generated
+it.
+
+The rule:
+
+- **Never publish a finding against a third-party repo that its owner has not
+  already disclosed or fixed.** Not in `examples/`, not in a report committed
+  to this repo, not in a PR body, an issue, a screenshot, a blog post, or a
+  social post. A committed file is worse than a post: it is permanent and
+  indexed.
+- **Report it privately first.** Use the project's own security policy or
+  bug-bounty program. Give them the file, the line, and the attacker scenario
+  the skill already produced.
+- **Scope the scan when the target is a demonstration.** If the point is to show
+  one already-public bug, run against that one workflow file rather than the
+  whole repository, so an unrelated live finding cannot end up in the artifact.
+- **A scan of our own repositories has no such constraint**, and dogfooding
+  ci-secure on this repo is encouraged.
+
+This applies to anything derived from a run, including a report a loop or an
+agent generated automatically. Read what you are about to commit.
+
+## Choosing a public example target
+
+`examples/` ships no ci-secure worked example yet. When one is added, its
+target has to be a repository whose findings are safe to publish permanently.
+In order of preference:
+
+1. **A repository we own.** No disclosure question at all.
+2. **A historical commit of a third-party repo whose vulnerability is already
+   public and already fixed**, cited to the published disclosure. The bug is
+   public knowledge, the current code is not affected, and the before/after pair
+   across the owner's own fix is the most persuasive artifact the skill can
+   produce: it shows the detector is specific, not merely noisy.
+3. **A current third-party repo.** Only with a clean scan, and only after
+   confirming nothing undisclosed is in the output.
+
+Scope option 2 to the affected file. A whole-repo scan of the same commit can
+surface unrelated findings that are still live today, which is exactly the case
+the rule above exists for.
+
+## Tests that govern this skill
+
+From the repo root, `python3 -m pytest -q` runs everything. The suites that
+specifically constrain catalog changes:
+
+- `skills/ci-secure/tests/test_census_why_these_ten.py` — binds the catalog, the
+  doc, the scanner's pattern set, the report manifest, anchors, severities,
+  platform notes, and the rejection-record arithmetic to each other
+- `skills/ci-secure/tests/test_scan.py` — per-detector positive and negative
+  cases
+- `skills/ci-secure/tests/verify_report.py` (the checker) and
+  `skills/ci-secure/tests/test_verify_report.py` (its tests) — the report's own
+  invariants, including that a source fence quotes only source and that the
+  rendered vector-status table covers all ten
+- `tests/test_ci_secure_install_surface.py` — fails if maintainer-only material
+  appears under `skills/ci-secure/`
+
+A guard that cannot fail is not a guard: several of these carry positive-control
+tests asserting the detector actually fires. Keep that property when adding one.

--- a/maintainers/ci-secure/MAINTAINERS.md
+++ b/maintainers/ci-secure/MAINTAINERS.md
@@ -2,73 +2,19 @@
 
 **Maintainers only.** This file is a sibling of the installable
 `skills/ci-secure/` tree; the `skills` CLI never copies `maintainers/` into an
-end-user install. `tests/test_ci_secure_install_surface.py` makes that boundary
-a PASS/FAIL invariant, and it already expects maintainer material to land here
-rather than under the skill.
+end-user install, and `tests/test_ci_secure_install_surface.py` makes that
+boundary a PASS/FAIL invariant.
 
-## Contents
+How the ten-vector catalog is governed — the three admission tests, what a
+pattern change has to touch, how a removal is recorded and what the rejection
+record must still add up to — already ships with the skill, in
+[`skills/ci-secure/references/why-these-ten.md`](../../skills/ci-secure/references/why-these-ten.md).
+Read that first; it is the authority, and repeating it here would only give it
+a second copy to drift from.
 
-- [Changing the catalog](#changing-the-catalog): the admission test, and what
-  must move with a pattern
-- [Removing a pattern](#removing-a-pattern)
-- [Third-party findings and disclosure](#third-party-findings-and-disclosure):
-  the rule for scans of repos we do not own
-- [Choosing a public example target](#choosing-a-public-example-target)
-- [Tests that govern this skill](#tests-that-govern-this-skill)
-
-## Changing the catalog
-
-The catalog is a **closed set of ten**, and that number is a promise the skill
-makes to every reader: `references/why-these-ten.md` ships with the skill so any
-finding can answer "why is this one of only ten?". Adding an eleventh is a
-product decision, not a code change.
-
-A candidate pattern is admitted **only if it passes all three tests** in
-`references/why-these-ten.md`:
-
-1. **The outsider-chain test.** Someone with no access to the repo reaches a
-   concrete compromise: code execution holding a write token, secret theft, or
-   poisoning of what the repo ships. Blast radius does not qualify. "This makes
-   a breach worse" is a different class and belongs in the rejection record.
-2. **The incident test.** The vector class has actually happened in public, and
-   the entry names its incidents. Nothing theoretical.
-3. **The same-day-fix test.** A maintainer can close it the day they read it.
-   Anything needing a hardening program fails.
-
-Severity is not the filter and never has been. Three catalog-HIGH patterns
-failed these tests; two catalog-MEDIUM patterns passed. Reaching for "but it's
-HIGH" as an argument means the case has not been made.
-
-**A pattern never travels alone.** Admitting or changing one touches, at
-minimum:
-
-- `skills/ci-secure/references/security-patterns.md` — the entry, its
-  `METADATA` block, and the five prose sections every entry must carry:
-  `**TL;DR.**`, `**What an attacker can do.**`, `**Anti-pattern**:`,
-  `**Fix recipe**`, `**Risk of the change.**`
-- `skills/ci-secure/references/why-these-ten.md` — the entry in the ten, its
-  incident grounding, and the census arithmetic in the rejection record
-- `skills/ci-secure/scripts/scan.py` — the detector
-- `skills/ci-secure/tests/` — detector tests, and the census tests below
-- `skills/ci-secure/CHANGELOG.md` — a dated entry, same PR
-
-The census tests bind these together on purpose: the catalog, the doc, the
-scanner's active pattern set, and the report manifest cannot drift apart. If a
-census test fails, the fix is almost never to relax the test.
-
-## Removing a pattern
-
-Removal has the same weight as admission. The rejection record in
-`references/why-these-ten.md` must account for it, and
-`test_the_rejection_record_accounts_for_the_catalog_size_it_claims` checks that
-the arithmetic still adds up. `test_no_shipped_doc_cites_a_removed_pattern`
-catches the dangling references a removal leaves behind.
-
-Fifteen patterns have already been removed, in two classes the record names
-and both worth reading before proposing a sixteenth: the blast-radius patterns
-(a real weakness that only makes an existing breach worse), and the
-presence-shaped hygiene observations, which either became scored config facts
-in ci-score or were dropped.
+What does not live anywhere else is the rule below, because it governs this
+repository rather than the skill: not what ci-secure looks for, but what may
+be done with what it finds.
 
 ## Third-party findings and disclosure
 
@@ -87,50 +33,33 @@ The rule:
 - **Report it privately first.** Use the project's own security policy or
   bug-bounty program. Give them the file, the line, and the attacker scenario
   the skill already produced.
-- **Scope the scan when the target is a demonstration.** If the point is to show
-  one already-public bug, run against that one workflow file rather than the
-  whole repository, so an unrelated live finding cannot end up in the artifact.
+- **Scope the scan when the target is a demonstration.** If the point is to
+  show one already-public bug, fetch and scan that one workflow file rather
+  than the whole repository, so an unrelated live finding cannot ride along
+  into the artifact.
+  [`examples/snowflakedb-snowflake-connector-net/README.md`](../../examples/snowflakedb-snowflake-connector-net/README.md)
+  records the scoped fetch that shipped example uses, and what to check before
+  scanning.
 - **A scan of our own repositories has no such constraint**, and dogfooding
   ci-secure on this repo is encouraged.
 
 This applies to anything derived from a run, including a report a loop or an
 agent generated automatically. Read what you are about to commit.
 
-## Choosing a public example target
+## The guard that enforces it
 
-`examples/` ships no ci-secure worked example yet. When one is added, its
-target has to be a repository whose findings are safe to publish permanently.
-In order of preference:
+A rule written down in a maintainers directory stops nobody, because the
+person who would break it is exactly the person who has not read the file. So
+the rule is also mechanical.
 
-1. **A repository we own.** No disclosure question at all.
-2. **A historical commit of a third-party repo whose vulnerability is already
-   public and already fixed**, cited to the published disclosure. The bug is
-   public knowledge, the current code is not affected, and the before/after pair
-   across the owner's own fix is the most persuasive artifact the skill can
-   produce: it shows the detector is specific, not merely noisy.
-3. **A current third-party repo.** Only with a clean scan, and only after
-   confirming nothing undisclosed is in the output.
+[`tests/test_findings_disclosure.py`](../../tests/test_findings_disclosure.py)
+fails the suite when a committed ci-secure findings artifact reports a finding
+against a repository that is not named in its `DISCLOSED_TARGETS` allowlist,
+alongside the disclosure that clears it. It recognises a ci-secure artifact by
+its top-level `catalog_patterns_evaluated` key or its `P<n>.<n>` pattern ids,
+so the other engines' `findings.json` files are not swept in and the allowlist
+keeps meaning "cleared for publication".
 
-Scope option 2 to the affected file. A whole-repo scan of the same commit can
-surface unrelated findings that are still live today, which is exactly the case
-the rule above exists for.
-
-## Tests that govern this skill
-
-From the repo root, `python3 -m pytest -q` runs everything. The suites that
-specifically constrain catalog changes:
-
-- `skills/ci-secure/tests/test_census_why_these_ten.py` — binds the catalog, the
-  doc, the scanner's pattern set, the report manifest, anchors, severities,
-  platform notes, and the rejection-record arithmetic to each other
-- `skills/ci-secure/tests/test_scan.py` — per-detector positive and negative
-  cases
-- `skills/ci-secure/tests/verify_report.py` (the checker) and
-  `skills/ci-secure/tests/test_verify_report.py` (its tests) — the report's own
-  invariants, including that a source fence quotes only source and that the
-  rendered vector-status table covers all ten
-- `tests/test_ci_secure_install_surface.py` — fails if maintainer-only material
-  appears under `skills/ci-secure/`
-
-A guard that cannot fail is not a guard: several of these carry positive-control
-tests asserting the detector actually fires. Keep that property when adding one.
+Adding a line to that allowlist **is** the decision, and it shows up in
+review. The guard does not judge whether publishing is acceptable — it forces
+somebody to say on the record that they thought about it.

--- a/tests/test_findings_disclosure.py
+++ b/tests/test_findings_disclosure.py
@@ -1,0 +1,286 @@
+"""Disclosure guard for committed ci-secure findings about third-party repos.
+
+A ci-secure report names live security holes. Committing one about a repository
+we do not own publishes those holes permanently and searchably, and a maintainer
+has to have thought about disclosure BEFORE the file lands. The rule is written
+down in `maintainers/ci-secure/MAINTAINERS.md`, but prose in a maintainers
+directory enforces nothing: the person who would break it is exactly the person
+who has not read it.
+
+This guard makes it mechanical. Every committed ci-secure findings artifact that
+reports at least one finding must name its target repository in
+`DISCLOSED_TARGETS` below, together with the public disclosure it relies on.
+Adding an entry is a deliberate edit that shows up in review, which is the whole
+point: the check does not decide whether publishing is acceptable, it forces
+somebody to say so on the record.
+
+Scope. It reads the machine-readable findings JSON, not the rendered markdown,
+because the renderer is derived from the JSON: a finding cannot reach a `.md`
+without appearing here first. It walks the files git has under version control,
+so a maintainer's gitignored local scan output (`.ci-speedup-gaps/` and friends,
+which may hold third-party findings by design) is never read.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Repositories whose committed ci-secure findings are cleared for publication,
+# keyed by `owner/name`, each with the disclosure that clears it. A repository we
+# own needs no disclosure and records that as its reason instead.
+#
+# Adding a line here IS the decision. Make it deliberately: the finding must
+# already be public, or already fixed, or ours.
+DISCLOSED_TARGETS: dict[str, str] = {
+    "snowflakedb/snowflake-connector-net": (
+        "Template injection in jira_issue.yml, found by Wiz Research, reported "
+        "via HackerOne 2026-06-23, fixed by the vendor the same day in 1dc7766. "
+        "Public write-up: "
+        "https://www.wiz.io/blog/red-agent-snowflake-copilot-cicd-bug"
+    ),
+    "starslingdev/skills": "Our own repository.",
+}
+
+# ci-secure catalog ids look like `P14.10`; ci-speedup's look like `OPT32`.
+_CI_SECURE_PATTERN_RE = re.compile(r"^P\d+\.\d+$")
+
+
+def _cleared_tokens() -> set[str]:
+    """Every spelling of a cleared repository the guard may encounter.
+
+    ci-secure scans a local checkout and records `"repo": null`, so for the
+    shipped examples the only identifier in the artifact is its directory name —
+    the slug with `/` written as `-` (`snowflakedb-snowflake-connector-net`).
+    Both spellings are accepted; neither can clear anything a maintainer did not
+    write into `DISCLOSED_TARGETS` by hand.
+    """
+    tokens = set()
+    for slug in DISCLOSED_TARGETS:
+        tokens.add(slug)
+        tokens.add(slug.replace("/", "-"))
+    return tokens
+
+
+def _git_env() -> dict[str, str]:
+    """The ambient environment with every GIT_* override stripped.
+
+    A worktree or hook run can export an absolute GIT_DIR / GIT_WORK_TREE, which
+    would make a `git` call inside a temporary fixture repo operate on the real
+    repository instead.
+    """
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    env["GIT_CONFIG_GLOBAL"] = os.devnull
+    env["GIT_CONFIG_SYSTEM"] = os.devnull
+    return env
+
+
+def _tracked_json(root: Path) -> list[Path] | None:
+    """Every version-controlled `*.json` under `root`, or None if git can't say."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(root), "ls-files", "-z", "--", "*.json"],
+            capture_output=True, env=_git_env(), timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    names = [n for n in proc.stdout.decode("utf-8", "replace").split("\0") if n]
+    return sorted(root / n for n in names)
+
+
+def _candidate_json(root: Path) -> list[Path]:
+    """The artifacts to inspect: tracked JSON, or `examples/` if git can't answer.
+
+    The fallback keeps the guard from silently passing on a tarball export with
+    no git metadata. `examples/` is never gitignored, so reading it there cannot
+    pull in local scan output.
+    """
+    tracked = _tracked_json(root)
+    if tracked is not None:
+        return tracked
+    return sorted((root / "examples").rglob("*.json"))
+
+
+def _load(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+
+def _security_findings(payload: object) -> list[dict]:
+    """The ci-secure findings in a parsed artifact, or [].
+
+    Discrimination matters more than it looks. Keying on a finding carrying
+    `pattern` + `severity` — the obvious choice — also matches every ci-speedup
+    artifact, whose findings carry both; the guard would then demand an allowlist
+    entry for `microsoft/playwright` and `pallets/flask` and the list would stop
+    meaning "cleared for disclosure". Two signals identify ci-secure instead, and
+    either alone is enough, so an artifact cannot dodge the guard by dropping
+    one:
+
+    * a top-level `catalog_patterns_evaluated` key, which ci-secure writes and
+      ci-speedup (`catalog_patterns_total` and friends) does not; and
+    * catalog ids of the form `P14.10`, which ci-speedup's `OPT32` never match.
+    """
+    if not isinstance(payload, dict):
+        return []
+    findings = payload.get("findings")
+    if not isinstance(findings, list):
+        findings = []
+    findings = [f for f in findings if isinstance(f, dict)]
+    by_key = "catalog_patterns_evaluated" in payload
+    by_pattern = any(
+        isinstance(f.get("pattern"), str) and _CI_SECURE_PATTERN_RE.match(f["pattern"])
+        for f in findings
+    )
+    return findings if (by_key or by_pattern) else []
+
+
+def _declared_target(payload: dict, artifact: Path) -> str:
+    """The repository an artifact reports on.
+
+    Prefers the recorded `repo` slug; falls back to the artifact's directory
+    name, which is what a local-checkout scan leaves behind. An artifact can
+    therefore never dodge the guard by omitting the field — the fallback is
+    a name that has to be cleared too.
+    """
+    repo = payload.get("repo")
+    if isinstance(repo, str) and "/" in repo:
+        return repo
+    return artifact.parent.name
+
+
+def _offenders(root: Path) -> list[str]:
+    """Committed artifacts reporting findings against an uncleared repository."""
+    cleared = _cleared_tokens()
+    offenders: list[str] = []
+    for artifact in _candidate_json(root):
+        payload = _load(artifact)
+        findings = _security_findings(payload)
+        if not findings:
+            continue
+        target = _declared_target(payload, artifact)
+        if target in cleared:
+            continue
+        patterns = sorted({str(f.get("pattern")) for f in findings})
+        try:
+            where = artifact.relative_to(root)
+        except ValueError:  # pragma: no cover - defensive
+            where = artifact
+        offenders.append(
+            f"{where} reports {len(findings)} finding(s) "
+            f"({', '.join(patterns)}) against {target!r}, which is not in "
+            f"DISCLOSED_TARGETS"
+        )
+    return offenders
+
+
+def test_committed_findings_only_name_disclosed_targets() -> None:
+    """No committed artifact reports a security finding about an uncleared repo."""
+    offenders = _offenders(REPO_ROOT)
+    assert not offenders, (
+        "Committed ci-secure findings about a repository with no recorded "
+        "disclosure:\n  "
+        + "\n  ".join(offenders)
+        + "\n\nEither the finding is already public, already fixed, or ours — in "
+        "which case add the repository to DISCLOSED_TARGETS with the disclosure "
+        "that clears it — or it is not, in which case it must not be committed. "
+        "See maintainers/ci-secure/MAINTAINERS.md."
+    )
+
+
+def test_the_shipped_ci_secure_example_is_actually_covered() -> None:
+    """The guard sees the real example, so the test above is not vacuously green.
+
+    Without this, deleting the examples, breaking the walk, or breaking the
+    discriminator would all read exactly like a clean repository.
+    """
+    artifact = (
+        REPO_ROOT / "examples" / "snowflakedb-snowflake-connector-net"
+        / "ci-secure-findings-4a1b8ce.json"
+    )
+    assert artifact.exists(), f"{artifact} is missing"
+    assert artifact in _candidate_json(REPO_ROOT), "the walk does not reach it"
+    findings = _security_findings(_load(artifact))
+    assert findings, "the discriminator does not recognise a real ci-secure artifact"
+    assert _declared_target(_load(artifact), artifact) in _cleared_tokens()
+
+
+def test_the_guard_can_actually_fail(tmp_path: Path) -> None:
+    """Positive control: run the real walk over a repo holding an uncleared artifact.
+
+    A guard that cannot fail is not a guard. This builds a throwaway git
+    repository with one committed ci-secure artifact about a repository nobody
+    cleared, and asserts the same `_offenders` the test above trusts reports it.
+    """
+    root = tmp_path / "fixture-repo"
+    target_dir = root / "examples" / "someone-else-private-thing"
+    target_dir.mkdir(parents=True)
+    artifact = target_dir / "ci-secure-findings-deadbee.json"
+    artifact.write_text(
+        json.dumps({
+            "repo": None,
+            "catalog_patterns_evaluated": ["P14.10"],
+            "findings": [{"pattern": "P14.10", "severity": "HIGH", "line": 24}],
+        }),
+        encoding="utf-8",
+    )
+    env = _git_env()
+    subprocess.run(["git", "init", "-q", str(root)], check=True, env=env)
+    subprocess.run(
+        ["git", "-C", str(root), "add", str(artifact.relative_to(root))],
+        check=True, env=env,
+    )
+
+    assert _tracked_json(root) == [artifact], "the fixture repo was not set up"
+    offenders = _offenders(root)
+    assert len(offenders) == 1, offenders
+    assert "someone-else-private-thing" in offenders[0]
+    assert "P14.10" in offenders[0]
+
+
+def test_the_guard_fires_on_pattern_ids_alone(tmp_path: Path) -> None:
+    """Second control: the `P<n>.<n>` signal works without the top-level key.
+
+    The two signals are an OR precisely so dropping one cannot buy silence.
+    """
+    payload = {
+        "repo": "someone-else/private-thing",
+        "findings": [{"pattern": "P4.2", "severity": "MEDIUM"}],
+    }
+    assert _security_findings(payload), "the pattern-id signal did not fire"
+    assert _declared_target(payload, tmp_path / "x.json") not in _cleared_tokens()
+
+
+def test_the_other_engines_artifacts_are_not_swept_in() -> None:
+    """A committed ci-speedup or ci-score artifact is not a security finding.
+
+    Pinned against the real shipped examples, not a synthetic shape, because the
+    false positive this prevents was found on exactly these files.
+    """
+    others = sorted(
+        p for p in (REPO_ROOT / "examples").rglob("*.json")
+        if "ci-secure" not in p.name
+    )
+    assert others, "no non-ci-secure example artifacts found to check against"
+    swept = [
+        str(p.relative_to(REPO_ROOT)) for p in others if _security_findings(_load(p))
+    ]
+    assert not swept, f"non-ci-secure artifacts treated as security findings: {swept}"
+
+
+@pytest.mark.parametrize("repo", sorted(DISCLOSED_TARGETS))
+def test_every_allowlist_entry_states_its_reason(repo: str) -> None:
+    """An entry with no stated reason is an unreviewed entry."""
+    assert "/" in repo, f"{repo!r} is not an owner/name slug"
+    assert DISCLOSED_TARGETS[repo].strip(), f"{repo} records no reason"


### PR DESCRIPTION
## TL;DR

Running ci-secure against a repository someone else owns can turn up a live,
undisclosed hole in their code, and committing that output publishes it
permanently and searchably. Nothing in this repo stopped that from happening —
it came within one command of happening while the shipped ci-secure example was
being prepared. This PR states the rule and, more importantly, adds a test that
fails the build when a committed findings artifact names a repository nobody
recorded a disclosure for.

This PR was cut down after review. It originally added a five-section
maintainer document; four of those sections restated material that already
ships with the skill or is visible by reading the tree, so they are gone and
the guard replaced them.

## What was removed, and why

`maintainers/ci-secure/MAINTAINERS.md` went from 136 lines to 68.

| Section | Verdict |
| --- | --- |
| Changing the catalog | Duplicated `skills/ci-secure/references/why-these-ten.md`, which installs with the skill and is the authority. A second copy only gives it something to drift from. |
| Removing a pattern | Same duplication. |
| Tests that govern this skill | A list of test files anyone can obtain by looking at the directory. |
| Choosing a public example target | Advisory, and overtaken by the worked example that has since landed. Its one operational instruction — scope a demonstration scan to the affected file — survives as a bullet inside the disclosure rule, where it is a disclosure control rather than example-authoring advice. |
| Third-party findings and disclosure | Kept. It governs this repository rather than the skill, so it has no other home. |

What remains is the rule, a pointer to `why-these-ten.md` for everything the
file used to copy, and a short section describing the guard.

## The guard

```
before:  rule lives in maintainers/ci-secure/MAINTAINERS.md
         -> read only by someone who already knew to look
         -> a committed third-party finding lands unnoticed

after:   rule lives in MAINTAINERS.md AND tests/test_findings_disclosure.py
         -> every committed ci-secure findings artifact is walked
         -> target repo absent from DISCLOSED_TARGETS  ->  suite FAILS
```

`tests/test_findings_disclosure.py` walks every version-controlled `*.json`,
picks out the ci-secure findings artifacts, and requires each one reporting a
finding to name its target repository in a `DISCLOSED_TARGETS` allowlist
alongside the disclosure that clears it. Adding a line to that list *is* the
decision, and it appears in review. The check does not judge whether publishing
is acceptable; it forces somebody to say on the record that they considered it.

It reads the machine-readable JSON rather than the rendered markdown, because
the renderer is derived from the JSON — a finding cannot reach a `.md` without
appearing there first. It enumerates files through `git ls-files`, so a
maintainer's gitignored local scan output is never read.

The single allowlist entry covers the shipped example: the template injection
in `snowflakedb/snowflake-connector-net`, found by Wiz Research, reported
through HackerOne on 2026-06-23, fixed by the vendor the same day in `1dc7766`,
and [written up publicly](https://www.wiz.io/blog/red-agent-snowflake-copilot-cicd-bug).

### Discriminating ci-secure from the other engines

The draft keyed on a finding carrying both `pattern` and `severity`. Every
ci-speedup finding carries both, so the guard fired on the existing ci-speedup
examples and would have demanded allowlist entries for `microsoft/playwright`
and `pallets/flask` — draining the list of the meaning it exists to hold.

Two signals identify ci-secure instead, either one sufficient so that dropping
one cannot buy silence: a top-level `catalog_patterns_evaluated` key, which
ci-speedup does not write (it has `catalog_patterns_total` and friends), and
catalog ids shaped `P14.10`, which ci-speedup's `OPT32` never match. Both were
verified against the committed artifacts rather than assumed.

## Red proof

The guard was mutated twice and watched fail before it was trusted.

| Mutation | Result |
| --- | --- |
| Drop `snowflakedb/snowflake-connector-net` from `DISCLOSED_TARGETS` | `test_committed_findings_only_name_disclosed_targets` FAILED, naming `examples/snowflakedb-snowflake-connector-net/ci-secure-findings-4a1b8ce.json` and its three `P14.10` findings |
| Restore the `pattern` + `severity` discriminator | `test_the_other_engines_artifacts_are_not_swept_in` FAILED with `['examples/microsoft-playwright/findings.json', 'examples/pallets-flask/findings.json']` |

The first leg is permanent as `test_the_guard_can_actually_fail`, which builds
a throwaway git repository holding one uncleared artifact and asserts the same
walk the real check trusts reports it. A companion test pins that the walk
actually reaches the shipped example, so deleting the examples or breaking the
walk cannot read as a clean repository.

An assertion in the draft requiring every allowlist reason to exceed 40
characters was dropped: it fails on a legitimately short and complete reason
("Our own repository."), and length is not a proxy for having thought about it.
The reason must now be non-empty and the key must be an `owner/name` slug.

## Verification

Branch rebased onto current `main` (`4e66a90`), which moved a long way since it
was cut. The README maintainer-index entry was re-checked against the current
README and narrowed to match the reduced scope.

`python3 -m pytest -q` — 4048 passed, 14 skipped, under the pre-commit hook's
pipx environment. Under this machine's system Python 3.9 the same run reports
4046 passed with two failures, `test_the_grammar_guard_can_actually_fail` and
one parametrised case of `test_page_text_strips_every_legal_script_end_tag_form`;
both reproduce on pristine `main` and are untouched by this change.

Nothing under `skills/` changes, so no end-user install and no skill behaviour
is affected, and no skill changelog entry is due.
