### PR TITLE
ci-secure: prove the installed gate can fail before handing it back

### DIFF
--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -34,7 +34,10 @@ entries are dated (UTC). Format loosely follows
   fixtures, there is no flag to skip the proof, and `vendor.py --self-test
   <vendored dir>` re-runs it on demand. The proof also runs with bytecode
   writing disabled, so it cannot leave a `__pycache__` that the adopter's own
-  drift check would then red on forever.
+  drift check would then red on forever. The report of what the gate makes of
+  the adopter's real tree keeps the two kinds of red apart: failed facts, which
+  the shipped `--advisory` reports without blocking, and scan-integrity
+  failures, which survive the ramp and make the very first run red.
 - **2026-08-17** — **An install into a repository that documents a
   guard-registration convention says the new gate is not registered with it.**
   A repository keeping a register of its build-breaking checks — a harness that

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -13,6 +13,36 @@ entries are dated (UTC). Format loosely follows
 
 ### Added
 
+- **2026-08-17** — **Installing the gate now proves it can fail, before it is
+  handed back.** The gate ships in `--advisory` mode, so its first runs are
+  green by construction, and the runbook then asks for `--advisory` to come off
+  and the check to be made required — a blocking check trusted on the strength
+  of never having been seen go red, which is the failure this skill's own
+  reports preach against one level up. `vendor.py --into` now fires the freshly
+  vendored gate at a throwaway workflow that fails a named security fact
+  (`sec.permissions.workflow-declares`) and requires a non-zero exit that names
+  it, then at the same workflow with the hole closed and requires a 0 — a gate
+  wedged red reds on everything and proves nothing. It then reports what the
+  gate makes of the adopter's real tree, so "can it block" and "would it block
+  me" are both answered before anything is committed. **Nothing is written into
+  the adopter's repository to do this**: both fixtures are temporary files,
+  deleted afterwards, and no workflow of theirs is broken to stage a red. The
+  three outcomes are kept apart — proved, FAILED (do not report a working
+  install), and could-not-run (the engine needs Python 3.12 and PyYAML; the
+  installer needs neither) — because a missing interpreter and a gate that
+  cannot fail must never read as the same thing. Refreshes re-prove on the same
+  fixtures, there is no flag to skip the proof, and `vendor.py --self-test
+  <vendored dir>` re-runs it on demand. The proof also runs with bytecode
+  writing disabled, so it cannot leave a `__pycache__` that the adopter's own
+  drift check would then red on forever.
+- **2026-08-17** — **An install into a repository that documents a
+  guard-registration convention says the new gate is not registered with it.**
+  A repository keeping a register of its build-breaking checks — a harness that
+  mutates each one and asserts it fires — gains, on install, a check that
+  register does not cover, and nothing said so. `CLAUDE.md`, `AGENTS.md` and
+  `CONTRIBUTING.md` are read for that convention and the matching line is
+  quoted back. Detection only: registering into an arbitrary repository's
+  harness means writing into files the installer knows nothing about.
 - **2026-08-17** — **A finding whose job sits behind a security gate that
   cannot work now says so.** Previously every gate got the same sentence —
   *"the finding stands only if that gate can be bypassed; verify it"* — which

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -37,7 +37,13 @@ entries are dated (UTC). Format loosely follows
   drift check would then red on forever. The report of what the gate makes of
   the adopter's real tree keeps the two kinds of red apart: failed facts, which
   the shipped `--advisory` reports without blocking, and scan-integrity
-  failures, which survive the ramp and make the very first run red.
+  failures, which survive the ramp and make the very first run red. That report
+  is withheld entirely unless the proof passed — a verdict from a gate that
+  just failed its own proof, or that could not run at all, is not an
+  observation about the adopter's code and is not offered as one — and a gate
+  that exits non-zero on their tree without naming a single finding is reported
+  as a scan that produced no usable result, never as a repository with nothing
+  to block.
 - **2026-08-17** — **An install into a repository that documents a
   guard-registration convention says the new gate is not registered with it.**
   A repository keeping a register of its build-breaking checks — a harness that

--- a/skills/ci-secure/SKILL.md
+++ b/skills/ci-secure/SKILL.md
@@ -610,8 +610,10 @@ Then, before it reports the install complete, it **proves the gate can
 fail**. The freshly vendored gate is pointed at a throwaway workflow
 that fails a named security fact (`sec.permissions.workflow-declares`),
 and must exit non-zero AND name that fact; then at the same workflow
-with the hole closed, where it must exit 0 — because a gate wedged red
-reds on everything and proves nothing. Both fixtures are temporary files
+with the hole closed — byte-for-byte the same but for the `permissions:`
+block — where it must exit 0, because a gate wedged red reds on
+everything and proves nothing. The two fixtures differ only by the fact
+under test, so a green has only one explanation. Both fixtures are temporary files
 that are deleted afterwards: **nothing is written into the user's tree
 for the proof, and no workflow of theirs is broken to demonstrate it.**
 It then runs the gate on their real tree and prints what it found,
@@ -624,29 +626,50 @@ and "red on day one". Read the proof line too, and relay it:
 
 - `self-proof PASSED` — the gate has been observed failing and passing.
   Only then is this a working install.
-- `self-proof FAILED` — the gate passed a vulnerable fixture, or redded
-  a clean one. **Do not report a working install.** Say the gate is not
-  usable, and do not walk them through going blocking.
-- `self-proof COULD NOT RUN` — the engine could not start here (it needs
-  Python 3.12 and PyYAML; the installer needs neither). The gate is
-  installed and **unproven**: say so, and tell them to re-run
+- `self-proof FAILED` (exit 1) — the gate passed a vulnerable fixture, or
+  redded a clean one. **Do not report a working install**, and **stop
+  before the handover runbook below** — skip it entirely rather than
+  walking them through going blocking. Say the gate is not usable, and
+  say what is on disk: the vendored files AND
+  `.github/workflows/ci-secure.yml`, which runs on every pull request
+  from the next push. Offer to revert them, or to refresh the copy.
+  Committing them ships a check that cannot block — a green tick and no
+  protection, the thing this skill exists to argue against.
+- `self-proof COULD NOT RUN` (exit 2 from `--self-test`; the install
+  itself still exits 0) — the proof did not happen here. The gate's own
+  output is quoted above the line and says whether the engine could not
+  start on this machine (PyYAML missing, most often — CI installs it) or
+  the vendored copy is broken everywhere; relay which, and do not assert
+  a cause the output does not give. The gate is installed and
+  **unproven**: say so, and tell them to re-run
   `<repo-root>/ci-secure/scripts/vendor.py --self-test <repo-root>/ci-secure`
-  somewhere the engine runs. That command is theirs to re-run at any
-  time; it writes nothing.
+  once that is resolved. That command is theirs to re-run at any time; it
+  writes nothing.
+
+Nothing else counts as a proof line. If none of the three appears, treat
+it as a failed proof, not as a pass.
+
+On both non-PASSED outcomes the install says nothing about what the gate
+makes of the user's own code, on purpose — a verdict from a gate that
+failed its proof, or that could not run at all, is not an observation
+about their repository. Do not fill that gap with a guess.
 
 It also reads their `CLAUDE.md` / `AGENTS.md` / `CONTRIBUTING.md` for a
 guard-registration convention (a register of build-breaking checks, a
 mutation harness) and, if it finds one, says the new gate has NOT been
-registered with it, quoting the line. It never edits their harness —
-pass that to the user as work they own. The check is a keyword read: it
-misses conventions phrased other ways, and a false hit costs one glance.
+registered with it, quoting the line. It never edits their harness, and
+**neither do you** — the harness is theirs, you do not know its shape,
+and guessing means writing into files you have not read. Pass it to the
+user as work they own. The check is a keyword read: it misses
+conventions phrased other ways, and a false hit costs one glance.
 
 Everything that can refuse refuses before the first byte is written, and
 the workflow is written last, after the manifest. So a refusal means at
 worst a partly-copied `ci-secure/`, never a live workflow with no gate
 behind it. A non-zero exit is now two different things, and the output
 says which: a refusal (nothing wired up) or a complete install whose
-self-proof failed (files on disk, gate not to be trusted). It refuses on: a vendored copy trying to install, a
+self-proof failed (files on disk, gate not to be trusted). It refuses
+on: a vendored copy trying to install, a
 missing licence, an incomplete skill, a `<repo-root>` that is a
 subdirectory of a repository rather than its root, a destination
 redirected by a symlink, a `ci-secure` that exists and is not a
@@ -659,8 +682,11 @@ stop; do not retry blind.
 
 If it reports that `.github/workflows/ci-secure.yml` already existed, the
 install did NOT wire anything up — resolve that with the user before
-telling them they have a gate. The exit code is 0 either way, so read
-the output; do not infer success from it.
+telling them they have a gate. Read the output; never infer success from
+the exit code. `--into` exits 0 for a proved install AND for one whose
+proof could not run, and exits 1 both for a refusal and for a failed
+proof, so the status alone cannot tell you which of the four you have —
+only the proof line and the refusal message can.
 
 The install leaves everything UNCOMMITTED, and nothing runs until those
 files are on a branch GitHub can see. Say that plainly when handing over
@@ -668,8 +694,10 @@ files are on a branch GitHub can see. Say that plainly when handing over
 bind. If their tree already had uncommitted work in it, say that too:
 the vendored files are now mixed in with it.
 
-Then walk the user through the following in the message that hands the
-work over. They need it whether or not a PR gets opened. Items 1, 3 and
+Then — **only if the self-proof PASSED** — walk the user through the
+following in the message that hands the work over. They need it whether
+or not a PR gets opened. On `self-proof FAILED` this runbook does not
+apply at all: it ends in making an unusable gate a required check. Items 1, 3 and
 4 also belong in the PR body; items 2, 5 and 6 name weaknesses the repo
 still has, so on a public repository keep those out of the PR body and
 say them to the user directly — the disclosure corollary below applies

--- a/skills/ci-secure/SKILL.md
+++ b/skills/ci-secure/SKILL.md
@@ -606,10 +606,42 @@ That writes, all under `<repo-root>`:
 - `.github/workflows/ci-secure.yml`, only if it does not already exist
   (see Refresh).
 
+Then, before it reports the install complete, it **proves the gate can
+fail**. The freshly vendored gate is pointed at a throwaway workflow
+that fails a named security fact (`sec.permissions.workflow-declares`),
+and must exit non-zero AND name that fact; then at the same workflow
+with the hole closed, where it must exit 0 — because a gate wedged red
+reds on everything and proves nothing. Both fixtures are temporary files
+that are deleted afterwards: **nothing is written into the user's tree
+for the proof, and no workflow of theirs is broken to demonstrate it.**
+It then runs the gate on their real tree and prints what it found. Read
+those lines and relay both to the user:
+
+- `self-proof PASSED` — the gate has been observed failing and passing.
+  Only then is this a working install.
+- `self-proof FAILED` — the gate passed a vulnerable fixture, or redded
+  a clean one. **Do not report a working install.** Say the gate is not
+  usable, and do not walk them through going blocking.
+- `self-proof COULD NOT RUN` — the engine could not start here (it needs
+  Python 3.12 and PyYAML; the installer needs neither). The gate is
+  installed and **unproven**: say so, and tell them to re-run
+  `<repo-root>/ci-secure/scripts/vendor.py --self-test <repo-root>/ci-secure`
+  somewhere the engine runs. That command is theirs to re-run at any
+  time; it writes nothing.
+
+It also reads their `CLAUDE.md` / `AGENTS.md` / `CONTRIBUTING.md` for a
+guard-registration convention (a register of build-breaking checks, a
+mutation harness) and, if it finds one, says the new gate has NOT been
+registered with it, quoting the line. It never edits their harness —
+pass that to the user as work they own. The check is a keyword read: it
+misses conventions phrased other ways, and a false hit costs one glance.
+
 Everything that can refuse refuses before the first byte is written, and
-the workflow is written last, after the manifest. So a non-zero exit
-means at worst a partly-copied `ci-secure/`, never a live workflow with
-no gate behind it. It refuses on: a vendored copy trying to install, a
+the workflow is written last, after the manifest. So a refusal means at
+worst a partly-copied `ci-secure/`, never a live workflow with no gate
+behind it. A non-zero exit is now two different things, and the output
+says which: a refusal (nothing wired up) or a complete install whose
+self-proof failed (files on disk, gate not to be trusted). It refuses on: a vendored copy trying to install, a
 missing licence, an incomplete skill, a `<repo-root>` that is a
 subdirectory of a repository rather than its root, a destination
 redirected by a symlink, a `ci-secure` that exists and is not a
@@ -653,6 +685,10 @@ to an install PR as much as to a fix PR:
    engine, zero workflows scanned, an unrecognised outcome or an
    incomplete scan stay red, because a ramp for findings must never
    become a mute button for a broken scan.
+   The install's self-proof already showed the gate failing on a
+   throwaway fixture, so "will this ever actually block?" is answered
+   before they commit anything — and `vendor.py --self-test` re-answers
+   it whenever they want, without touching their tree.
 3. **Going blocking**, once those are burned down: drop `--advisory`
    from the "Run ci-secure" step in
    `.github/workflows/ci-secure.yml`, then require **`ci-secure`** — the
@@ -721,6 +757,11 @@ only if they ask for one.
   downstream would catch that. If the template has changed in a way they
   want, show them the diff against `<ci-secure>/scaffold/ci-secure.yml`
   and let them choose.
+- **A refresh re-proves the gate**, on the same throwaway fixtures and
+  with the same three outcomes as an install. It replaces the engine,
+  the gate and the rule, which is exactly when a gate can stop being
+  able to fail — and their `git diff` shows code, not behaviour. Relay
+  the proof line as you would on an install.
 - There is no dry run, and `--verify` compares their copy against its own
   manifest, not against this skill — so "is it already current?" can only
   be answered after the refresh, from `git diff`. If that diff is empty,

--- a/skills/ci-secure/SKILL.md
+++ b/skills/ci-secure/SKILL.md
@@ -614,8 +614,13 @@ with the hole closed, where it must exit 0 — because a gate wedged red
 reds on everything and proves nothing. Both fixtures are temporary files
 that are deleted afterwards: **nothing is written into the user's tree
 for the proof, and no workflow of theirs is broken to demonstrate it.**
-It then runs the gate on their real tree and prints what it found. Read
-those lines and relay both to the user:
+It then runs the gate on their real tree and prints what it found,
+keeping the two kinds of red apart: failed FACTS, which the shipped
+`--advisory` reports without blocking, and everything else — a crashed
+engine, an unscannable workflow, a dropped match — which stays red even
+in advisory, so their very first run will be red until it is resolved.
+Relay that distinction; it is the difference between "green on day one"
+and "red on day one". Read the proof line too, and relay it:
 
 - `self-proof PASSED` — the gate has been observed failing and passing.
   Only then is this a working install.

--- a/skills/ci-secure/scripts/vendor.py
+++ b/skills/ci-secure/scripts/vendor.py
@@ -18,8 +18,10 @@ answer "is our copy current": `--verify` compares the copy against its own
 manifest, never against this skill, so the recorded version is the only
 staleness signal and reading it is a human step.
 
-    vendor.py --into <repo>     copy in (or refresh) and write the manifest
-    vendor.py --verify <dir>    recompute the hashes and compare
+    vendor.py --into <repo>       copy in (or refresh), write the manifest, and
+                                  PROVE the installed gate can fail
+    vendor.py --verify <dir>      recompute the hashes and compare
+    vendor.py --self-test <dir>   re-run that proof on an existing copy
 
 What the manifest is NOT is a tamper seal. Anyone who can edit the vendored
 gate can edit the manifest in the same commit, and no amount of hashing changes
@@ -33,9 +35,11 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 _HERE = Path(__file__).resolve().parent
@@ -540,6 +544,284 @@ def verify(dest: Path) -> int:
     return 1
 
 
+# --------------------------------------------------------------------------
+# The self-proof: fire the installed gate once and watch it go red
+# --------------------------------------------------------------------------
+#
+# An install used to hand back a gate nobody had ever seen fail. It ships in
+# `--advisory` mode, so its first runs are green by construction, and the
+# adopter is then asked to drop that flag and make it a REQUIRED check - to
+# trust a blocking check on the strength of having watched it pass. This skill
+# says, in its own reports and in the gate's own docstring, that a check which
+# did not run is not a check that passed; the same standard has to apply to the
+# gate it installs in someone else's repository.
+#
+# So the install proves it, both ways, before it reports success:
+#
+#   RED   the gate is pointed at a throwaway workflow that fails a named
+#         security fact, and must exit non-zero AND name that fact;
+#   GREEN the gate is pointed at the same workflow with the hole closed, and
+#         must exit 0 - otherwise "it went red" proves nothing, because a gate
+#         wedged red reds on everything.
+#
+# NOTHING IS WRITTEN INTO THE ADOPTER'S TREE. Both fixtures are generated into
+# a temporary directory and deleted with it. Breaking one of their workflows to
+# watch a build go red would be the obvious way to do this and is not an
+# acceptable price for the demonstration, and a fixture committed into their
+# repository is a deliberately vulnerable workflow file sitting under
+# `.github/` forever, which their own scanners would then report.
+#
+# The fixtures are GENERATED here rather than shipped in `scaffold/`, for the
+# same reason: a tracked, intentionally-failing workflow file is content a
+# registry scanner attributes to this repository as live automation. They are
+# also deliberately dull - a workflow missing a `permissions:` block is a real,
+# scored security fact and needs no payload, no address and no command to
+# demonstrate, so nothing here looks like an attack even out of context.
+
+SELF_TEST_TIMEOUT_S = 300
+
+# The fact the RED fixture is built to fail. Asserting on the id, not merely on
+# a non-zero exit, is what stops the proof passing vacuously: the gate exits 1
+# for a dozen reasons that are not "a security fact failed" - a missing engine,
+# PyYAML absent, a crash - and every one of them would otherwise be read as
+# proof that the security check works.
+PROOF_FACT = "sec.permissions.workflow-declares"
+
+_PROOF_WORKFLOW_UNSAFE = """\
+name: ci-secure self-proof (throwaway fixture, not part of any repository)
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo self-proof
+"""
+
+# The same workflow with the hole closed. `permissions:` declared, and a
+# CODEOWNERS entry so the other file-scoped fact passes too.
+_PROOF_WORKFLOW_SAFE = """\
+name: ci-secure self-proof (throwaway fixture, not part of any repository)
+on: [push]
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo self-proof
+"""
+
+_PROOF_CODEOWNERS = ".github/ @ci-secure-self-proof\n"
+
+
+def _gate_env(dest: Path, workspace: Path) -> dict:
+    """The environment one proof run gets.
+
+    Every ambient `GITHUB_*` and `CI_SECURE_*` is dropped before ours go in. A
+    maintainer running this inside Actions would otherwise have the proof
+    append its fixture summary to the real job summary, scan `GITHUB_WORKSPACE`
+    instead of the fixture, or pick up a `CI_SECURE_ENGINE` aimed elsewhere -
+    a proof that quietly examined something other than what it says it did.
+
+    `PYTHONDONTWRITEBYTECODE` is not hygiene here, it is correctness: the gate
+    loads `config.py` by file location and the engine imports its neighbours,
+    so a proof run would otherwise leave `__pycache__` inside the vendored
+    directory - which the adopter's own drift check reds on, on every run, for
+    a file the install itself created.
+    """
+    env = {k: v for k, v in os.environ.items()
+           if not k.startswith(("GITHUB_", "CI_SECURE_"))}
+    env.update({
+        "GITHUB_WORKSPACE": str(workspace),
+        "CI_SECURE_ENGINE": str(dest / "scripts" / "scan.py"),
+        # Explicitly off: the proof must not need a token, a network, or an
+        # authenticated `gh`, and a check that silently did not run must not be
+        # part of what is being demonstrated.
+        "CI_SECURE_GH_IMPOSTOR": "off",
+        "CI_SECURE_GH_STRICT": "0",
+        "PYTHONDONTWRITEBYTECODE": "1",
+    })
+    return env
+
+
+def _run_gate(dest: Path, workspace: Path):
+    """Run the vendored gate against `workspace`. None if it did not finish."""
+    try:
+        return subprocess.run(
+            [sys.executable, str(dest / GATE_DEST)],
+            capture_output=True, text=True, errors="replace",
+            cwd=str(workspace), env=_gate_env(dest, workspace),
+            timeout=SELF_TEST_TIMEOUT_S)
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def _write_proof_tree(root: Path, workflow: str, codeowners: str = "") -> Path:
+    (root / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
+    (root / ".github" / "workflows" / "self-proof.yml").write_text(
+        workflow, encoding="utf-8")
+    if codeowners:
+        (root / ".github" / "CODEOWNERS").write_text(codeowners, encoding="utf-8")
+    return root
+
+
+def _headline(output: str) -> str:
+    for line in output.splitlines():
+        if "facts pass" in line:
+            return line.strip()
+    return "(the gate printed no headline)"
+
+
+def self_test(dest: Path) -> int:
+    """Prove the installed gate can fail, then say what it makes of this repo.
+
+    Returns 0 proved, 1 NOT proved, 2 could not be run here. The three are kept
+    apart on purpose: "this gate cannot go red" and "this machine could not run
+    the proof" are different facts about the install, and collapsing them would
+    let a missing interpreter read as a broken gate or - far worse - the other
+    way round.
+    """
+    gate = dest / GATE_DEST
+    if not gate.is_file():
+        print(f"::error::self-proof: no gate at {gate}, so there is nothing to "
+              "prove. This copy is not a working install.")
+        return 1
+
+    with tempfile.TemporaryDirectory(prefix="ci-secure-self-proof-") as tmp:
+        unsafe = _write_proof_tree(Path(tmp) / "unsafe", _PROOF_WORKFLOW_UNSAFE)
+        safe = _write_proof_tree(Path(tmp) / "safe", _PROOF_WORKFLOW_SAFE,
+                                 _PROOF_CODEOWNERS)
+        red = _run_gate(dest, unsafe)
+        green = _run_gate(dest, safe)
+
+    if red is None or green is None:
+        print("::warning::self-proof COULD NOT RUN: the gate did not finish "
+              f"within {SELF_TEST_TIMEOUT_S}s, or could not be started at all. "
+              "The gate is installed and UNPROVEN - re-run "
+              f"`vendor.py --self-test {dest}` somewhere it can run.")
+        return 2
+
+    expected = f"ci-secure fact failed: {PROOF_FACT}"
+    if red.returncode != 0 and expected not in red.stdout:
+        # Red for a reason that is not the security check: almost always the
+        # engine, which needs Python 3.12 and PyYAML while this script needs
+        # neither. Reporting that as a successful proof is the exact vacuous
+        # pass this whole function exists to prevent.
+        for line in (red.stdout + red.stderr).splitlines()[-20:]:
+            print(f"gate| {line}")
+        print("::warning::self-proof COULD NOT RUN: the gate went red on the "
+              "throwaway vulnerable workflow, but not because a security fact "
+              f"failed ({PROOF_FACT} was never reported), so it proves nothing "
+              "about the check. The usual cause is the engine's own "
+              "requirements - Python 3.12 and PyYAML - missing on this "
+              "machine; CI installs them. The gate is installed and UNPROVEN: "
+              f"re-run `vendor.py --self-test {dest}` where the engine can run.")
+        return 2
+
+    if red.returncode == 0:
+        for line in red.stdout.splitlines()[-20:]:
+            print(f"gate| {line}")
+        print("::error::self-proof FAILED: the gate passed a workflow that "
+              f"fails `{PROOF_FACT}` - it declares no `permissions:` block. A "
+              "gate that cannot go red is not a gate, and making this a "
+              "required check would add a green tick and no protection. Do not "
+              "rely on this install; the files are on disk, so review them, or "
+              "ask ci-secure to refresh the copy.")
+        return 1
+
+    if green.returncode != 0:
+        for line in green.stdout.splitlines()[-20:]:
+            print(f"gate| {line}")
+        print("::error::self-proof FAILED: the gate went red on the throwaway "
+              "workflow with the hole CLOSED, so its red on the vulnerable one "
+              "proves nothing - a gate wedged red reds on everything, and "
+              "requiring it would block every pull request. Do not rely on "
+              "this install.")
+        return 1
+
+    print(f"self-proof PASSED: pointed at a throwaway workflow that fails "
+          f"`{PROOF_FACT}`, the installed gate exited {red.returncode} and "
+          f"named that fact; pointed at the same workflow with the hole "
+          f"closed, it exited 0. The gate can fail, and it does not fail "
+          "indiscriminately. Both fixtures were temporary files, now deleted - "
+          "nothing was written into this repository.")
+    return 0
+
+
+def report_on_this_repo(dest: Path, repo: Path) -> None:
+    """Run the installed gate on the adopter's own tree and say what it found.
+
+    Read-only, and informational only: this NEVER decides whether the install
+    succeeded. A repository that has never been scanned usually reds a fact or
+    three on its first run, which is what `--advisory` is for. What the adopter
+    must not be left guessing at is which of the two they are looking at when
+    the check first appears on a pull request.
+    """
+    run = _run_gate(dest, repo)
+    if run is None:
+        print("::warning::the gate could not be run against this repository "
+              f"within {SELF_TEST_TIMEOUT_S}s, so what it will say about your "
+              "code is not known yet.")
+        return
+    failed = [line.split("::error::", 1)[1] for line in run.stdout.splitlines()
+              if line.startswith("::error::")]
+    print(f"on THIS repository, blocking (no --advisory): "
+          f"{_headline(run.stdout)}")
+    for item in failed:
+        print(f"  would block: {item}")
+    if failed:
+        print("  The workflow this install writes passes `--advisory`, so "
+              "those are REPORTED and do not block until that flag is "
+              "removed.")
+
+
+# --------------------------------------------------------------------------
+# Guard-registration conventions the host repository declares
+# --------------------------------------------------------------------------
+#
+# Some repositories keep a register of their own build-breaking checks - a
+# harness that mutates each guard and asserts it fires, a list every new check
+# has to be added to - and declare that convention in their contributor docs.
+# A gate installed without being added to it is a check that convention was
+# meant to cover and does not.
+#
+# This DETECTS and TELLS, and never edits: registering into an arbitrary repo's
+# harness means writing into files this tool knows nothing about, and guessing
+# wrong there is worse than saying nothing. It is deliberately a keyword read
+# over a handful of well-known doc paths - it will miss conventions written in
+# other words, and that is the acceptable direction to be wrong in, because the
+# cost of a miss is silence and the cost of a false hit is one sentence the
+# adopter can dismiss by reading the line it quotes.
+
+_GUARD_DOCS = ("CLAUDE.md", "AGENTS.md", "CONTRIBUTING.md",
+               ".github/CONTRIBUTING.md", "docs/CONTRIBUTING.md")
+_GUARD_DOC_BYTES = 400_000
+_GUARD_CONVENTION = re.compile(
+    r"guard[\w.:-]*\b[^\n]{0,60}\bregist"      # "every guard ... registered"
+    r"|regist\w*\b[^\n]{0,60}\bguard\b"        # "register ... guard"
+    r"|\bguard:[a-z][\w-]*",                   # a `guard:verify`-style task
+    re.IGNORECASE)
+
+
+def guard_convention_notice(repo: Path) -> list[str]:
+    """Lines quoting any guard-registration convention this repo declares."""
+    notices = []
+    for rel in _GUARD_DOCS:
+        path = repo / rel
+        if not path.is_file() or path.is_symlink():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")[
+                :_GUARD_DOC_BYTES]
+        except OSError:                          # pragma: no cover - defensive
+            continue
+        for number, line in enumerate(text.splitlines(), 1):
+            if _GUARD_CONVENTION.search(line):
+                notices.append(f"{rel}:{number}: {esc(line.strip()[:160])}")
+                break                            # one quote per file is enough
+    return notices
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     group = parser.add_mutually_exclusive_group(required=True)
@@ -547,14 +829,42 @@ def main(argv: list[str] | None = None) -> int:
                        help="repository root to vendor ci-secure into")
     group.add_argument("--verify", metavar="DIR",
                        help="vendored ci-secure directory to check")
+    group.add_argument("--self-test", metavar="DIR", dest="self_test",
+                       help="prove an installed gate can fail, against "
+                            "throwaway fixtures; writes nothing")
     args = parser.parse_args(argv)
 
     if args.verify:
         return verify(Path(args.verify).resolve())
 
-    dest = install(Path(args.into).resolve())
+    if args.self_test:
+        dest = Path(args.self_test).resolve()
+        outcome = self_test(dest)
+        report_on_this_repo(dest, dest.parent)
+        return outcome
+
+    repo = Path(args.into).resolve()
+    dest = install(repo)
     print(f"vendored ci-secure into {dest}")
-    return 0
+
+    for notice in guard_convention_notice(repo):
+        print(f"::warning::this repository documents a guard-registration "
+              f"convention and the ci-secure gate has NOT been registered "
+              f"with it - {notice}")
+
+    # The proof runs on a refresh too, and there is no flag to skip it. A
+    # refresh replaces the engine, the gate and the rule, so it is exactly a
+    # moment when a gate can stop being able to fail; and a proof that can be
+    # turned off is one that gets turned off in the script that automates the
+    # install, which is where it was most needed.
+    outcome = self_test(dest)
+    report_on_this_repo(dest, repo)
+    # Files are written either way, and the exit code says which of the two
+    # things happened: 0 the gate was proved able to fail, 1 it was not. An
+    # environment that could not run the proof (2 above) is a warning, not a
+    # failure of the install - but it is not a proof either, and the caller is
+    # told to re-run it somewhere the engine can run.
+    return 1 if outcome == 1 else 0
 
 
 if __name__ == "__main__":

--- a/skills/ci-secure/scripts/vendor.py
+++ b/skills/ci-secure/scripts/vendor.py
@@ -763,16 +763,32 @@ def report_on_this_repo(dest: Path, repo: Path) -> None:
               f"within {SELF_TEST_TIMEOUT_S}s, so what it will say about your "
               "code is not known yet.")
         return
-    failed = [line.split("::error::", 1)[1] for line in run.stdout.splitlines()
-              if line.startswith("::error::")]
+    reds = [line.split("::error::", 1)[1] for line in run.stdout.splitlines()
+            if line.startswith("::error::")]
+    # `--advisory` downgrades failed FACTS and nothing else. Every other red -
+    # a crashed engine, a workflow that could not be scanned, a dropped match,
+    # an outcome the gate cannot classify - survives the ramp, because a ramp
+    # for findings must never become a mute button for a broken scan. Reporting
+    # the two together under the advisory sentence would tell an adopter their
+    # first run is green when it is red, which is the same false reassurance
+    # this whole self-proof exists to remove.
+    facts = [item for item in reds if item.startswith("ci-secure fact failed:")]
+    integrity = [item for item in reds if item not in facts]
     print(f"on THIS repository, blocking (no --advisory): "
           f"{_headline(run.stdout)}")
-    for item in failed:
+    for item in facts:
         print(f"  would block: {item}")
-    if failed:
+    if facts:
         print("  The workflow this install writes passes `--advisory`, so "
               "those are REPORTED and do not block until that flag is "
               "removed.")
+    for item in integrity:
+        print(f"  blocks even in --advisory mode: {item}")
+    if integrity:
+        print("  `--advisory` downgrades failed FACTS only. These say the scan "
+              "itself could not be trusted, so they stay red - the first run "
+              "of this gate on this repository will be RED until they are "
+              "resolved.")
 
 
 # --------------------------------------------------------------------------

--- a/skills/ci-secure/scripts/vendor.py
+++ b/skills/ci-secure/scripts/vendor.py
@@ -597,11 +597,17 @@ jobs:
       - run: echo self-proof
 """
 
-# The same workflow with the hole closed. `permissions:` declared, and a
-# CODEOWNERS entry so the other file-scoped fact passes too.
+# The same workflow with the hole closed, and NOTHING else different. The
+# green half's whole argument is minimal delta - the gate passed this workflow
+# and failed the same one with a hole in it, so the red was about the hole -
+# and any second difference is a second explanation for the green. A gate
+# wedged red on `pull_request` workflows specifically would pass a proof whose
+# control quietly switched to `push`, while blocking every pull request in the
+# adopter's repository: exactly what the control exists to exclude. Both
+# fixture trees get the same CODEOWNERS for the same reason.
 _PROOF_WORKFLOW_SAFE = """\
 name: ci-secure self-proof (throwaway fixture, not part of any repository)
-on: [push]
+on: [pull_request]
 permissions:
   contents: read
 jobs:
@@ -665,6 +671,27 @@ def _write_proof_tree(root: Path, workflow: str, codeowners: str = "") -> Path:
     return root
 
 
+def _unproven_cause(run) -> str:
+    """One sentence about WHY a proof run is unusable - only if we observed it.
+
+    "Could not run" covers an environment the engine cannot start in AND a
+    vendored copy that is structurally broken, and they want opposite remedies:
+    re-run this elsewhere, versus this copy will never work anywhere. Asserting
+    the first for both - "the usual cause is Python and PyYAML" - sends someone
+    holding a corrupt install off to change their interpreter. The engine says
+    which it is when it can; when it cannot, saying so is the honest answer.
+    """
+    if "PyYAML is required" in run.stdout + run.stderr:
+        return ("The engine needs PyYAML and could not import it here; CI "
+                "installs it.")
+    if "engine failed to run" in run.stdout:
+        return ("The engine could not start here - most often its own "
+                "requirements are missing on this machine, which CI installs.")
+    return ("The cause is not diagnosed here: the gate's own output is quoted "
+            "above, and it distinguishes an engine that cannot start on this "
+            "machine from a vendored copy that is broken everywhere.")
+
+
 def _headline(output: str) -> str:
     for line in output.splitlines():
         if "facts pass" in line:
@@ -687,12 +714,27 @@ def self_test(dest: Path) -> int:
               "prove. This copy is not a working install.")
         return 1
 
-    with tempfile.TemporaryDirectory(prefix="ci-secure-self-proof-") as tmp:
-        unsafe = _write_proof_tree(Path(tmp) / "unsafe", _PROOF_WORKFLOW_UNSAFE)
-        safe = _write_proof_tree(Path(tmp) / "safe", _PROOF_WORKFLOW_SAFE,
-                                 _PROOF_CODEOWNERS)
-        red = _run_gate(dest, unsafe)
-        green = _run_gate(dest, safe)
+    try:
+        with tempfile.TemporaryDirectory(prefix="ci-secure-self-proof-") as tmp:
+            unsafe = _write_proof_tree(Path(tmp) / "unsafe",
+                                       _PROOF_WORKFLOW_UNSAFE,
+                                       _PROOF_CODEOWNERS)
+            safe = _write_proof_tree(Path(tmp) / "safe", _PROOF_WORKFLOW_SAFE,
+                                     _PROOF_CODEOWNERS)
+            red = _run_gate(dest, unsafe)
+            green = _run_gate(dest, safe)
+    except OSError as exc:
+        # A full disk, a read-only or absent temp filesystem, a teardown race.
+        # Left to propagate this is a bare traceback and exit 1 - the code that
+        # means "the gate cannot go red, do not rely on this install" - so an
+        # environment that could not host the fixtures would be reported as a
+        # broken gate. That is the inversion the docstring above promises not
+        # to make.
+        print(f"::warning::self-proof COULD NOT RUN: the throwaway fixtures "
+              f"could not be created or cleaned up here ({exc!r}). The gate is "
+              f"installed and UNPROVEN - re-run `vendor.py --self-test {dest}` "
+              "somewhere with a usable temporary directory.")
+        return 2
 
     if red is None or green is None:
         print("::warning::self-proof COULD NOT RUN: the gate did not finish "
@@ -701,21 +743,28 @@ def self_test(dest: Path) -> int:
               f"`vendor.py --self-test {dest}` somewhere it can run.")
         return 2
 
-    expected = f"ci-secure fact failed: {PROOF_FACT}"
+    # Anchored with the separator the gate always prints after the id. An
+    # unanchored substring reintroduces a smaller version of the hole this
+    # assertion exists to close: any id the expected one is a prefix of would
+    # satisfy it, so a fact renamed upstream - the case where the proof most
+    # needs to speak up - would read as proved.
+    expected = f"ci-secure fact failed: {PROOF_FACT} -"
     if red.returncode != 0 and expected not in red.stdout:
-        # Red for a reason that is not the security check: almost always the
-        # engine, which needs Python 3.12 and PyYAML while this script needs
-        # neither. Reporting that as a successful proof is the exact vacuous
-        # pass this whole function exists to prevent.
+        # Red for a reason that is not the security check. Reporting that as a
+        # successful proof is the exact vacuous pass this whole function exists
+        # to prevent - but it is equally wrong to name a cause we have not
+        # observed. A missing PyYAML, a vendored file that no longer parses,
+        # and a `PROOF_FACT` that upstream renamed all land here and want
+        # different remedies, so the gate's own words are quoted above and the
+        # cause is only asserted when the engine says it is the engine.
         for line in (red.stdout + red.stderr).splitlines()[-20:]:
             print(f"gate| {line}")
         print("::warning::self-proof COULD NOT RUN: the gate went red on the "
               "throwaway vulnerable workflow, but not because a security fact "
               f"failed ({PROOF_FACT} was never reported), so it proves nothing "
-              "about the check. The usual cause is the engine's own "
-              "requirements - Python 3.12 and PyYAML - missing on this "
-              "machine; CI installs them. The gate is installed and UNPROVEN: "
-              f"re-run `vendor.py --self-test {dest}` where the engine can run.")
+              f"about the check. {_unproven_cause(red)} The gate is installed "
+              f"and UNPROVEN: re-run `vendor.py --self-test {dest}` once that "
+              "is resolved.")
         return 2
 
     if red.returncode == 0:
@@ -725,13 +774,30 @@ def self_test(dest: Path) -> int:
               f"fails `{PROOF_FACT}` - it declares no `permissions:` block. A "
               "gate that cannot go red is not a gate, and making this a "
               "required check would add a green tick and no protection. Do not "
-              "rely on this install; the files are on disk, so review them, or "
-              "ask ci-secure to refresh the copy.")
+              "rely on this install. The files are already on disk - including "
+              f"`{WORKFLOW_DEST}`, which runs on every pull request from the "
+              "next push - so revert them or ask ci-secure to refresh the copy "
+              "before committing anything.")
         return 1
 
     if green.returncode != 0:
-        for line in green.stdout.splitlines()[-20:]:
+        for line in (green.stdout + green.stderr).splitlines()[-20:]:
             print(f"gate| {line}")
+        if "ci-secure fact failed:" not in green.stdout:
+            # The same classifier the red half gets, for the same reason. A red
+            # on the clean fixture that is not a failed fact - a crashed
+            # engine, an unscannable file, an outcome the gate could not
+            # classify - says nothing about whether this gate reds
+            # indiscriminately, and convicting a working install on it would
+            # send the adopter away from a gate that was never disproved.
+            print("::warning::self-proof COULD NOT RUN: the gate went red on "
+                  "the throwaway workflow with the hole CLOSED, but not "
+                  "because a security fact failed, so it says nothing about "
+                  f"whether this gate reds indiscriminately. "
+                  f"{_unproven_cause(green)} The gate is installed and "
+                  f"UNPROVEN: re-run `vendor.py --self-test {dest}` once that "
+                  "is resolved.")
+            return 2
         print("::error::self-proof FAILED: the gate went red on the throwaway "
               "workflow with the hole CLOSED, so its red on the vulnerable one "
               "proves nothing - a gate wedged red reds on everything, and "
@@ -748,7 +814,7 @@ def self_test(dest: Path) -> int:
     return 0
 
 
-def report_on_this_repo(dest: Path, repo: Path) -> None:
+def report_on_this_repo(dest: Path, repo: Path, proved: int = 0) -> None:
     """Run the installed gate on the adopter's own tree and say what it found.
 
     Read-only, and informational only: this NEVER decides whether the install
@@ -756,7 +822,29 @@ def report_on_this_repo(dest: Path, repo: Path) -> None:
     three on its first run, which is what `--advisory` is for. What the adopter
     must not be left guessing at is which of the two they are looking at when
     the check first appears on a pull request.
+
+    `proved` is what the self-proof just concluded about this gate, and it
+    gates this whole section, because a verdict is only worth as much as the
+    thing that produced it. A gate that FAILED its proof reports every
+    repository the way its defect dictates - a permanently-green one calls this
+    tree clean - and printing that under the failure reads as "the gate is
+    broken, and also your code is fine". A gate that could not run here reds on
+    this tree for that same local reason, and the integrity sentence below
+    would then promise a RED first CI run over something CI does not have.
+    Neither is an observation about the adopter's code, so neither is offered
+    as one.
     """
+    if proved == 1:
+        print("Not reporting what this gate makes of your code: it just failed "
+              "its own proof, so its verdict on any repository - including a "
+              "clean bill of health - is worth exactly nothing.")
+        return
+    if proved == 2:
+        print("What the gate will say about your code is NOT KNOWN YET: the "
+              "proof could not run on this machine, so a run against your tree "
+              "here would fail for that same local reason and say nothing "
+              "about CI.")
+        return
     run = _run_gate(dest, repo)
     if run is None:
         print("::warning::the gate could not be run against this repository "
@@ -765,6 +853,20 @@ def report_on_this_repo(dest: Path, repo: Path) -> None:
         return
     reds = [line.split("::error::", 1)[1] for line in run.stdout.splitlines()
             if line.startswith("::error::")]
+    if run.returncode != 0 and not reds:
+        # A crash is not a clean scan. The whole classifier below is built from
+        # `::error::` lines on stdout, and a gate that dies before it prints
+        # one - an unparseable vendored file, an interpreter that cannot load
+        # it, a kill on a large repository - leaves an empty red list that
+        # renders as a repository with nothing to block. That is the same false
+        # reassurance this change exists to remove, one level further in.
+        for line in (run.stdout + run.stderr).splitlines()[-20:]:
+            print(f"gate| {line}")
+        print(f"::warning::the gate exited {run.returncode} on this repository "
+              "and did not report a single finding, so the scan of your code "
+              "produced no usable result. Its own output is above. What it "
+              "will say about your code is not known yet.")
+        return
     # `--advisory` downgrades failed FACTS and nothing else. Every other red -
     # a crashed engine, a workflow that could not be scanned, a dropped match,
     # an outcome the gate cannot classify - survives the ramp, because a ramp
@@ -812,8 +914,16 @@ def report_on_this_repo(dest: Path, repo: Path) -> None:
 _GUARD_DOCS = ("CLAUDE.md", "AGENTS.md", "CONTRIBUTING.md",
                ".github/CONTRIBUTING.md", "docs/CONTRIBUTING.md")
 _GUARD_DOC_BYTES = 400_000
+# A contributor doc is adopter-controlled input, so the pattern has to be safe
+# on any of it. `guard[\w.:-]*` next to `[^\n]{0,60}` let the two quantifiers
+# compete for the same characters, which backtracks quadratically: one 400 KB
+# line of the right shape took three minutes to scan, five doc paths of it a
+# quarter of an hour, with no timeout and nothing on screen. `\w*` cannot
+# overlap the separator run in the same way, and absurd lines are skipped
+# outright below - a convention nobody could read is not one to quote.
+_GUARD_LINE_CHARS = 2_000
 _GUARD_CONVENTION = re.compile(
-    r"guard[\w.:-]*\b[^\n]{0,60}\bregist"      # "every guard ... registered"
+    r"guard\w*\b[^\n]{0,60}\bregist"           # "every guard ... registered"
     r"|regist\w*\b[^\n]{0,60}\bguard\b"        # "register ... guard"
     r"|\bguard:[a-z][\w-]*",                   # a `guard:verify`-style task
     re.IGNORECASE)
@@ -832,8 +942,16 @@ def guard_convention_notice(repo: Path) -> list[str]:
         except OSError:                          # pragma: no cover - defensive
             continue
         for number, line in enumerate(text.splitlines(), 1):
+            if len(line) > _GUARD_LINE_CHARS:
+                continue
             if _GUARD_CONVENTION.search(line):
-                notices.append(f"{rel}:{number}: {esc(line.strip()[:160])}")
+                quote = line.strip()
+                # A quote cut mid-word, presented as the whole line, defeats
+                # the bargain this check is sold on: a false hit is supposed to
+                # cost one glance, which it only does if the glance sees what
+                # the file actually says.
+                clipped = quote[:160] + ("..." if len(quote) > 160 else "")
+                notices.append(f"{rel}:{number}: {esc(clipped)}")
                 break                            # one quote per file is enough
     return notices
 
@@ -856,7 +974,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.self_test:
         dest = Path(args.self_test).resolve()
         outcome = self_test(dest)
-        report_on_this_repo(dest, dest.parent)
+        report_on_this_repo(dest, dest.parent, outcome)
         return outcome
 
     repo = Path(args.into).resolve()
@@ -864,9 +982,14 @@ def main(argv: list[str] | None = None) -> int:
     print(f"vendored ci-secure into {dest}")
 
     for notice in guard_convention_notice(repo):
-        print(f"::warning::this repository documents a guard-registration "
-              f"convention and the ci-secure gate has NOT been registered "
-              f"with it - {notice}")
+        # Hedged on purpose, because the evidence is a keyword match on one
+        # line. "This repository documents X" is a confident claim about
+        # someone's project, and the same match fires on a line saying they
+        # removed the convention. The quoted line is what settles it, so the
+        # sentence points at the line rather than asserting over it.
+        print(f"::warning::a line here reads like a guard-registration "
+              f"convention, and if it is one, the ci-secure gate has NOT been "
+              f"registered with it - {notice}")
 
     # The proof runs on a refresh too, and there is no flag to skip it. A
     # refresh replaces the engine, the gate and the rule, so it is exactly a
@@ -874,7 +997,7 @@ def main(argv: list[str] | None = None) -> int:
     # turned off is one that gets turned off in the script that automates the
     # install, which is where it was most needed.
     outcome = self_test(dest)
-    report_on_this_repo(dest, repo)
+    report_on_this_repo(dest, repo, outcome)
     # Files are written either way, and the exit code says which of the two
     # things happened: 0 the gate was proved able to fail, 1 it was not. An
     # environment that could not run the proof (2 above) is a warning, not a

--- a/tests/test_ci_secure_scaffold.py
+++ b/tests/test_ci_secure_scaffold.py
@@ -1647,11 +1647,17 @@ def test_advisory_is_only_claimed_over_the_failures_it_actually_downgrades(
     repo = tmp_path / "acme-app"
     (repo / ".github" / "workflows").mkdir(parents=True)
     assert _vendor(repo).returncode == 0
-    _stub_gate(repo / "ci-secure",
+    # Fixture-aware, so the proof reaches PASSED and the report of the
+    # adopter's own tree is actually produced: a gate that reds on the clean
+    # fixture too has failed its proof, and a gate that failed its proof is not
+    # allowed to hand over a verdict about anyone's code.
+    _stub_gate(repo / "ci-secure", _FIXTURE_AWARE_GATE +
                "print('::error::ci-secure fact failed: sec.codeowners.workflows"
                " - no CODEOWNERS file')\n"
                "print('::error::ci-secure scan incomplete: 1 workflow file(s) "
-               "could not be parsed')\nsys.exit(1)\n")
+               "could not be parsed')\n"
+               "print('5/6 facts pass of 6 applicable, 1 workflow file(s) "
+               "scanned')\nsys.exit(1)\n")
 
     proof = _self_test(repo / "ci-secure")
     report = proof.stdout
@@ -1670,3 +1676,293 @@ def test_advisory_is_only_claimed_over_the_failures_it_actually_downgrades(
         f"run will be red with it: {downgraded}\n" + report)
     assert "blocks even in --advisory" in report, (
         "the report must name the reds that survive the ramp:\n" + report)
+
+
+# --------------------------------------------------------------------------
+# 5. What the install says when the proof did NOT happen
+# --------------------------------------------------------------------------
+#
+# The proof itself is sound - a permanently-green gate, a wedged-red gate and
+# an engine that cannot start are all caught. The remaining ways to mislead an
+# adopter are all at the boundary: the report of what the gate makes of THEIR
+# tree is computed and printed unconditionally, by the same gate, whatever the
+# proof just concluded about it. A verdict from a gate that failed its proof is
+# not a verdict, and a verdict from a gate that could not run at all is not
+# even an observation - neither may be handed over as one.
+
+
+# A gate whose behaviour on the throwaway fixtures is correct, so the proof
+# reaches its verdict, and whose behaviour on the adopter's real tree the test
+# dictates. The fixtures live under a temp dir whose name the proof chooses, so
+# the two are told apart by the directory the gate was pointed at.
+_FIXTURE_AWARE_GATE = """\
+import pathlib, sys
+cwd = pathlib.Path.cwd()
+if "ci-secure-self-proof" in str(cwd):
+    workflow = (cwd / ".github" / "workflows" / "self-proof.yml").read_text()
+    if "permissions:" in workflow:
+        print("6/6 facts pass of 6 applicable, 1 workflow file(s) scanned")
+        sys.exit(0)
+    print("::error::ci-secure fact failed: sec.permissions.workflow-declares"
+          " - no `permissions:` block")
+    print("5/6 facts pass of 6 applicable, 1 workflow file(s) scanned")
+    sys.exit(1)
+"""
+
+
+def test_a_gate_that_crashes_on_the_adopters_tree_is_not_reported_as_finding_nothing(
+        tmp_path: Path) -> None:
+    """A crash is not a clean scan, and an empty red list must never say it is.
+
+    The report is built entirely by grepping the gate's stdout for `::error::`.
+    A gate that dies before it can print one - a syntax error in a vendored
+    file, an interpreter that cannot load it, a kill on a large repository -
+    produces no reds and a missing headline, which renders as a repository with
+    nothing to report. That is the same false reassurance in the same sentence
+    this whole change exists to remove, one level further in: the proof passed,
+    so the adopter is told the gate works AND that their tree is clean, when
+    the scan of their tree never happened.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    assert _vendor(repo).returncode == 0
+    _stub_gate(repo / "ci-secure", _FIXTURE_AWARE_GATE + (
+        'import sys\n'
+        'print("boom: the gate could not start", file=sys.stderr)\n'
+        'sys.exit(1)\n'))
+
+    proof = _self_test(repo / "ci-secure")
+    report = proof.stdout.split("on THIS repository", 1)[-1]
+
+    assert "self-proof PASSED" in proof.stdout, proof.stdout
+    assert "did not report" in report or "no usable" in report, (
+        "a gate that exited non-zero without printing a single red was "
+        "reported as a repository with nothing to block:\n" + proof.stdout)
+    assert "boom: the gate could not start" in proof.stdout, (
+        "the gate's own error output is the only diagnostic there is, and it "
+        "was discarded:\n" + proof.stdout + proof.stderr)
+
+
+def test_a_proof_that_could_not_run_never_claims_the_first_ci_run_will_be_red(
+        tmp_path: Path) -> None:
+    """The over-warn inverse, and it fires on the ordinary adopter laptop.
+
+    When the engine cannot start here, the gate reds on the adopter's tree for
+    that reason too - and the report then names it as an integrity failure that
+    survives `--advisory` and makes their first run RED. There is nothing for
+    them to resolve: their repository is fine and CI installs what this machine
+    is missing. The install would be telling them, in the same breath as "the
+    proof could not run here", a confident fact about a CI run it has no
+    evidence about.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    assert _vendor(repo).returncode == 0
+    _stub_gate(repo / "ci-secure",
+               'print("::error::ci-secure engine failed to run")\n'
+               'sys.exit(1)\n')
+
+    proof = _self_test(repo / "ci-secure")
+
+    assert proof.returncode == 2, proof.stdout + proof.stderr
+    assert "COULD NOT RUN" in proof.stdout, proof.stdout
+    assert "will be RED" not in proof.stdout, (
+        "the install told the adopter their first CI run will be red, on the "
+        "strength of a gate that could not run on this machine at all:\n"
+        + proof.stdout)
+
+
+def test_a_gate_that_failed_its_proof_does_not_hand_over_a_verdict_on_the_repo(
+        tmp_path: Path) -> None:
+    """A verdict from a gate that cannot block is not a verdict.
+
+    A permanently-green gate reports every repository as clean, including this
+    one. Printing that immediately under `self-proof FAILED` reads as "the gate
+    is broken, and also your code is fine" - the second half being produced by
+    the first half's defect.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    assert _vendor(repo).returncode == 0
+    _stub_gate(repo / "ci-secure", "sys.exit(0)\n")
+
+    proof = _self_test(repo / "ci-secure")
+
+    assert proof.returncode == 1 and "self-proof FAILED" in proof.stdout
+    assert "blocking (no --advisory)" not in proof.stdout, (
+        "a gate that just failed its own proof was allowed to hand over a "
+        "verdict about the adopter's code as though it meant something:\n"
+        + proof.stdout)
+
+
+def test_a_non_fact_red_on_the_CLEAN_fixture_is_not_called_a_wedged_gate(
+        tmp_path: Path) -> None:
+    """The green half needs the same classifier the red half already has.
+
+    "Red, but not because a security fact failed" is carefully separated from a
+    real failure on the vulnerable fixture - it becomes COULD NOT RUN, because
+    a crashed engine says nothing about the check. The clean fixture has no
+    such branch: any non-zero exit is attributed to a gate "wedged red", which
+    condemns the install and tells the adopter not to go blocking. An engine
+    that hiccups on the second of two runs must not convict a working gate.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    assert _vendor(repo).returncode == 0
+    _stub_gate(repo / "ci-secure",
+               'import pathlib\n'
+               'workflow = (pathlib.Path.cwd() / ".github" / "workflows"\n'
+               '            / "self-proof.yml").read_text()\n'
+               'if "permissions:" in workflow:\n'
+               '    print("::error::ci-secure scan incomplete: 1 workflow "\n'
+               '          "file(s) could not be parsed")\n'
+               '    sys.exit(1)\n'
+               'print("::error::ci-secure fact failed: '
+               'sec.permissions.workflow-declares - stub")\n'
+               'sys.exit(1)\n')
+
+    proof = _self_test(repo / "ci-secure")
+
+    assert proof.returncode == 2, (
+        "a scan-integrity red on the CLEAN fixture was scored as a gate wedged "
+        "red, condemning an install the proof never actually disproved:\n"
+        + proof.stdout + proof.stderr)
+    assert "COULD NOT RUN" in proof.stdout, proof.stdout
+    assert "wedged red" not in proof.stdout, proof.stdout
+
+
+def test_the_green_control_differs_from_the_red_fixture_only_by_the_hole_it_closes(
+        tmp_path: Path) -> None:
+    """"The same workflow with the hole closed" has to be literally true.
+
+    The green half's entire argument is minimal delta: the gate passed THIS
+    workflow and failed the SAME one with a hole in it, so the red was about
+    the hole. Every other difference between the two fixtures is a second
+    explanation for the green, and the printed proof line, SKILL.md and the
+    changelog all state there are none. A gate wedged red on `pull_request`
+    workflows specifically - red on the vulnerable fixture, green on a `push`
+    one - would satisfy a two-fixture proof while blocking every pull request
+    in the adopter's repository, which is precisely what the control exists to
+    exclude.
+    """
+    vendor = _load_vendor_module()
+    hole_closed = [line for line in vendor._PROOF_WORKFLOW_SAFE.splitlines()
+                   if line not in ("permissions:", "  contents: read")]
+
+    assert hole_closed == vendor._PROOF_WORKFLOW_UNSAFE.splitlines(), (
+        "the green control varies more than the fact under test, so its pass "
+        "has more than one explanation:\n"
+        f"  red:   {vendor._PROOF_WORKFLOW_UNSAFE!r}\n"
+        f"  green: {vendor._PROOF_WORKFLOW_SAFE!r}")
+
+
+def test_the_install_itself_exits_non_zero_when_the_gate_cannot_fail(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`--into` is the invocation the runbook prescribes, so pin ITS exit code.
+
+    Every other test here drives `--self-test`. The path an automated installer
+    depends on - `vendor.py --into … || stop` - is the one that decides whether
+    a broken gate gets committed unattended, and nothing pinned it: the proof's
+    verdict could stop reaching the process exit status entirely without a
+    single test noticing.
+
+    A stub gate cannot be used here - `--into` re-vendors, which overwrites it
+    with the real one - so the verdict is injected at the seam instead, and
+    what is under test is only that it reaches the process exit status.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    vendor = _load_vendor_module()
+    monkeypatch.setattr(vendor, "self_test", lambda dest: 1)
+    monkeypatch.setattr(vendor, "report_on_this_repo",
+                        lambda dest, repo, proved=0: None)
+
+    assert vendor.main(["--into", str(repo)]) == 1, (
+        "an install that watched the gate pass a vulnerable workflow still "
+        "reported success to its caller")
+
+    monkeypatch.setattr(vendor, "self_test", lambda dest: 2)
+    assert vendor.main(["--into", str(repo)]) == 0, (
+        "an environment that could not run the proof was reported as a failed "
+        "install; the files are on disk and the outcome is a warning")
+
+
+def test_a_renamed_fact_does_not_satisfy_the_proof_by_prefix(
+        tmp_path: Path) -> None:
+    """The fact-id assertion has to be about THE fact, not anything starting with it.
+
+    The whole reason the proof asserts on an id rather than a non-zero exit is
+    that "it went red" is also what a crashed engine looks like. An unanchored
+    substring match reintroduces a smaller version of the same hole: any id for
+    which the expected one is a prefix satisfies it, so a fact that was renamed
+    - the case where the proof most needs to speak up - reads as proved.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    assert _vendor(repo).returncode == 0
+    _stub_gate(repo / "ci-secure",
+               'import pathlib\n'
+               'workflow = (pathlib.Path.cwd() / ".github" / "workflows"\n'
+               '            / "self-proof.yml").read_text()\n'
+               'if "permissions:" in workflow:\n'
+               '    sys.exit(0)\n'
+               'print("::error::ci-secure fact failed: '
+               'sec.permissions.workflow-declares-RENAMED - stub")\n'
+               'sys.exit(1)\n')
+
+    proof = _self_test(repo / "ci-secure")
+
+    assert "self-proof PASSED" not in proof.stdout, (
+        "a fact id the engine no longer has satisfied the proof because the "
+        "expected id is a prefix of it:\n" + proof.stdout)
+    assert proof.returncode == 2, proof.stdout + proof.stderr
+
+
+def test_the_guard_convention_read_cannot_hang_the_install(
+        tmp_path: Path) -> None:
+    """A contributor doc is adopter-controlled input. It must not be able to stall.
+
+    The convention pattern nests two unbounded-ish quantifiers over the same
+    characters, so a single long line of the right shape backtracks
+    quadratically - minutes per file, five files, with no timeout and no
+    output. An install that hangs on someone's `CONTRIBUTING.md` is a denial of
+    service delivered by the thing that was supposed to help them.
+    """
+    import time
+
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    (repo / "CLAUDE.md").write_text("guard" * 40_000 + "\n", encoding="utf-8")
+    vendor = _load_vendor_module()
+
+    started = time.monotonic()
+    vendor.guard_convention_notice(repo)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 5, (
+        f"one adopter-supplied line took {elapsed:.1f}s to scan; five doc "
+        "paths of it would stall the install for minutes with no output")
+
+
+def test_the_guard_notice_does_not_state_a_keyword_hit_as_established_fact(
+        tmp_path: Path) -> None:
+    """It is a keyword read, and the sentence has to carry the hedge it claims.
+
+    The design accepts false hits - the cost is one glance at the quoted line -
+    but that bargain only holds if the notice reads as something to check. A
+    line saying the opposite ("we removed the guard registry") matches, and an
+    unqualified "this repository documents a guard-registration convention"
+    then asserts, confidently and wrongly, a fact about the adopter's project.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    (repo / "CLAUDE.md").write_text(
+        "# acme\n\nDo NOT register guards anywhere; we removed the guard "
+        "registry in 2024.\n", encoding="utf-8")
+
+    install = _vendor(repo)
+
+    assert "CLAUDE.md:3" in install.stdout, install.stdout
+    assert "reads like" in install.stdout or "may document" in install.stdout, (
+        "a keyword match was stated as an established fact about the "
+        "repository:\n" + install.stdout)

--- a/tests/test_ci_secure_scaffold.py
+++ b/tests/test_ci_secure_scaffold.py
@@ -1481,12 +1481,24 @@ def test_the_self_proof_writes_nothing_into_the_adopters_repository(
     """
     repo = tmp_path / "acme-app"
     (repo / ".github" / "workflows").mkdir(parents=True)
+    # Baselined BEFORE the install, because the install runs the proof too. A
+    # baseline taken afterwards bakes any leak the proof committed during the
+    # install into "before", and this is the test that owns the claim.
+    pristine = _census(repo)
     assert _vendor(repo).returncode == 0
     before = _census(repo)
+    installed = set(before) - set(pristine)
 
     proof = _self_test(repo / "ci-secure")
 
     assert proof.returncode == 0, proof.stdout + proof.stderr
+    assert not [path for path in installed
+                if not path.startswith(("ci-secure/", ".github/workflows/"))], (
+        "the install put files somewhere it does not document writing to, "
+        f"which is where a leaked fixture would land: {sorted(installed)}")
+    assert not [path for path in installed if "self-proof" in path], (
+        "a throwaway proof fixture was left behind in the adopter's tree: "
+        f"{sorted(installed)}")
     assert _census(repo) == before, (
         "the self-proof changed the adopter's tree: "
         f"{sorted(set(_census(repo)) ^ set(before))}")
@@ -1966,3 +1978,32 @@ def test_the_guard_notice_does_not_state_a_keyword_hit_as_established_fact(
     assert "reads like" in install.stdout or "may document" in install.stdout, (
         "a keyword match was stated as an established fact about the "
         "repository:\n" + install.stdout)
+
+
+def test_the_quoted_guard_line_cannot_forge_a_workflow_annotation(
+        tmp_path: Path) -> None:
+    """The line comes out of someone else's `CLAUDE.md` and goes into a log sink.
+
+    A `::warning::` is a command channel, not a text field. A newline in the
+    quoted line forges a `::notice::` on the check run, and `::stop-commands::`
+    swallows everything printed after it - so an install run inside Actions
+    against a repository whose contributor doc is hostile could rewrite what the
+    log says about itself. `esc()` exists for exactly this and nothing pinned
+    its use here.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    (repo / "CLAUDE.md").write_text(
+        "# acme\n\nEvery guard must be registered."
+        "%0A::notice::all clear%0A::stop-commands::ci-secure\n",
+        encoding="utf-8")
+
+    install = _vendor(repo)
+
+    assert "CLAUDE.md:3" in install.stdout, install.stdout
+    for line in install.stdout.splitlines():
+        assert not line.lstrip().startswith(("::notice::", "::stop-commands::")), (
+            "a contributor doc forged a workflow command through the guard "
+            f"notice: {line!r}\n" + install.stdout)
+    assert "%250A" in install.stdout, (
+        "the quoted line reached the log unescaped:\n" + install.stdout)

--- a/tests/test_ci_secure_scaffold.py
+++ b/tests/test_ci_secure_scaffold.py
@@ -1629,3 +1629,44 @@ def test_a_repository_with_no_such_convention_is_not_told_it_has_one(
     install = _vendor(repo)
 
     assert "guard-registration convention" not in install.stdout, install.stdout
+
+
+def test_advisory_is_only_claimed_over_the_failures_it_actually_downgrades(
+        tmp_path: Path) -> None:
+    """`--advisory` downgrades failed FACTS. Nothing else, and the report must agree.
+
+    The workflow this installer writes passes that flag, so the report of what
+    the gate makes of the adopter's own tree has to say which of its reds the
+    flag will silence. Every red is not that set: a crashed engine, a workflow
+    that could not be scanned, a dropped match and an unrecognised outcome stay
+    red in advisory mode on purpose - a ramp for findings must never become a
+    mute button for a broken scan. Telling an adopter their first run will be
+    green when it will be red is the same class of false reassurance this whole
+    change exists to remove.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    assert _vendor(repo).returncode == 0
+    _stub_gate(repo / "ci-secure",
+               "print('::error::ci-secure fact failed: sec.codeowners.workflows"
+               " - no CODEOWNERS file')\n"
+               "print('::error::ci-secure scan incomplete: 1 workflow file(s) "
+               "could not be parsed')\nsys.exit(1)\n")
+
+    proof = _self_test(repo / "ci-secure")
+    report = proof.stdout
+
+    assert "sec.codeowners.workflows" in report and "scan incomplete" in report, (
+        "both reds must reach the adopter:\n" + report)
+    section = report.split("on THIS repository", 1)[1].splitlines()
+    ramped = [line for line in section if "REPORTED and do not block" in line]
+    assert ramped, (
+        "the report must say which reds the shipped flag silences:\n" + report)
+    downgraded = [line for line in section[:section.index(ramped[0])]
+                  if "would block:" in line]
+    assert downgraded and all("fact failed" in line for line in downgraded), (
+        "a red that is not a failed fact was described as downgraded by "
+        "`--advisory`, which it is not - it stays red and the adopter's first "
+        f"run will be red with it: {downgraded}\n" + report)
+    assert "blocks even in --advisory" in report, (
+        "the report must name the reds that survive the ramp:\n" + report)

--- a/tests/test_ci_secure_scaffold.py
+++ b/tests/test_ci_secure_scaffold.py
@@ -1392,3 +1392,240 @@ def test_the_recorded_source_commit_is_a_sha_or_says_why_it_is_not(
                         recorded), (
         "vendoring from this source checkout must record its real commit, "
         f"not a marker: {recorded!r}")
+
+
+# --------------------------------------------------------------------------
+# 4. The self-proof: the install watches the gate fail before reporting success
+# --------------------------------------------------------------------------
+#
+# The gate ships in `--advisory` mode, so an adopter's first runs are green by
+# construction, and the runbook then asks them to drop that flag and make it a
+# required check. Until this section existed, that was a request to trust a
+# blocking check nobody had ever seen go red. The engine's own reports say a
+# check that did not run is not a check that passed; these tests hold the
+# installer to it.
+
+
+def _self_test(vendored: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(vendored / "scripts" / "vendor.py"),
+         "--self-test", str(vendored)],
+        capture_output=True, text=True)
+
+
+def _census(root: Path) -> dict:
+    """Every file under `root`, by path and content hash."""
+    return {p.relative_to(root).as_posix(): hashlib.sha256(p.read_bytes()).hexdigest()
+            for p in sorted(root.rglob("*")) if p.is_file()}
+
+
+def _stub_gate(vendored: Path, body: str) -> None:
+    """Replace the vendored gate with one whose verdict the test dictates."""
+    (vendored / "scripts" / "gate.py").write_text(
+        "import sys\n" + body, encoding="utf-8")
+
+
+def test_the_install_proves_the_gate_can_fail_before_reporting_success(
+        tmp_path: Path) -> None:
+    """Red on a vulnerable fixture, green on the same fixture repaired.
+
+    Both halves are load-bearing. Without the red the adopter is asked to
+    require a check that has only ever been observed passing; without the green
+    a gate wedged red - one that reds on everything, protects nothing and
+    blocks every pull request - would read as a successful proof.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+
+    install = _vendor(repo)
+
+    assert install.returncode == 0, install.stdout + install.stderr
+    assert "self-proof PASSED" in install.stdout, (
+        "the install reported success without ever watching the gate fail:\n"
+        + install.stdout)
+    assert "sec.permissions.workflow-declares" in install.stdout, (
+        "the proof must name the fact it made the gate fail on - 'it exited "
+        "non-zero' is also what a crashed engine looks like:\n" + install.stdout)
+
+
+def test_the_install_says_what_the_gate_makes_of_this_repository(
+        tmp_path: Path) -> None:
+    """The second half of the handover: proved it can fail, now what does it say?
+
+    A proof against a fixture answers "can this ever go red". It does not
+    answer "will it go red on MY code", which is the question that decides
+    whether dropping `--advisory` is a five-minute change or a week of work.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+
+    install = _vendor(repo)
+
+    assert "on THIS repository" in install.stdout, install.stdout
+    assert "facts pass" in install.stdout, (
+        "the install did not say what the gate found in the adopter's own "
+        "tree:\n" + install.stdout)
+
+
+def test_the_self_proof_writes_nothing_into_the_adopters_repository(
+        tmp_path: Path) -> None:
+    """The demonstration must not cost the adopter a single byte of their tree.
+
+    Two ways to get this wrong, and both were on the table: break one of their
+    workflows so a real build goes red, or drop a deliberately vulnerable
+    fixture under their `.github/`, where it outlives the install and their own
+    scanners find it. The fixtures are temporary files instead, and the vendored
+    copy still verifies afterwards - which also catches the subtle one, the
+    `__pycache__` a proof run leaves beside the engine it just executed and the
+    adopter's own drift check then reds on forever.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    assert _vendor(repo).returncode == 0
+    before = _census(repo)
+
+    proof = _self_test(repo / "ci-secure")
+
+    assert proof.returncode == 0, proof.stdout + proof.stderr
+    assert _census(repo) == before, (
+        "the self-proof changed the adopter's tree: "
+        f"{sorted(set(_census(repo)) ^ set(before))}")
+    assert not list((repo / "ci-secure").rglob("__pycache__")), (
+        "the proof left bytecode in the vendored tree, which the adopter's own "
+        "drift check reds on")
+    assert _verify(repo / "ci-secure").returncode == 0, (
+        "the vendored copy no longer matches its manifest after a self-proof")
+
+
+def test_a_gate_that_cannot_fail_is_reported_as_a_broken_install(
+        tmp_path: Path) -> None:
+    """The whole point: a permanently-green gate must not pass for a working one.
+
+    This is the regression the website install actually hit - a build-breaking
+    verdict that nothing ever exercised, so a change making it green forever
+    would ship unnoticed. Here the gate is replaced with one that always exits
+    0, which is what that regression looks like from outside.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    assert _vendor(repo).returncode == 0
+    _stub_gate(repo / "ci-secure", "sys.exit(0)\n")
+
+    proof = _self_test(repo / "ci-secure")
+
+    assert proof.returncode == 1, (
+        "a gate that passes a workflow with no `permissions:` block was "
+        "accepted as a working install:\n" + proof.stdout + proof.stderr)
+    assert "self-proof FAILED" in proof.stdout, proof.stdout
+    assert "self-proof PASSED" not in proof.stdout
+
+
+def test_a_gate_wedged_red_is_not_accepted_as_proof(tmp_path: Path) -> None:
+    """Red on everything is not the same as red on the right thing.
+
+    A gate that fails whatever it is pointed at satisfies "watch it go red" and
+    would then block every pull request in the repository the moment it became
+    a required check. The green control is what separates the two, so it is
+    tested with a gate that cannot produce one.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    assert _vendor(repo).returncode == 0
+    _stub_gate(repo / "ci-secure",
+               "print('::error::ci-secure fact failed: "
+               "sec.permissions.workflow-declares - stub')\nsys.exit(1)\n")
+
+    proof = _self_test(repo / "ci-secure")
+
+    assert proof.returncode == 1, (
+        "a gate that reds on a clean fixture too was accepted as proved:\n"
+        + proof.stdout + proof.stderr)
+    assert "self-proof FAILED" in proof.stdout, proof.stdout
+    assert "hole CLOSED" in proof.stdout, (
+        "the failure must say which half of the proof failed:\n" + proof.stdout)
+
+
+def test_a_red_for_a_reason_that_is_not_the_check_is_never_a_proof(
+        tmp_path: Path) -> None:
+    """"Exited non-zero" is also what a missing PyYAML looks like.
+
+    The engine needs Python 3.12 and PyYAML; this installer needs neither, so
+    an install can land on a machine where the engine cannot start. That reds
+    the gate - for a reason that says nothing whatsoever about the security
+    check - and must be reported as a proof that could not be run, distinct
+    from both a proved gate and a broken one.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    assert _vendor(repo).returncode == 0
+    _stub_gate(repo / "ci-secure",
+               "print('::error::ci-secure engine failed to run')\nsys.exit(1)\n")
+
+    proof = _self_test(repo / "ci-secure")
+
+    assert proof.returncode == 2, (
+        "an engine that could not start was scored as a proved gate, a broken "
+        "one, or nothing at all:\n" + proof.stdout + proof.stderr)
+    assert "COULD NOT RUN" in proof.stdout, proof.stdout
+    assert "self-proof PASSED" not in proof.stdout
+
+
+def test_a_refresh_re_proves_the_gate(tmp_path: Path) -> None:
+    """A refresh replaces the engine, the gate and the rule. Prove it again.
+
+    That is precisely a moment when a gate can stop being able to fail, and the
+    adopter has no other signal: a refresh writes no workflow and its `git diff`
+    shows code, not behaviour.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    assert _vendor(repo).returncode == 0
+
+    refresh = _vendor(repo)
+
+    assert refresh.returncode == 0, refresh.stdout + refresh.stderr
+    assert "this is a refresh" in refresh.stdout, refresh.stdout
+    assert "self-proof PASSED" in refresh.stdout, (
+        "a refresh handed back a gate it never watched fail:\n" + refresh.stdout)
+
+
+@pytest.mark.parametrize("doc", ["CLAUDE.md", "AGENTS.md", "CONTRIBUTING.md"])
+def test_a_documented_guard_register_is_named_as_unregistered(
+        tmp_path: Path, doc: str) -> None:
+    """Say plainly that the new gate is not in their register, rather than walk past.
+
+    A repository that keeps a register of its build-breaking checks - a harness
+    that mutates each one and asserts it fires - gains a check that register
+    does not cover. Nothing here edits their harness: the install has no idea
+    what shape it takes, and guessing would write into files it knows nothing
+    about.
+    """
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    (repo / doc).write_text(
+        "# acme\n\nEvery build-breaking guard must be registered with the "
+        "mutation harness.\n", encoding="utf-8")
+
+    install = _vendor(repo)
+
+    assert install.returncode == 0, install.stdout + install.stderr
+    assert "guard-registration convention" in install.stdout, (
+        f"the convention declared in {doc} was walked past in silence:\n"
+        + install.stdout)
+    assert "has NOT been registered" in install.stdout, install.stdout
+    assert f"{doc}:3" in install.stdout, (
+        "the notice must quote the line it read, so a false hit costs the "
+        "adopter one glance:\n" + install.stdout)
+
+
+def test_a_repository_with_no_such_convention_is_not_told_it_has_one(
+        tmp_path: Path) -> None:
+    """The negative control. A notice on every install is a notice nobody reads."""
+    repo = tmp_path / "acme-app"
+    (repo / ".github" / "workflows").mkdir(parents=True)
+    (repo / "CLAUDE.md").write_text(
+        "# acme\n\nRun the tests before you push.\n", encoding="utf-8")
+
+    install = _vendor(repo)
+
+    assert "guard-registration convention" not in install.stdout, install.stdout


### PR DESCRIPTION
## TL;DR

ci-secure can install itself as a blocking CI check in someone's repository. Until now nothing ever proved that installed check could fail, so adopters were asked to make a gate required having only ever seen it pass. The install now fires the freshly vendored gate at a throwaway vulnerable workflow, watches it fail, watches it pass a repaired copy, and refuses to report a working install if either half goes wrong. Not one byte is written into the adopter's repository to do it.

```
before:  vendor files  ->  "installed, now make it required"   (never seen fail)
after:   vendor files  ->  RED on a throwaway vulnerable fixture, naming the fact
                       ->  GREEN on the same fixture repaired
                       ->  report what the gate says about YOUR tree
                       ->  only then: "installed"
         (both fixtures are temp files, deleted; the repo is untouched)
```

## Why both halves

A gate that always fails blocks every pull request once required, so "it went red" is not proof on its own. The red half asserts the exit is non-zero **and** that the specific failing fact is named, because the gate exits non-zero for a dozen reasons that say nothing about security. The green control then separates a working gate from a wedged one.

## Nothing is written into the adopter's tree

The fixtures are generated into temp files and deleted. No workflow of theirs is broken to test the gate, and no fixture is committed to their repository. Verified by execution rather than inspection: a full before/after `git status` on a throwaway repo shows the delta is exactly the ten documented install paths, with no `__pycache__`, no temp residue and no git state change. `$GITHUB_ENV`, `$GITHUB_OUTPUT` and `$GITHUB_STEP_SUMMARY` are all still empty after a simulated Actions run; removing the stripped environment writes 1605 bytes to the job summary, so that hygiene is load-bearing.

## Three outcomes, deliberately not two

**proved** — the gate was observed failing and passing. Only then is this a working install.

**FAILED** — the gate passed a vulnerable fixture, or redded a clean one. Loud, non-zero, and the runbook says not to report a working install or walk the owner through going blocking.

**could not run** — the engine needs PyYAML, which the installer does not, so an install can land where the engine cannot start. Reported as installed-and-unproven with the command to re-run, never as either of the above. A missing interpreter and a gate that cannot fail must not look the same.

Refreshes re-prove on the same fixtures, since a refresh replaces the engine, the gate and the rule, which is exactly when a gate can stop being able to fail. There is no flag to skip the proof: a proof that can be turned off is one that gets turned off in the script that automates the install, which is where it was needed most. `vendor.py --self-test <vendored dir>` re-runs it on demand and writes nothing.

## What review found

Adversarial review mutated the self-proof rather than reading it. A permanently-green gate, a wedged-red gate and an engine that cannot start were all caught. **One mutation was not, and it was the one this feature is named for.**

The fixtures were not a minimal pair: only the green tree had a CODEOWNERS file, and the trigger differed too. Neutering the permissions fact so it could never fail still left the red fixture exiting non-zero, because a different fact failed in its place. The proof then reported "could not run" and exited 0 — a dead security check handed back as a laptop problem. Both fixtures now differ only by the `permissions:` block.

```
before:  red fixture (no CODEOWNERS, pull_request)  vs  green (CODEOWNERS, push)
         -> three differences, so a green has three explanations
after:   red fixture  vs  the same file plus `permissions:`
         -> one difference, so a green has one
```

Also fixed: a crashed gate read as a clean repository, because the report was built from `::error::` lines and never looked at the exit code. Verdicts survived the gate that produced them, so a permanently-green gate called the tree clean directly under `self-proof FAILED`. A non-fact red on the clean fixture convicted a working install. The fact-id assertion matched by unanchored prefix. `--into`'s propagation of a failed proof to its exit status was untested and survived being mutated away. An `OSError` creating fixtures escaped as a traceback under the exit code reserved for a broken gate. The guard-convention regex backtracked quadratically, taking 180 seconds on one 400 KB line, silently. Three stale runbook instructions went with them, including "the exit code is 0 either way", which this PR made false.

## Red proof

Twelve new tests. Against the pre-change installer, eleven of the twelve fail:

```
FAILED test_the_install_proves_the_gate_can_fail_before_reporting_success
E   AssertionError: the install reported success without ever watching the gate fail:
E     wrote the workflow to .github/workflows/ci-secure.yml
E     vendored ci-secure into .../acme-app/ci-secure
```

The single pass is the negative control: a repository with no guard-registration convention is not told it has one, which is correct before and after. Every behavioural fix from the review round carries its own test, proven red against the commit before it. Full suite green on the version CI runs.

## Secondary: guard registration

When the host repository documents a guard-registration convention, the install says the new gate has not been registered with it and quotes the line it matched. It detects and tells; it never edits anyone's harness.

## Known residuals

Deliberately not taken here: `--into` still exits 0 when the proof could not run, so an automated caller cannot tell proved from unproven by status alone; `--self-test` infers the repo root as the vendored directory's parent without checking; the repository preview forces the network-gated impostor detector off without disclosing it; and three sequential 300-second gate runs share no aggregate budget.

## Merge collision to reconcile

#59 moves the gate runbook out of `SKILL.md` into a new `references/ci-gate.md`. This branch is based on `main`, where the runbook is still in `SKILL.md`, and edits it there. Whichever lands second must carry those edits into wherever the runbook then lives. The `vendor.py`, test and changelog changes do not collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
