### PR TITLE
examples: regenerate the ci-secure pair from an on-main scanner commit

### DIFF
--- a/examples/snowflakedb-snowflake-connector-net/README.md
+++ b/examples/snowflakedb-snowflake-connector-net/README.md
@@ -46,16 +46,17 @@ The same catalog, the same file, the same command — 3 findings before, 0 after
   `.github/workflows/jira_issue.yml` only, at the two commits above (clean tree
   in both cases — the reports' `Audited commit` rows carry no dirty marker).
 - **Scanner:** `ci-secure` at `starslingdev/skills` commit
-  [`553baad`](https://github.com/starslingdev/skills/commit/553baad), run from a
-  clean checkout of that commit. The reports stamp the same SHA, and both
-  findings JSONs record `skill_tree_dirty: false`.
+  [`3545d1b`](https://github.com/starslingdev/skills/commit/3545d1b), run from a
+  clean checkout of that commit on `main`. The reports stamp the same SHA, and
+  both findings JSONs record `skill_tree_dirty: false`.
 - **One spliced field.** Each finding's `attacker_scenario` is the prose the
   skill's own Phase 2.5 wrote for these exact findings on an earlier run at
-  commit `a43d237`, carried forward when the reports were re-rendered against
-  the partial-checkout coverage fix. Every other field, including all three
-  file:line locations and their quoted evidence, is byte-identical between the
-  two runs; nothing was hand-authored, and no number or finding was edited.
-- **Generated:** 2026-08-17 (UTC).
+  commit `a43d237`, carried forward each time the reports were re-rendered
+  (first against the partial-checkout coverage fix, then against the on-`main`
+  scanner commit above). Every other field, including all three file:line
+  locations and their quoted evidence, is byte-identical across those runs;
+  nothing was hand-authored, and no number or finding was edited.
+- **Generated:** 2026-08-18 (UTC).
 - **Coverage caveats, stated loudly in both reports.** Neither report claims a
   clean repository, and that is the second thing this pair demonstrates:
 

--- a/examples/snowflakedb-snowflake-connector-net/ci-secure-findings-1dc7766.json
+++ b/examples/snowflakedb-snowflake-connector-net/ci-secure-findings-1dc7766.json
@@ -1,17 +1,19 @@
 {
-  "scanned_at": "2026-08-17T22:46:27Z",
+  "scanned_at": "2026-08-18T00:37:44Z",
   "scanned_workflows": 1,
   "repo_root": "/local/snowflake-connector-net",
   "repo": null,
   "commit_sha": "1dc7766c5aa4b07da3cf3416e501364d3bc827a0",
   "repo_tree_dirty": false,
-  "skill_commit_sha": "553baad54b3b412856f208d4c39275fa7e10115c",
+  "skill_commit_sha": "3545d1b547178905c41dd8b2280fd9225d7df2f7",
   "skill_tree_dirty": false,
   "timings": {
-    "run_start_epoch": 1787006787.237,
+    "run_start_epoch": 1787013464.958,
     "activity_enrich_s": 0.0,
     "scan_total_s": 0.04,
-    "total_run_s": 8.2
+    "scripted_end_epoch": 1787013465.045,
+    "scripted_total_s": 0.15,
+    "total_run_s": 26.55
   },
   "gh_checks": {
     "P14.11": "skipped: disabled via --gh-impostor=off (network-gated check did NOT run)"

--- a/examples/snowflakedb-snowflake-connector-net/ci-secure-findings-4a1b8ce.json
+++ b/examples/snowflakedb-snowflake-connector-net/ci-secure-findings-4a1b8ce.json
@@ -1,17 +1,20 @@
 {
-  "scanned_at": "2026-08-17T22:46:27Z",
+  "scanned_at": "2026-08-18T00:37:37Z",
   "scanned_workflows": 1,
   "repo_root": "/local/snowflake-connector-net",
   "repo": null,
   "commit_sha": "4a1b8cecd65b899540e4324715557d6b080ddeb5",
   "repo_tree_dirty": false,
-  "skill_commit_sha": "553baad54b3b412856f208d4c39275fa7e10115c",
+  "skill_commit_sha": "3545d1b547178905c41dd8b2280fd9225d7df2f7",
   "skill_tree_dirty": false,
   "timings": {
-    "run_start_epoch": 1787006787.087,
+    "run_start_epoch": 1787013457.804,
     "activity_enrich_s": 0.0,
     "scan_total_s": 0.04,
-    "total_run_s": 8.3
+    "scripted_end_epoch": 1787013457.969,
+    "scripted_total_s": 0.23,
+    "total_run_s": 33.67,
+    "risk_scenario_s": 33.44
   },
   "gh_checks": {
     "P14.11": "skipped: disabled via --gh-impostor=off (network-gated check did NOT run)"

--- a/examples/snowflakedb-snowflake-connector-net/ci-secure-report-1dc7766.md
+++ b/examples/snowflakedb-snowflake-connector-net/ci-secure-report-1dc7766.md
@@ -6,8 +6,8 @@
 | **Workflows scanned** | 1 workflow file(s) under `.github/workflows/` |
 | **Catalog** | ten critical attack vectors (critical-only — not a comprehensive audit) |
 | **Coverage** | ⚠️ **PARTIAL** — not every workflow was fully scanned; see the Incomplete-coverage warning below |
-| **Scanned** | 2026-08-17 (UTC) |
-| **Scanner** | ci-secure (skill commit `553baad`) — 0 finding(s) |
+| **Scanned** | 2026-08-18 (UTC) |
+| **Scanner** | ci-secure (skill commit `3545d1b`) — 0 finding(s) |
 
 ```
 CI Secure   0 critical findings  ▏0 of 10 vectors hit▕  1 workflow · impostor check SKIPPED
@@ -116,10 +116,10 @@ One line per vector, taken from the catalog entry each detector is built from.
 
 | Source | Coverage | Used for |
 | --- | --- | --- |
-| ci-secure scanner at commit `553baad` | Every `.github/workflows/` file ending `.yml` or `.yaml`, dot-prefixed names included, under the audited tree (1dc7766) | Critical exploit-chain pattern detection (see the catalog) |
+| ci-secure scanner at commit `3545d1b` | Every `.github/workflows/` file ending `.yml` or `.yaml`, dot-prefixed names included, under the audited tree (1dc7766) | Critical exploit-chain pattern detection (see the catalog) |
 | GitHub API — run activity | not queried (no `--repo`) | Pass `--repo owner/repo` to enrich findings with workflow activity |
 
-**Data freshness.** Scanner ran at `2026-08-17T22:46:27Z`. Workflow YAML is read from the audited tree at commit `1dc7766`. Activity counts (when `--repo` is supplied) reflect a rolling 30-day window at scan time.
+**Data freshness.** Scanner ran at `2026-08-18T00:37:44Z`. Workflow YAML is read from the audited tree at commit `1dc7766`. Activity counts (when `--repo` is supplied) reflect a rolling 30-day window at scan time.
 
 ---
 

--- a/examples/snowflakedb-snowflake-connector-net/ci-secure-report-4a1b8ce.md
+++ b/examples/snowflakedb-snowflake-connector-net/ci-secure-report-4a1b8ce.md
@@ -7,8 +7,8 @@
 | **Catalog** | ten critical attack vectors (critical-only — not a comprehensive audit) |
 | **Severity breakdown (by occurrence)** | HIGH: 3 |
 | **Coverage** | ⚠️ **PARTIAL** — not every workflow was fully scanned; see the Incomplete-coverage warning below |
-| **Scanned** | 2026-08-17 (UTC) |
-| **Scanner** | ci-secure (skill commit `553baad`) — 3 finding(s) |
+| **Scanned** | 2026-08-18 (UTC) |
+| **Scanner** | ci-secure (skill commit `3545d1b`) — 3 finding(s) |
 
 ```
 CI Secure   3 critical findings  ▏1 of 10 vectors hit▕  1 workflow · impostor check SKIPPED
@@ -221,10 +221,10 @@ One line per vector, taken from the catalog entry each detector is built from.
 
 | Source | Coverage | Used for |
 | --- | --- | --- |
-| ci-secure scanner at commit `553baad` | Every `.github/workflows/` file ending `.yml` or `.yaml`, dot-prefixed names included, under the audited tree (4a1b8ce) | Critical exploit-chain pattern detection (see the catalog) |
+| ci-secure scanner at commit `3545d1b` | Every `.github/workflows/` file ending `.yml` or `.yaml`, dot-prefixed names included, under the audited tree (4a1b8ce) | Critical exploit-chain pattern detection (see the catalog) |
 | GitHub API — run activity | not queried (no `--repo`) | Pass `--repo owner/repo` to enrich findings with workflow activity |
 
-**Data freshness.** Scanner ran at `2026-08-17T22:46:27Z`. Workflow YAML is read from the audited tree at commit `4a1b8ce`. Activity counts (when `--repo` is supplied) reflect a rolling 30-day window at scan time.
+**Data freshness.** Scanner ran at `2026-08-18T00:37:37Z`. Workflow YAML is read from the audited tree at commit `4a1b8ce`. Activity counts (when `--repo` is supplied) reflect a rolling 30-day window at scan time.
 
 ---
 


### PR DESCRIPTION
## TL;DR

`main` is currently red. The two published ci-secure example reports say which
version of the scanner produced them, and the version they name was thrown away
by the squash merge that shipped them — so the stamp points at nothing, and the
freshness guard that exists to catch exactly that has been failing on `main`
ever since. This PR re-runs the real scanner from a version that is on `main`
and replaces the two reports with what it emitted, which turns `main` green
again. The scan results are unchanged: the same 3 findings before the vendor's
fix, the same 0 after.

```
before:  reports stamp `553baad`  ->  squash merge discards that commit  ->  stamp resolves to nothing  ->  main red
after:   reports stamp `3545d1b`  ->  a commit that is on main           ->  stamp resolves               ->  main green
```

## What changed

Both ci-secure example reports and both findings JSONs were re-emitted by the
shipped pipeline. Nothing was hand-authored, and no number, finding or line of
report text was edited in.

The regeneration reproduced the documented recipe exactly:

- scanner run from a pristine checkout of `3545d1b` (the squash commit of #60,
  on `main`) — `skill_tree_dirty: false` in both findings JSONs;
- target `snowflakedb/snowflake-connector-net` at `4a1b8ce` and `1dc7766`, each
  a **sparse checkout of `.github/workflows/jira_issue.yml` only**, verified as
  the single file materialised on disk;
- `--gh-impostor off` and no `--repo`, so the run made zero GitHub API calls
  against that repository;
- only the local filesystem prefix stripped and replaced with `/local/…`.

Results match the measured expectation: **3 HIGH P14.10 findings at
`jira_issue.yml` lines 24, 25 and 42** for the vulnerable commit, and **0** for
the fixed one.

Each finding's `attacker_scenario` — the one field an LLM step authors, so the
one field that is not byte-reproducible — was carried forward verbatim, the same
convention the example README already documents. Every other finding field was
byte-identical between the old and new runs before that splice, so the committed
diff is confined to the provenance stamp, the scan timestamps and the timing
block, plus a README paragraph naming the new scanner commit.

## Verification

- `python3 -m pytest -q` — full suite green under the pre-commit hook
  (4037 passed, 18 skipped). Under this machine's system Python 3.9 the only two
  failures are the two known pre-existing ones unrelated to this change.
- `tests/test_examples_provenance.py` — 14 passed, 4 skipped.
- `skills/ci-secure/tests/verify_report.py` — `all checks passed` on both reports.
- `git merge-base --is-ancestor 3545d1b… origin/main` — succeeds.
- Disclosure property: the committed `findings` arrays contain only the three
  public P14.10 findings, and none for the fixed commit; `suppressed_findings`
  and `dropped_matches` are empty in both. Other workflow filenames appear only
  in the unchanged coverage-gap banner that names the seven files the scan never
  opened — a list of files not read, carrying no finding about any of them.

## The second-order problem, and a cheap fix worth considering

The guard checks that an example's stamped scanner commit is an ancestor of
`HEAD`. On a PR branch that is trivially satisfied by a branch commit, so the
guard is green right up to the moment it cannot help: the squash merge rewrites
that commit away, and the failure only appears afterwards, on `main`. The guard
is correct and should not be weakened — it caught real rot — but it is checking
against the wrong reference.

The cheap version of the fix is to make the ancestry leg compare against the
**base branch** rather than `HEAD` — `origin/main`, or the merge base when it
resolves — so an example may only stamp a commit that is *already* on `main`.
That flips the failure from post-merge to pre-merge with no new mechanism: CI
already checks out `fetch-depth: 0`, and the leg already skips loudly when
history is unavailable. The tradeoff is real and, on reflection, is the point:
an example can no longer be generated from an in-flight branch commit and landed
in that same PR, because that stamp is precisely the kind a squash discards.
Examples would be regenerated in a follow-up PR after the engine change lands —
one extra PR on the rare occasion an engine change and an example change coincide,
in exchange for making this class of breakage impossible to merge.

Left as a proposal rather than built here, so unblocking `main` is not held up
behind a change to the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
