### PR TITLE
tests: anchor example provenance to the base branch, not HEAD

### DIFF
--- a/tests/test_examples_provenance.py
+++ b/tests/test_examples_provenance.py
@@ -12,14 +12,27 @@ to a resolvable on-main commit``) had to repair manually.
 
 This guard closes that gap **cheaply and without re-rendering** (no engine run, no ``gh``
 calls): it pins each example's stamped ``ci-speedup skill commit `<sha>` `` provenance to
-a real commit that is an ancestor of ``HEAD`` (the mainline history), and checks the SHA
-is internally consistent across the report. CI checks out ``fetch-depth: 0`` precisely so
-this ancestry check can resolve historical skill commits; on a shallow clone (where the
-history isn't present) the ancestry leg SKIPS LOUDLY rather than false-failing — the
-well-formedness / consistency legs still run.
+a real commit **already reachable from the base branch**, and checks the SHA is internally
+consistent across the report. CI checks out ``fetch-depth: 0`` precisely so this ancestry
+check can resolve historical skill commits; on a shallow clone (where the history isn't
+present) the ancestry leg SKIPS LOUDLY rather than false-failing — the well-formedness /
+consistency legs still run.
+
+**Base branch, not HEAD** (see ``_mainline_ref``). The ancestry leg originally resolved the
+stamp against ``HEAD``, which a PR branch satisfies trivially with a commit of its own — so
+the guard was green for exactly as long as the problem existed and could only fail after the
+merge that caused it. That is not hypothetical: #60 was squash-merged, its examples stamped
+``553baad`` (a commit that lived only on the PR branch), the squash discarded it, ``main``
+went red on the next run and #64 had to repair the artifacts by hand. Anchoring to the base
+branch moves the failure onto the PR, before the merge. The cost is deliberate: an example
+can no longer be generated from an in-flight branch commit and landed in the same PR — when
+an engine change and an example change coincide, the example is regenerated in a follow-up
+PR once the engine has landed. A branch-commit stamp is precisely what a squash discards,
+so forbidding it IS the fix.
 """
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -82,6 +95,59 @@ def _history_available() -> tuple[bool, str]:
     return True, ""
 
 
+def _resolves(rev: str) -> bool:
+    return _run_git("rev-parse", "--verify", "--quiet", f"{rev}^{{commit}}").returncode == 0
+
+
+def _mainline_ref() -> tuple[str, str]:
+    """The ref an example's stamped engine commit must ALREADY be reachable from.
+
+    This is deliberately NOT ``HEAD``. Resolving against ``HEAD`` is what made the
+    ancestry leg unable to protect the merge that broke it: on a PR branch, a commit
+    that exists only on that branch IS an ancestor of HEAD, so the guard stayed green
+    for the whole life of the PR and only went red on ``main`` after the squash had
+    already discarded the stamped commit (#60 → the by-hand repair in #64). Anchoring
+    to the BASE BRANCH inverts that timing — the stamp must name a commit that has
+    already landed, so the violation surfaces on the PR, pre-merge, with no new
+    mechanism and no post-merge cleanup.
+
+    The tip of the base branch is the reference, not the merge base with it: a commit
+    that landed on ``main`` after this branch was cut is perfectly legitimate to stamp
+    (a squash cannot discard it), and the merge base would reject it.
+
+    Resolution order, first hit wins:
+      1. ``GITHUB_BASE_REF`` — the PR's target branch, as the remote-tracking ref or a
+         local branch. Set only on ``pull_request`` runs.
+      2. ``origin/main`` / ``main`` / ``origin/HEAD`` — a normal clone, a worktree, and
+         the ``push``-to-main CI run (actions/checkout writes ``origin/main`` there).
+      3. The first parent of HEAD on a GitHub ``pull_request`` run. actions/checkout
+         checks out ``refs/pull/N/merge`` and fetches ONLY that ref, so no
+         ``origin/<base>`` exists in a PR job however deep the fetch; the merge commit
+         GitHub generated for it has the base branch tip as its first parent. Guarded
+         on the event being a pull_request AND HEAD actually being a two-parent merge,
+         so an ordinary local merge commit can never be mistaken for a base ref.
+
+    Returns ``(ref, "")`` or ``("", reason)``.
+    """
+    tried: list[str] = []
+    base_env = os.environ.get("GITHUB_BASE_REF", "").strip()
+    candidates: list[str] = []
+    if base_env:
+        candidates += [f"refs/remotes/origin/{base_env}", f"refs/heads/{base_env}"]
+    candidates += ["refs/remotes/origin/main", "refs/heads/main", "refs/remotes/origin/HEAD"]
+    for rev in candidates:
+        tried.append(rev)
+        if _resolves(rev):
+            return rev, ""
+    if base_env and os.environ.get("GITHUB_EVENT_NAME") == "pull_request":
+        tried.append("HEAD^1 (the pull_request merge ref's base parent)")
+        parents = _run_git("rev-list", "--parents", "-n", "1", "HEAD")
+        if (parents.returncode == 0 and len(parents.stdout.split()) == 3
+                and _resolves("HEAD^1")):
+            return "HEAD^1", ""
+    return "", ("no base-branch ref could be resolved (tried: " + ", ".join(tried) + ")")
+
+
 def test_examples_corpus_is_present():
     # Never let this whole gate pass vacuously: if the shipped examples disappear, say so
     # LOUDLY (a silently-empty corpus is how a freshness gate rots into a no-op).
@@ -132,32 +198,15 @@ def test_example_provenance_sha_is_a_real_ancestor_commit(report: Path):
         )
         pytest.skip(f"{report.parent.name}: archive-era stamp `{sha}` "
                     f"(ran {ran}, pre-cut) — ancestry lives in the private archive")
-    ok, why = _history_available()
-    if not ok:
-        pytest.skip(f"cannot verify example provenance ancestry: {why}")
     m = _AUDIT_SHA_RE.search(text)
     assert m, f"{report.parent.name}: no provenance stamp (see the well-formedness test)"
-    sha = m.group(1)
-    kind = _run_git("cat-file", "-t", sha)
-    assert kind.returncode == 0 and kind.stdout.strip() == "commit", (
-        f"{report.parent.name}: stamped skill commit `{sha}` is not a resolvable commit "
-        "object in this repo — a fabricated, typo'd, or discarded (squash-merged) SHA. "
-        "Regenerate the example from an on-main engine commit and stamp that SHA."
-    )
-    anc = _run_git("merge-base", "--is-ancestor", sha, "HEAD")
-    # git distinguishes its two outcomes by exit code: rc 0 = ancestor, rc 1 = genuinely NOT an
-    # ancestor (the provenance violation this leg exists to catch), rc >= 2 (typically 128) = git
-    # couldn't answer at all (bad revision, unborn/detached HEAD, object pruned mid-run). Only rc
-    # 1 is a real verdict; a rc-128 environment error must NOT be mislabeled "not an ancestor —
-    # regenerate", which would send a maintainer down the wrong path. Skip loudly on rc >= 2.
-    if anc.returncode >= 2:
-        pytest.skip(f"{report.parent.name}: cannot resolve ancestry of `{sha}` "
-                    f"(git merge-base rc={anc.returncode}: {anc.stderr.strip()!r})")
-    assert anc.returncode == 0, (
-        f"{report.parent.name}: stamped skill commit `{sha}` is a real commit but NOT an "
-        "ancestor of HEAD — the example was generated from an engine that never landed on "
-        "the mainline (a discarded branch/squash commit). Regenerate from an on-main commit."
-    )
+    # ONE ancestry implementation for every engine family (this leg used to carry its own
+    # copy, so the base-ref fix would have had to be made — and kept — in two places).
+    # It resolves the stamp against the BASE BRANCH, not HEAD, and distinguishes git's exit
+    # codes: rc 0 = reachable, rc 1 = the provenance violation, rc >= 2 = git could not
+    # answer at all (bad revision, object pruned mid-run) and skips loudly rather than
+    # mislabelling an environment error as "regenerate this example".
+    _assert_engine_sha_is_an_ancestor(report, m.group(1))
 
 
 def test_provenance_ancestry_guard_actually_rejects_a_fabricated_sha(tmp_path, monkeypatch):
@@ -192,6 +241,10 @@ def test_provenance_ancestry_guard_actually_rejects_a_fabricated_sha(tmp_path, m
                 return _cp(0, ".git\n")
             if args[0] == "rev-parse" and "--is-shallow-repository" in args:
                 return _cp(0, "false\n")   # force the ancestry leg to actually run
+            if args[0] == "rev-parse" and "--verify" in args:
+                # A resolvable base branch, so the legs below reach their real verdict
+                # instead of skipping on an unresolvable base.
+                return _cp(0, "beef" * 10 + "\n")
             if args[0] == "cat-file":
                 return cat
             if args[:2] == ("merge-base", "--is-ancestor"):
@@ -459,27 +512,235 @@ def test_ci_score_example_matches_its_findings_json(report: Path):
 
 
 def _assert_engine_sha_is_an_ancestor(report: Path, sha: str) -> None:
-    """Same ancestry contract the ci-speedup leg enforces, reused verbatim: the engine
-    commit an example was generated from must be a real commit on this repo's mainline,
-    and an unresolvable history SKIPS loudly rather than false-failing."""
+    """THE ancestry contract, shared by every engine family's leg: the engine commit an
+    example was generated from must be a real commit that is ALREADY reachable from the
+    base branch (see ``_mainline_ref``), not merely from HEAD. An unresolvable history
+    SKIPS loudly rather than false-failing."""
     ok, why = _history_available()
     if not ok:
-        pytest.skip(f"cannot verify {report.parent.name}/{report.name} ancestry: {why}")
+        pytest.skip(f"cannot verify {_rel(report)} ancestry: {why}")
     kind = _run_git("cat-file", "-t", sha)
     assert kind.returncode == 0 and kind.stdout.strip() == "commit", (
         f"{_rel(report)}: stamped engine commit `{sha}` is not a resolvable "
         "commit object — a fabricated, typo'd, or squash-discarded SHA. Regenerate the "
         "example from an on-main engine commit."
     )
-    anc = _run_git("merge-base", "--is-ancestor", sha, "HEAD")
+    base, why_no_base = _mainline_ref()
+    if not base:
+        # No base branch to measure against. In CI that is not a tolerable degradation —
+        # this gate exists to fire in CI, and a silent skip there is how the leg lost its
+        # teeth in the first place — so say it as a FAILURE. Off CI (a vendored copy, a
+        # clone with no `main` and no remote) skip loudly instead of false-failing.
+        message = (
+            f"{_rel(report)}: cannot check the provenance of `{sha}` — {why_no_base}. "
+            "The stamp must be reachable from the branch this change merges into; "
+            "fetch it (`git fetch origin main`) and re-run."
+        )
+        if os.environ.get("GITHUB_ACTIONS") == "true":
+            pytest.fail(message + " Skipping this in CI would leave the gate toothless.")
+        pytest.skip(message)
+    anc = _run_git("merge-base", "--is-ancestor", sha, base)
     if anc.returncode >= 2:
-        pytest.skip(f"{_rel(report)}: cannot resolve ancestry of `{sha}` "
-                    f"(git merge-base rc={anc.returncode}: {anc.stderr.strip()!r})")
+        pytest.skip(f"{_rel(report)}: cannot resolve ancestry of `{sha}` against "
+                    f"{base} (git merge-base rc={anc.returncode}: {anc.stderr.strip()!r})")
     assert anc.returncode == 0, (
-        f"{_rel(report)}: stamped engine commit `{sha}` is a real commit but "
-        "NOT an ancestor of HEAD — generated from an engine that never landed on the "
-        "mainline. Regenerate from an on-main commit."
+        f"{_rel(report)}: stamped engine commit `{sha}` is a real commit but is NOT "
+        f"reachable from {base} — it exists only on this branch (or on no branch at all). "
+        "A squash merge DISCARDS branch commits, so this stamp would dangle the moment "
+        "the change lands, exactly as #60's did. Land the engine change first, then "
+        "regenerate the example from the resulting on-main commit in a follow-up PR. "
+        "(If the commit really is on main, this checkout's base ref is stale — "
+        "`git fetch origin main`.)"
     )
+
+
+def _init_pr_shaped_repo(root: Path) -> tuple[str, str]:
+    """A throwaway clone-shaped repo in the exact shape a pull request has:
+    one commit on ``main`` (mirrored to ``refs/remotes/origin/main``, as a real
+    clone would), and one further commit that exists ONLY on the feature branch,
+    which is checked out. Returns ``(on_main_sha, branch_only_sha)``.
+
+    Everything stays inside the caller's ``tmp_path``; the repo-wide conftest
+    scrubs the ``GIT_*`` addressing env, so these commands cannot escape onto the
+    real checkout (2026-07-30 incident).
+    """
+    def g(*args: str) -> str:
+        r = subprocess.run(
+            ["git", "-C", str(root),
+             "-c", "user.email=fixture@example.invalid", "-c", "user.name=fixture",
+             "-c", "commit.gpgsign=false", *args],
+            capture_output=True, text=True)
+        assert r.returncode == 0, f"fixture git {args}: {r.stderr}"
+        return r.stdout.strip()
+
+    init = subprocess.run(["git", "init", "-q", str(root)], capture_output=True, text=True)
+    assert init.returncode == 0, init.stderr
+    g("checkout", "-q", "-b", "main")
+    g("commit", "-q", "--allow-empty", "-m", "engine commit that landed on main")
+    on_main = g("rev-parse", "HEAD")
+    # A real clone tracks the remote branch; the guard reads that ref, not just the local one.
+    g("update-ref", "refs/remotes/origin/main", on_main)
+    g("checkout", "-q", "-b", "feature")
+    g("commit", "-q", "--allow-empty", "-m", "engine commit that exists only on the PR branch")
+    branch_only = g("rev-parse", "HEAD")
+    return on_main, branch_only
+
+
+def test_ancestry_leg_rejects_an_engine_commit_that_exists_only_on_the_pr_branch(
+        tmp_path, monkeypatch):
+    # POSITIVE CONTROL for the defect this leg was rebuilt to close (PR #60 → #64).
+    #
+    # #60 was squash-merged. Its examples stamped `553baad`, a commit that existed only
+    # on the PR branch; the squash discarded it and `main` went red on the very next run,
+    # needing #64 to repair the artifacts by hand. The guard was GREEN throughout #60,
+    # because it resolved the stamp against HEAD — and on a PR branch a branch-only commit
+    # is trivially an ancestor of HEAD. It could only fail AFTER the merge that broke it.
+    #
+    # This test builds that exact situation with a real git repo — a commit on `main`,
+    # a commit only on a feature branch, the feature branch checked out — and asserts the
+    # branch-only stamp is REJECTED while the on-main stamp still passes. Against the
+    # pre-fix HEAD-relative guard the rejection assertion does not fire (the guard accepts
+    # what it must reject), which is this change's red proof, inverted.
+    import sys
+    mod = sys.modules[__name__]
+
+    repo = tmp_path / "clone"
+    repo.mkdir()
+    on_main, branch_only = _init_pr_shaped_repo(repo)
+    monkeypatch.setattr(mod, "_REPO", repo)
+
+    def _stamped(name: str, sha: str) -> Path:
+        d = tmp_path / name
+        d.mkdir()
+        p = d / "ci-secure-report-abc1234.md"
+        p.write_text(f"| **Scanner** | ci-secure (skill commit `{sha[:7]}`) — 0 finding(s) |\n",
+                     encoding="utf-8")
+        return p
+
+    # Control: a stamp already reachable from the base branch passes. Without this the
+    # test could "pass" by rejecting everything (a guard that fails on valid examples is
+    # just as broken, and would be discovered only by whoever regenerates one next).
+    _assert_engine_sha_is_an_ancestor(_stamped("on-main", on_main), on_main[:7])
+
+    # Tonight's scenario: the stamp names a commit that lives only on this branch and
+    # will not survive the squash. It must be rejected HERE, on the PR, before the merge.
+    with pytest.raises(AssertionError, match="only on this branch|not reachable"):
+        _assert_engine_sha_is_an_ancestor(
+            _stamped("branch-only", branch_only), branch_only[:7])
+
+    # A stamp that landed on main AFTER this branch was cut is legitimate — a squash
+    # cannot discard it — so the reference is the base branch TIP, not the merge base.
+    subprocess.run(["git", "-C", str(repo),
+                    "-c", "user.email=fixture@example.invalid", "-c", "user.name=fixture",
+                    "checkout", "-q", "main"], capture_output=True, text=True, check=True)
+    subprocess.run(["git", "-C", str(repo),
+                    "-c", "user.email=fixture@example.invalid", "-c", "user.name=fixture",
+                    "-c", "commit.gpgsign=false",
+                    "commit", "-q", "--allow-empty", "-m", "later engine commit on main"],
+                   capture_output=True, text=True, check=True)
+    later = subprocess.run(["git", "-C", str(repo), "rev-parse", "HEAD"],
+                           capture_output=True, text=True, check=True).stdout.strip()
+    subprocess.run(["git", "-C", str(repo), "update-ref", "refs/remotes/origin/main", later],
+                   capture_output=True, text=True, check=True)
+    subprocess.run(["git", "-C", str(repo),
+                    "-c", "user.email=fixture@example.invalid", "-c", "user.name=fixture",
+                    "checkout", "-q", "feature"], capture_output=True, text=True, check=True)
+    _assert_engine_sha_is_an_ancestor(_stamped("later-on-main", later), later[:7])
+
+
+def test_the_base_ref_resolves_in_a_github_pull_request_checkout(tmp_path, monkeypatch):
+    # The shape EVERY PR run of this suite actually has, and the one no ordinary clone
+    # reproduces: actions/checkout checks out `refs/pull/N/merge` and fetches only that
+    # ref, so there is no `origin/main` however deep the fetch — HEAD is a detached
+    # two-parent merge commit whose FIRST parent is the base branch tip. If that fallback
+    # ever stops resolving, every PR either skips this gate (toothless) or fails it
+    # (spurious red on a correct example); both are caught here rather than in the wild.
+    import sys
+    mod = sys.modules[__name__]
+
+    repo = tmp_path / "pr-checkout"
+    repo.mkdir()
+    on_main, branch_only = _init_pr_shaped_repo(repo)
+
+    def g(*args: str) -> str:
+        r = subprocess.run(
+            ["git", "-C", str(repo),
+             "-c", "user.email=fixture@example.invalid", "-c", "user.name=fixture",
+             "-c", "commit.gpgsign=false", *args], capture_output=True, text=True)
+        assert r.returncode == 0, f"fixture git {args}: {r.stderr}"
+        return r.stdout.strip()
+
+    # GitHub's generated merge commit: base tip first, PR head second. Then drop every
+    # trace of the base branch's own refs, exactly as a PR job's checkout has none.
+    merge = g("commit-tree", "-p", on_main, "-p", branch_only,
+              "-m", "Merge pull request", f"{on_main}^{{tree}}")
+    g("checkout", "-q", "--detach", merge)
+    g("branch", "-q", "-D", "main")
+    g("branch", "-q", "-D", "feature")
+    g("update-ref", "-d", "refs/remotes/origin/main")
+
+    monkeypatch.setattr(mod, "_REPO", repo)
+    for ref in ("refs/heads/main", "refs/remotes/origin/main"):
+        assert not _resolves(ref), f"{ref} must not exist in a PR-shaped checkout"
+    monkeypatch.setenv("GITHUB_BASE_REF", "main")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+
+    base, why = _mainline_ref()
+    assert base == "HEAD^1", f"PR-shaped checkout resolved no base ref: {why}"
+
+    d = tmp_path / "pr-example"
+    d.mkdir()
+    report = d / "ci-secure-report-abc1234.md"
+    report.write_text("stub\n", encoding="utf-8")
+    # On-main stamp passes; the branch-only stamp — reachable from HEAD, since HEAD is the
+    # merge — is still rejected. THAT is the whole point: pre-merge, on the PR.
+    _assert_engine_sha_is_an_ancestor(report, on_main[:7])
+    with pytest.raises(AssertionError, match="only on this branch|not reachable"):
+        _assert_engine_sha_is_an_ancestor(report, branch_only[:7])
+
+
+def test_an_unresolvable_base_branch_fails_in_ci_and_skips_only_off_it(tmp_path, monkeypatch):
+    # The one way this leg can go quiet: no base-branch ref to measure against. Skipping
+    # is right for a vendored copy or a clone with no `main` and no remote — and WRONG in
+    # CI, where a silent skip is precisely how a gate rots into a no-op (the failure mode
+    # this whole PR exists to remove). Pin both halves so a later refactor cannot turn the
+    # CI branch back into a skip without going red here.
+    import sys
+    mod = sys.modules[__name__]
+
+    orphan = tmp_path / "no-mainline"
+    orphan.mkdir()
+    subprocess.run(["git", "init", "-q", str(orphan)], capture_output=True, check=True)
+    r = subprocess.run(["git", "-C", str(orphan),
+                        "-c", "user.email=f@f.invalid", "-c", "user.name=f",
+                        "-c", "commit.gpgsign=false",
+                        "checkout", "-q", "-b", "detached-work"],
+                       capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    subprocess.run(["git", "-C", str(orphan),
+                    "-c", "user.email=f@f.invalid", "-c", "user.name=f",
+                    "-c", "commit.gpgsign=false",
+                    "commit", "-q", "--allow-empty", "-m", "lone commit, no main, no remote"],
+                   capture_output=True, text=True, check=True)
+    sha = subprocess.run(["git", "-C", str(orphan), "rev-parse", "HEAD"],
+                         capture_output=True, text=True, check=True).stdout.strip()
+    monkeypatch.setattr(mod, "_REPO", orphan)
+    for var in ("GITHUB_BASE_REF", "GITHUB_EVENT_NAME"):
+        monkeypatch.delenv(var, raising=False)
+
+    d = tmp_path / "somewhere"
+    d.mkdir()
+    report = d / "ci-secure-report-abc1234.md"
+    report.write_text("stub\n", encoding="utf-8")
+
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    with pytest.raises(pytest.skip.Exception, match="no base-branch ref"):
+        _assert_engine_sha_is_an_ancestor(report, sha[:7])
+
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    with pytest.raises(pytest.fail.Exception, match="toothless"):
+        _assert_engine_sha_is_an_ancestor(report, sha[:7])
 
 
 def test_the_other_engines_legs_actually_reject_tampering(tmp_path, monkeypatch):


### PR DESCRIPTION
## TL;DR

The check that keeps the sample reports honest about which version of the scanner
produced them could not fail until after the damage was done. It verified the recorded
commit against the branch it was running on, and on a pull request that is always
satisfied by the branch's own commits — so it stayed green through review and only went
red on the main branch, after the merge had already thrown that commit away. That is not
theoretical: it happened with #60 and #64 had to clean up by hand. This moves the check
to ask whether the recorded commit is already on the main branch, so the same mistake now
stops the pull request instead of following it in.

```
before:  example stamps a branch-only commit  ->  PR green  ->  squash drops it  ->  main RED
after:   example stamps a branch-only commit  ->  PR RED    ->  never merges
```

## What changed

`tests/test_examples_provenance.py` only. No shipped skill code, no example artifacts, so
no changelog entry.

- The ancestry leg resolves the stamped engine commit against the **base branch** rather
  than `HEAD`.
- Base-branch resolution, first hit wins: `GITHUB_BASE_REF` (as `origin/<base>` or
  `refs/heads/<base>`), then `origin/main`, `main`, `origin/HEAD`, then the first parent
  of `HEAD` on a GitHub `pull_request` run. That last one carries the CI case:
  `actions/checkout` checks out `refs/pull/N/merge` and fetches only that ref, so no
  `origin/<base>` exists in a pull-request job however deep the fetch, while the merge
  commit GitHub generated has the base branch tip as its first parent. It is guarded on
  the event being a pull request *and* `HEAD` genuinely being a two-parent merge, so an
  ordinary local merge commit can never be mistaken for a base ref.
- The **tip** of the base branch, not the merge base with it. A commit that landed on
  `main` after this branch was cut is perfectly legitimate to stamp — a squash cannot
  discard it — and measuring from the merge base would reject it.
- The `ci-speedup` leg now delegates to the single shared ancestry implementation instead
  of carrying its own copy, so this fix cannot drift back in one of two places.

Nothing else was touched. The report-versus-findings cross-check, the coverage-claim
check against the raw gap keys, the sanitization leg, the archive-era date bound and the
family registry all stay exactly as they were.

## The cost, which is the point

An example can no longer be generated from an in-flight branch commit and landed in the
same pull request. When an engine change and an example regeneration coincide, the engine
lands first and the example is regenerated in a follow-up. A branch-commit stamp is
exactly what a squash merge discards, so forbidding it is the fix rather than a side
effect of it.

## Proof it can fail

A positive control builds the situation from #60 with a real git repository — one commit
on `main`, one commit only on a feature branch, that branch checked out, an artifact
stamping the branch-only commit — and asserts the guard rejects it. Run against the
unfixed guard first:

```
    with pytest.raises(AssertionError, match="only on this branch|not reachable"):
>       _assert_engine_sha_is_an_ancestor(
            _stamped("branch-only", branch_only), branch_only[:7])
E   Failed: DID NOT RAISE <class 'AssertionError'>
```

The old guard accepted precisely what it must reject. It passes after the change.

Three more controls stop the new leg from being over-eager or quietly inert:

- an on-main stamp still passes, and so does a commit that landed on `main` after the
  branch point (the tip-versus-merge-base decision above);
- the pull-request merge-ref shape resolves its base through the first-parent fallback,
  and still rejects the branch-only stamp even though `HEAD` reaches it;
- with no base ref resolvable at all, the leg skips loudly off CI and **fails** in CI.

## When the check cannot run

| situation | behavior |
| --- | --- |
| shallow clone | skips loudly, as before — CI pins `fetch-depth: 0` and a separate leg keeps it pinned |
| pull request, same-repo or fork | resolves the base through the merge ref's first parent; fork pull requests are checked out from the base repository, so this is the same path |
| local clone or worktree | uses `origin/main`; a stale one is named in the failure message with the `git fetch origin main` remedy |
| no `main`, no remote, no base env (a vendored copy) | skips loudly off CI, **fails** in CI — a silent skip in CI is the same rot this change removes |

## Tests

`python3 -m pytest -q`: 4042 passed, 14 skipped, plus the two failures already known to be
unrelated on this machine's Python 3.9 (`test_the_grammar_guard_can_actually_fail` and one
`test_page_text_strips_every_legal_script_end_tag_form` case). The provenance suite itself
runs 21 passed, 0 skipped, so the ancestry legs really executed against the shipped
examples rather than skipping past them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
