### PR TITLE
ci-secure: run the behavioral eval cases on the PRs that can break them

### DIFF
--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -1,0 +1,134 @@
+# Behavioral eval suite for the ci-secure skill.
+#
+# The rest of CI tests the scanner: deterministic Python, every push, every PR. This tests the
+# CONTRACT — the instructions in SKILL.md that a live agent reads and executes. A refactor can
+# leave every unit test green while changing what the agent actually does, and nothing else in
+# this repository would notice.
+#
+# Each case scaffolds fixture workflows into a throwaway directory, drives one headless
+# `claude -p` session against it, and applies the case's own graders to the recorded tool calls
+# and output. See skills/ci-secure/evals/README.md for the cases and
+# maintainers/ci-secure/scripts/run_skill_evals.py for the harness.
+#
+# WHY THIS IS NOT THE `test` GATE, and is not required:
+#
+#   - It spends real tokens. One session per case, so it is path-filtered to the files that can
+#     actually change agent behaviour. A README or example PR never pays for it.
+#   - It is non-deterministic. An agent can reach a correct outcome by a different route, so a
+#     required check here would be flaky, and a flaky gate gets disabled or ignored.
+#   - It cannot run on fork PRs at all: `pull_request` from a fork has no access to
+#     ANTHROPIC_API_KEY. That is reported as "did not run", never as a pass — see the verdict
+#     job. `.github/workflows/claude.yml` shows the other pattern (comment-triggered, base-repo
+#     context) if on-demand fork coverage is ever wanted.
+#
+# Start advisory, exactly as the ci-secure gate itself ships advisory: let it report on a few
+# contract PRs, then decide whether it has earned being required.
+name: Skill evals
+
+on:
+  # Automatic: any PR that touches something able to change agent behaviour.
+  pull_request:
+    paths:
+      - "skills/ci-secure/SKILL.md"
+      - "skills/ci-secure/references/**"
+      - "skills/ci-secure/scripts/**"
+      - "skills/ci-secure/evals/**"
+      - "maintainers/ci-secure/scripts/run_skill_evals.py"
+      - ".github/workflows/skill-evals.yml"
+
+  # Manual: run it against any branch on demand, from the Actions tab or
+  # `gh workflow run skill-evals.yml --ref <branch>`. This is the escape hatch for a PR that
+  # changed behaviour without touching a filtered path, and for re-running after a flake
+  # without pushing an empty commit.
+  workflow_dispatch:
+    inputs:
+      case:
+        description: "Single case to run (blank = all five)"
+        required: false
+        type: string
+      runs:
+        description: "Runs per case"
+        required: false
+        default: "1"
+        type: string
+
+# A superseded run is wasted tokens, not just wasted minutes.
+concurrency:
+  group: skill-evals-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  evals:
+    name: skill evals (self-hosted)
+    # Same-repo PRs only. A fork PR cannot see ANTHROPIC_API_KEY, and running fork-authored
+    # workflow fixtures through an agent on the self-hosted pool is not something to do for a
+    # convenience. The verdict job below reports the gap rather than hiding it.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: starsling-ubuntu-24.04
+    # Five sessions at roughly four minutes each, plus headroom. A hung session must not hold
+    # the pool: self-hosted jobs otherwise queue for hours with no signal.
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install harness dependencies
+        run: pip install pyyaml
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      # One run per case. Bump --runs only if the suite proves flaky in practice: every extra
+      # run is another full agent session.
+      - name: Run the eval cases
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CASE: ${{ inputs.case }}
+          RUNS: ${{ inputs.runs }}
+        run: |
+          python3 maintainers/ci-secure/scripts/run_skill_evals.py \
+            --runs "${RUNS:-1}" ${CASE:+--case "$CASE"}
+        # Defaults keep the automatic path unchanged: one run, every case.
+
+
+  # ONE check name, always reported, mirroring `test`'s verdict job in ci.yml. The evals job is
+  # conditional, and GitHub counts a skipped check as a pass — so a skip must be turned into a
+  # visible statement here instead. `always()` rather than `!cancelled()` for the same reason it
+  # is used there: a cancelled run reports skipped, and skipped reads as green.
+  verdict:
+    name: skill evals
+    needs: [evals]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Report
+        env:
+          RESULT: ${{ needs.evals.result }}
+          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          set -euo pipefail
+          echo "evals job: ${RESULT}"
+          if [ "${IS_FORK}" = "true" ]; then
+            echo "::warning::Skill evals DID NOT RUN: fork PRs have no access to ANTHROPIC_API_KEY."
+            echo "This is a coverage gap, not a pass. The contract's behaviour is unverified on this PR."
+            exit 0
+          fi
+          case "${RESULT}" in
+            success)   echo "Skill evals passed."; exit 0 ;;
+            failure)   echo "::error::Skill evals FAILED — the agent's behaviour changed. Read the job log."; exit 1 ;;
+            cancelled) echo "::warning::Skill evals were cancelled; nothing was verified."; exit 1 ;;
+            *)         echo "::error::Skill evals did not run (${RESULT}); that is not a pass."; exit 1 ;;
+          esac

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -17,8 +17,11 @@
 #   - It is non-deterministic. An agent can reach a correct outcome by a different route, so a
 #     required check here would be flaky, and a flaky gate gets disabled or ignored.
 #   - It cannot run on fork PRs at all: `pull_request` from a fork has no access to
-#     ANTHROPIC_API_KEY. That is reported as "did not run", never as a pass — see the verdict
-#     job. `.github/workflows/claude.yml` shows the other pattern (comment-triggered, base-repo
+#     ANTHROPIC_API_KEY. A fork PR therefore gets no `skill evals` check and a separate check
+#     whose NAME is the message — `skill evals NOT RUN (fork PR — no agent session)` — exactly
+#     as registry-scan.yml reports its own fork gap. A green check called "skill evals" must
+#     never appear over a session that did not happen.
+#     `.github/workflows/claude.yml` shows the other pattern (comment-triggered, base-repo
 #     context) if on-demand fork coverage is ever wanted.
 #
 # Start advisory, exactly as the ci-secure gate itself ships advisory: let it report on a few
@@ -70,9 +73,11 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: starsling-ubuntu-24.04
-    # Five sessions at roughly four minutes each, plus headroom. A hung session must not hold
-    # the pool: self-hosted jobs otherwise queue for hours with no signal.
-    timeout-minutes: 45
+    # Above the harness's own worst case: five cases at the 900s per-run cap the case files
+    # declare is 75 minutes, so a lower budget here would kill a slow-but-healthy suite and
+    # report it as a behaviour change. A hung session must still not hold the pool: self-hosted
+    # jobs otherwise queue for hours with no signal.
+    timeout-minutes: 90
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -87,8 +92,11 @@ jobs:
       - name: Install harness dependencies
         run: pip install pyyaml
 
+      # Pinned. A contract-regression suite whose failure message says "the agent's behaviour
+      # changed" must hold the runtime still; on `latest`, an upstream CLI release would read
+      # as a skill regression. Bump this deliberately, and expect to re-baseline when you do.
       - name: Install Claude Code
-        run: npm install -g @anthropic-ai/claude-code
+        run: npm install -g @anthropic-ai/claude-code@2.1.235
 
       # One run per case. Bump --runs only if the suite proves flaky in practice: every extra
       # run is another full agent session.
@@ -97,10 +105,41 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CASE: ${{ inputs.case }}
           RUNS: ${{ inputs.runs }}
+          # The runner executes as root, and `claude` refuses `--permission-mode
+          # bypassPermissions` under uid 0 unless a deliberate sandbox is declared: it prints
+          # "cannot be used with root/sudo privileges" and exits before the first turn. That is
+          # what happened on this workflow's first run — five cases failed every grader in 1.6
+          # seconds with zero tool calls. This declares what is already true: the job runs in a
+          # throwaway repo checkout on an ephemeral runner, and the agent's own working
+          # directory is a temp dir the harness creates and deletes.
+          IS_SANDBOX: "1"
+        # The harness separates "a case ran and failed" (1) from "the harness could not run at
+        # all" (2), so preserve the distinction here rather than collapsing both into a red
+        # check that asserts a cause the workflow cannot know.
         run: |
+          set -uo pipefail
+          status=0
           python3 maintainers/ci-secure/scripts/run_skill_evals.py \
-            --runs "${RUNS:-1}" ${CASE:+--case "$CASE"}
+            --runs "${RUNS:-1}" ${CASE:+--case "$CASE"} || status=$?
+          if [ "$status" -eq 2 ]; then
+            echo "::error title=SKILL EVALS DID NOT RUN::The harness could not run (exit 2). Nothing was verified — this is a coverage gap, not a behaviour change. The reason is on the line above."
+          elif [ "$status" -ne 0 ]; then
+            echo "::error title=SKILL EVALS FAILED::A case ran and failed a grader (exit ${status})."
+          fi
+          exit "$status"
         # Defaults keep the automatic path unchanged: one run, every case.
+
+      # The harness writes the session of any case that failed. Grader names
+      # alone do not explain a failure, and "read the job log" is only useful
+      # advice if the log has the run in it.
+      - name: Keep the sessions that failed
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: skill-eval-sessions
+          path: skill-eval-logs/
+          retention-days: 14
+          if-no-files-found: ignore
 
 
   # ONE check name, always reported, mirroring `test`'s verdict job in ci.yml. The evals job is
@@ -110,25 +149,54 @@ jobs:
   verdict:
     name: skill evals
     needs: [evals]
-    if: always()
+    # `always()` so a skipped or cancelled evals job still gets a verdict — but NOT on a fork
+    # PR, where the check would be green over a session that could not happen. The fork job
+    # below carries that case under a name that says so. The two conditions are exact
+    # complements on purpose, and tests/test_skill_evals_workflow.py pins that they stay so.
+    if: >-
+      always() &&
+      !(github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Report
         env:
           RESULT: ${{ needs.evals.result }}
-          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
         run: |
           set -euo pipefail
           echo "evals job: ${RESULT}"
-          if [ "${IS_FORK}" = "true" ]; then
-            echo "::warning::Skill evals DID NOT RUN: fork PRs have no access to ANTHROPIC_API_KEY."
-            echo "This is a coverage gap, not a pass. The contract's behaviour is unverified on this PR."
-            exit 0
-          fi
           case "${RESULT}" in
             success)   echo "Skill evals passed."; exit 0 ;;
-            failure)   echo "::error::Skill evals FAILED — the agent's behaviour changed. Read the job log."; exit 1 ;;
+            failure)   echo "::error::Skill evals FAILED. Read the job log: the harness prints whether a case ran and failed a grader, or whether it could not run at all."; exit 1 ;;
             cancelled) echo "::warning::Skill evals were cancelled; nothing was verified."; exit 1 ;;
             *)         echo "::error::Skill evals did not run (${RESULT}); that is not a pass."; exit 1 ;;
           esac
+
+  # The name is the message: this check being green must not read as "the contract was
+  # verified". Failing an external contributor's PR for a secret they have no way to reach
+  # would be hostile, so this reports rather than blocks — the same trade registry-scan.yml
+  # makes for its own fork gap — but a maintainer must run the evals on an internal branch
+  # before merging a fork change to SKILL.md, the references, or the scripts.
+  fork-did-not-run:
+    name: skill evals NOT RUN (fork PR — no agent session)
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Report the coverage gap
+        run: |
+          echo "::warning title=SKILL EVALS DID NOT RUN::Fork PRs have no access to ANTHROPIC_API_KEY, so no agent session ran on this PR. The contract's behaviour is unverified here — a coverage gap, not a pass."
+          echo "================================================================"
+          echo "  SKILL EVALS DID NOT RUN — NO AGENT SESSION HAPPENED"
+          echo ""
+          echo "  This pull request comes from a fork. Fork runs cannot reach"
+          echo "  ANTHROPIC_API_KEY, so no headless session could be started and"
+          echo "  none of the five behavioural cases was executed."
+          echo ""
+          echo "  This is a coverage gap, NOT a pass. Before merging a fork"
+          echo "  change to SKILL.md, references/, scripts/ or evals/, push the"
+          echo "  branch to this repository and let 'skill evals' run."
+          echo "================================================================"

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,10 @@ skills/ci-secure/evals/files/*/.github/
 # whatever sits there. Always pass `--output-dir` somewhere outside the skill;
 # `tests/test_ci_secure_install_surface.py` fails if results land here anyway.
 skills/ci-secure/evals/results/
+
+# The ci-secure eval harness writes a failing session's full stream-json plus
+# the file corpus it collected to `./skill-eval-logs/` (relative to the working
+# directory, so the repo root on a local run). Those hold the verbatim
+# transcript of an agent session — prompts, tool output, the rendered report.
+# Never tracked; see maintainers/ci-secure/scripts/run_skill_evals.py.
+skill-eval-logs/

--- a/maintainers/ci-secure/scripts/run_skill_evals.py
+++ b/maintainers/ci-secure/scripts/run_skill_evals.py
@@ -77,7 +77,16 @@ _EVALS = _SKILL / "evals"
 # expected string while `tests/` holds rendered report fixtures containing them.
 # An agent that greps the plugin directory would put those strings into the
 # transcript, satisfying the graders without ever running a scan.
-_PLUGIN_EXCLUDE = ("evals", "tests")
+#
+# `CHANGELOG.md` is here for the same reason and is the less obvious one: it
+# narrates the graders themselves, so it quotes their expected banner strings
+# verbatim -- `0 critical findings` sits in the entry explaining why that very
+# pattern needs its `(?<![\d.])` guard. It is also of no use to an agent
+# auditing a repository, so withholding it costs the run nothing.
+# `test_no_file_the_plugin_copy_mounts_can_satisfy_a_grader` states the property
+# this list exists to satisfy, so the next file added at the skill root cannot
+# quietly reopen the hole.
+_PLUGIN_EXCLUDE = ("evals", "tests", "CHANGELOG.md")
 
 # Where a failing session is written, relative to the working directory, so the
 # run that failed can be read rather than reproduced.
@@ -87,6 +96,14 @@ _LOGS = Path("skill-eval-logs")
 # kilobytes; anything past this is a lockfile, a cache or a binary the agent
 # happened to create, and reading it in would bloat every regex match.
 _MAX_CORPUS_FILE = 4 * 1024 * 1024
+
+# The artifact every `files` grader is anchored on. SKILL.md renders it as
+# `$TMPDIR/ci-secure-report-<slug>.md` and the save option copies it to
+# `./ci-secure-report.md`, so one glob covers both landing spots. `_grade` uses
+# the header form to tell "the report was never collected" (a harness failure)
+# apart from "the report says something else" (a real red).
+_REPORT_GLOB = "ci-secure-report*.md"
+_REPORT_HEADER = re.compile(r"^=== [^\n]*ci-secure-report[^\n]*\.md ===", re.M)
 
 
 def _env(tmpdir: Path | None = None) -> dict:
@@ -397,19 +414,30 @@ def _grade(graders: list[dict], stream: str, tools: list[tuple[str, str]],
                 _die(f"{name}: grader target {target!r} is not implemented — "
                      "this harness cannot score the case, so it must not "
                      "report one")
-            if target == "files" and not files:
-                # An empty corpus scores every `contains` as a failure and every
-                # `not_contains` as a pass: the session's own behaviour reported
-                # from evidence that was never collected.
-                _die(f"{name}: targets `files`, but the session produced no "
-                     "readable file — nothing was graded, and that is not a "
-                     "behavioural failure")
+            if target == "files" and not _REPORT_HEADER.search(files):
+                # Every `files` grader in this suite is anchored on the rendered
+                # report, so a corpus without one scores every `contains` as a
+                # failure and every `not_contains` as a pass: the session's own
+                # behaviour, reported from evidence that was never collected.
+                #
+                # Testing `not files` was too weak. A session leaves scratch
+                # notes and a fix branch, and any one of them keeps the corpus
+                # non-empty while the report is still missing — which is what
+                # happens the day `claude` stops honouring TMPDIR, a subprocess
+                # resets it, or SKILL.md drifts to a literal path. Ask for the
+                # artifact the graders actually read.
+                _die(f"{name}: targets `files`, but the session wrote no "
+                     f"{_REPORT_GLOB} the harness could collect — the graders "
+                     "anchored on the report had no evidence to read, and that "
+                     "is not a behavioural failure")
             found = bool(re.search(pat, corpora[target]))
             if mode == "not_contains":
                 scored.append((name, not found, "absent" if not found else "PRESENT"))
             elif mode.startswith("count:"):
+                # `corpora[target]`, not `stream`: counting always read the
+                # transcript, so a `files` grader scored the agent's prose.
                 want = int(mode.split(":", 1)[1])
-                n = len(re.findall(pat, stream))
+                n = len(re.findall(pat, corpora[target]))
                 scored.append((name, n == want, f"count={n}"))
             else:
                 scored.append((name, found, "found" if found else "missing"))

--- a/maintainers/ci-secure/scripts/run_skill_evals.py
+++ b/maintainers/ci-secure/scripts/run_skill_evals.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Execute ci-secure's behavioral eval cases against a real agent session.
+
+`claude plugin eval` is the runner these cases were written for, and it is
+gated behind early access. This is the same four steps built on shipped
+primitives instead:
+
+  1. scaffold  - the case's `scaffold.sh` materializes fixture workflows into
+                 an empty temp directory and makes it a git repo;
+  2. run       - `claude -p ... --plugin-dir <skill> --output-format stream-json`
+                 drives one headless session against that directory;
+  3. collect   - every tool call and message is read back out of the stream;
+  4. grade     - the case's own graders are applied to that record.
+
+Maintainer-only, and deliberately outside `skills/`: it spends real tokens, so
+it is never part of `pytest`. Run it before shipping a change to SKILL.md, the
+reference files, or the scripts the contract tells the agent to invoke.
+
+    python3 maintainers/ci-secure/scripts/run_skill_evals.py            # all cases
+    python3 maintainers/ci-secure/scripts/run_skill_evals.py --case clean-repo
+    python3 maintainers/ci-secure/scripts/run_skill_evals.py --runs 3
+
+Exit 0 when every selected case passes every mechanical grader, 1 otherwise, 2
+when the harness itself could not run (no `claude`, no PyYAML, scaffold failure)
+— a distinction that matters, because a harness that could not run is not a
+suite that passed.
+
+`llm` graders are REPORTED, NOT SCORED. They need a judge model; scoring them
+here without one would be inventing a verdict.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_SKILL = Path(__file__).resolve().parents[3] / "skills" / "ci-secure"
+_EVALS = _SKILL / "evals"
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(f"harness: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _cases(only: str | None) -> list[Path]:
+    dirs = sorted(p.parent for p in _EVALS.glob("*/case.yaml"))
+    if only:
+        dirs = [d for d in dirs if d.name == only]
+        if not dirs:
+            _die(f"no case named {only!r} under {_EVALS}")
+    if not dirs:
+        _die(f"no cases found under {_EVALS}")
+    return dirs
+
+
+def _scaffold(case: Path, sandbox: Path) -> None:
+    script = case / "scaffold.sh"
+    if not script.is_file():
+        _die(f"{case.name}: no scaffold.sh")
+    r = subprocess.run(
+        ["bash", str(script)], cwd=sandbox, capture_output=True, text=True, timeout=120
+    )
+    if r.returncode != 0:
+        _die(f"{case.name}: scaffold failed: {r.stderr.strip()[-400:]}")
+
+
+def _run_agent(prompt: str, sandbox: Path, max_turns: int, timeout: int) -> str:
+    """One headless session against the sandbox. Returns the raw stream."""
+    cmd = [
+        "claude", "-p", prompt,
+        "--output-format", "stream-json",
+        "--verbose",
+        "--max-turns", str(max_turns),
+        "--permission-mode", "bypassPermissions",
+        "--plugin-dir", str(_SKILL),
+    ]
+    try:
+        r = subprocess.run(
+            cmd, cwd=sandbox, capture_output=True, text=True, timeout=timeout
+        )
+    except subprocess.TimeoutExpired:
+        _die(f"agent run exceeded {timeout}s", 2)
+    if "early access" in r.stdout[:400] or "early access" in r.stderr[:400]:
+        _die("claude refused the run (early access gate)")
+    return r.stdout
+
+
+def _tool_calls(stream: str) -> list[tuple[str, str]]:
+    """(tool_name, json-encoded input) for every tool_use in the stream."""
+    out: list[tuple[str, str]] = []
+    for line in stream.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            ev = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        content = (ev.get("message") or {}).get("content")
+        if not isinstance(content, list):
+            continue
+        for c in content:
+            if isinstance(c, dict) and c.get("type") == "tool_use":
+                out.append((c.get("name", ""), json.dumps(c.get("input", {}))))
+    return out
+
+
+def _grade(graders: list[dict], stream: str, tools: list[tuple[str, str]]) -> tuple[list, list]:
+    """(scored results, unscored llm graders)."""
+    scored, unscored = [], []
+    for g in graders:
+        kind, name = g.get("type"), g.get("name", "?")
+        if kind == "tool_used":
+            pat = g.get("input_match")
+            n = sum(
+                1 for t, i in tools
+                if t == g.get("tool") and (pat is None or re.search(pat, i))
+            )
+            lo, hi = g.get("min", 1), g.get("max")
+            scored.append((name, n >= lo and (hi is None or n <= hi), f"count={n}"))
+        elif kind == "regex":
+            pat, mode = g.get("pattern", ""), g.get("match", "contains")
+            found = bool(re.search(pat, stream))
+            if mode == "not_contains":
+                scored.append((name, not found, "absent" if not found else "PRESENT"))
+            elif mode.startswith("count:"):
+                want = int(mode.split(":", 1)[1])
+                n = len(re.findall(pat, stream))
+                scored.append((name, n == want, f"count={n}"))
+            else:
+                scored.append((name, found, "found" if found else "missing"))
+        elif kind == "file_exists":
+            unscored.append((name, "file_exists needs the harness's created-file diff"))
+        elif kind in ("llm", "baseline"):
+            unscored.append((name, f"{kind} grader needs a judge model — reported, not scored"))
+        else:
+            unscored.append((name, f"unknown grader type {kind!r}"))
+    return scored, unscored
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--case", help="run one case by directory name")
+    ap.add_argument("--runs", type=int, default=1, help="runs per case (default 1)")
+    ap.add_argument("--keep", action="store_true", help="keep sandboxes for debugging")
+    args = ap.parse_args()
+
+    if shutil.which("claude") is None:
+        _die("`claude` is not on PATH")
+    try:
+        import yaml
+    except ImportError:
+        _die("PyYAML is required")
+
+    failed = False
+    for case in _cases(args.case):
+        spec = yaml.safe_load((case / "case.yaml").read_text(encoding="utf-8"))
+        ex = spec.get("execution", {})
+        prompt = ex.get("prompt")
+        if not prompt:
+            _die(f"{case.name}: no execution.prompt")
+
+        for run in range(1, args.runs + 1):
+            sandbox = Path(tempfile.mkdtemp(prefix=f"skill-eval-{case.name}-"))
+            try:
+                _scaffold(case, sandbox)
+                stream = _run_agent(
+                    prompt, sandbox,
+                    ex.get("max_turns", 60), ex.get("timeout_seconds", 900),
+                )
+                tools = _tool_calls(stream)
+                scored, unscored = _grade(spec.get("graders", []), stream, tools)
+
+                ok = all(p for _, p, _ in scored)
+                failed |= not ok
+                tag = f"{case.name} (run {run}/{args.runs})"
+                print(f"\n{'PASS' if ok else 'FAIL'}  {tag}  "
+                      f"— {sum(p for _, p, _ in scored)}/{len(scored)} scored graders, "
+                      f"{len(tools)} tool calls")
+                for name, passed, detail in scored:
+                    print(f"    {'ok  ' if passed else 'FAIL'} {name}  ({detail})")
+                for name, why in unscored:
+                    print(f"    ----  {name}  ({why})")
+            finally:
+                if not args.keep:
+                    shutil.rmtree(sandbox, ignore_errors=True)
+                else:
+                    print(f"    sandbox kept: {sandbox}")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/maintainers/ci-secure/scripts/run_skill_evals.py
+++ b/maintainers/ci-secure/scripts/run_skill_evals.py
@@ -20,19 +20,40 @@ reference files, or the scripts the contract tells the agent to invoke.
     python3 maintainers/ci-secure/scripts/run_skill_evals.py --case clean-repo
     python3 maintainers/ci-secure/scripts/run_skill_evals.py --runs 3
 
-Exit 0 when every selected case passes every mechanical grader, 1 otherwise, 2
-when the harness itself could not run (no `claude`, no PyYAML, scaffold failure)
-— a distinction that matters, because a harness that could not run is not a
-suite that passed.
+Exit 0 when every selected case passes every mechanical grader, 1 only when a
+case really ran and failed one, and 2 whenever the harness could not run: no
+`claude`, no PyYAML, a scaffold failure, an agent that refused to start, a
+session that produced no events, a turn cap hit, or a grader type this harness
+cannot evaluate. The split is the whole point. A session that never happened,
+graded, fails every positive grader and passes every negative one — which reads
+as "the agent behaved wrongly" when the truth is "the agent never ran". That is
+the wrong diagnosis pointing at the wrong file, and it is exactly the honesty
+rule the skill under test enforces on its own skipped checks.
 
 `llm` graders are REPORTED, NOT SCORED. They need a judge model; scoring them
 here without one would be inventing a verdict.
+
+WHAT THIS HARNESS DOES NOT YET DO, and `claude plugin eval` does:
+
+  - `execution.allowed_tools` is not applied. The session runs with the full
+    tool set, so a pass means the behaviour is reachable — not that it is
+    reachable under the tool grant the case declares.
+  - The no-plugin ablation arm (`arm: both`) is not run, so no grader is
+    checked against a session without the skill loaded.
+  - `execution.model` and `runs: 3` in the case files are not honoured; the
+    model is whatever the CLI defaults to and the run count comes from `--runs`.
+  - `target` (`trace` / `last_message` / `files`) and regex `flags` are ignored:
+    every regex grader is matched against the whole decoded transcript.
+
+Each of those makes a pass weaker than the case author asked for. None of them
+makes a failure wrong.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -42,6 +63,37 @@ from pathlib import Path
 
 _SKILL = Path(__file__).resolve().parents[3] / "skills" / "ci-secure"
 _EVALS = _SKILL / "evals"
+
+# The skill tree minus the parts that would hand the agent its own answer key.
+# `--plugin-dir` mounts the whole directory, and `evals/` holds every grader's
+# expected string while `tests/` holds rendered report fixtures containing them.
+# An agent that greps the plugin directory would put those strings into the
+# transcript, satisfying the graders without ever running a scan.
+_PLUGIN_EXCLUDE = ("evals", "tests")
+
+# Where a failing session is written, relative to the working directory, so the
+# run that failed can be read rather than reproduced.
+_LOGS = Path("skill-eval-logs")
+
+
+def _env() -> dict:
+    """A deliberately small environment for every subprocess.
+
+    Inherited `GIT_DIR` / `GIT_WORK_TREE` are the hazard: the scaffold's own
+    guard checks that the working directory is empty, which an empty temp dir
+    always is, so a git repository-selection variable exported by a hook or a
+    `git worktree` would send its `git init` / `git add` / `git commit` at a
+    real repository — and what it commits is intentionally vulnerable workflow
+    YAML. `_scaffold_common.sh` documents the minimal environment it is built
+    against; this is that environment.
+    """
+    keep = ("PATH", "HOME", "TMPDIR", "TERM", "LANG", "LC_ALL",
+            "ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "IS_SANDBOX",
+            "CLAUDE_CODE_BUBBLEWRAP", "NODE_PATH", "NPM_CONFIG_PREFIX")
+    env = {k: v for k, v in os.environ.items() if k in keep and v is not None}
+    env.setdefault("PATH", "/usr/local/bin:/usr/bin:/bin")
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    return env
 
 
 def _die(msg: str, code: int = 2) -> None:
@@ -65,44 +117,88 @@ def _scaffold(case: Path, sandbox: Path) -> None:
     if not script.is_file():
         _die(f"{case.name}: no scaffold.sh")
     r = subprocess.run(
-        ["bash", str(script)], cwd=sandbox, capture_output=True, text=True, timeout=120
+        ["bash", str(script)], cwd=sandbox, capture_output=True, text=True,
+        timeout=120, env=_env(),
     )
     if r.returncode != 0:
         _die(f"{case.name}: scaffold failed: {r.stderr.strip()[-400:]}")
 
 
-def _run_agent(prompt: str, sandbox: Path, max_turns: int, timeout: int) -> str:
-    """One headless session against the sandbox. Returns the raw stream."""
+def _events(stream: str) -> list[dict]:
+    """Every decodable JSON event in the stream, in order."""
+    out = []
+    for line in stream.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def _plugin_dir(into: Path) -> Path:
+    """A copy of the skill with the answer key removed, for `--plugin-dir`."""
+    dest = into / "ci-secure"
+    shutil.copytree(
+        _SKILL, dest,
+        ignore=lambda d, names: [n for n in names if n in _PLUGIN_EXCLUDE
+                                 and Path(d) == _SKILL],
+    )
+    return dest
+
+
+def _run_agent(prompt: str, sandbox: Path, plugin: Path, max_turns: int,
+               timeout: int) -> str:
+    """One headless session against the sandbox. Returns the raw stream.
+
+    Exits 2 rather than returning a stream no session produced. `claude` has
+    several ways to decline before the first turn — an auth failure, a refusal
+    to use `bypassPermissions` as root, an unknown flag — and every one of them
+    yields an empty stdout that grades as a full behavioural regression.
+    """
     cmd = [
         "claude", "-p", prompt,
         "--output-format", "stream-json",
         "--verbose",
         "--max-turns", str(max_turns),
         "--permission-mode", "bypassPermissions",
-        "--plugin-dir", str(_SKILL),
+        "--plugin-dir", str(plugin),
     ]
     try:
         r = subprocess.run(
-            cmd, cwd=sandbox, capture_output=True, text=True, timeout=timeout
+            cmd, cwd=sandbox, capture_output=True, text=True, timeout=timeout,
+            env=_env(),
         )
     except subprocess.TimeoutExpired:
         _die(f"agent run exceeded {timeout}s", 2)
-    if "early access" in r.stdout[:400] or "early access" in r.stderr[:400]:
+    if "early access" in r.stdout or "early access" in r.stderr:
         _die("claude refused the run (early access gate)")
+    if r.returncode != 0:
+        _die(f"claude exited {r.returncode} — the session never ran. "
+             f"claude said: {(r.stderr.strip() or r.stdout.strip())[-600:]}")
+    events = _events(r.stdout)
+    if not any(e.get("type") == "system" and e.get("subtype") == "init"
+               for e in events):
+        _die("claude exited 0 but the stream carries no session — nothing to "
+             f"grade. stderr: {r.stderr.strip()[-600:] or '(empty)'}")
+    for e in events:
+        if e.get("type") != "result":
+            continue
+        if e.get("subtype") == "error_max_turns":
+            _die(f"the session hit its {max_turns}-turn cap; a truncated run is "
+                 "not a graded run")
+        if e.get("is_error"):
+            _die(f"the session ended in an error: "
+                 f"{str(e.get('result', ''))[:400]}")
     return r.stdout
 
 
 def _tool_calls(stream: str) -> list[tuple[str, str]]:
     """(tool_name, json-encoded input) for every tool_use in the stream."""
     out: list[tuple[str, str]] = []
-    for line in stream.splitlines():
-        line = line.strip()
-        if not line.startswith("{"):
-            continue
-        try:
-            ev = json.loads(line)
-        except json.JSONDecodeError:
-            continue
+    for ev in _events(stream):
         content = (ev.get("message") or {}).get("content")
         if not isinstance(content, list):
             continue
@@ -110,6 +206,43 @@ def _tool_calls(stream: str) -> list[tuple[str, str]]:
             if isinstance(c, dict) and c.get("type") == "tool_use":
                 out.append((c.get("name", ""), json.dumps(c.get("input", {}))))
     return out
+
+
+def _transcript(stream: str) -> str:
+    r"""The decoded transcript the regex graders are written against.
+
+    Grading the raw stream-json is not the same thing, and is wrong in both
+    directions: inside a JSON string a newline is the two characters `\` and
+    `n`, so `[^\n]` stops meaning "on one line". `ci\.yml[^\n]{0,30}\b11\b`
+    would then match `ci.yml` on one line of output and a stray `11` on the
+    next — a false pass on the very grader that pins a finding to its real file
+    and line — while a `not_contains` guard fails on text that never shared a
+    line. Decode first, then match.
+
+    The corpus is what the session produced: the agent's own prose and the
+    output of the tools it ran. The prompt is excluded, so a grader cannot be
+    satisfied by the instructions the agent was handed.
+    """
+    parts: list[str] = []
+    for ev in _events(stream):
+        content = (ev.get("message") or {}).get("content")
+        if not isinstance(content, list):
+            continue
+        is_assistant = ev.get("type") == "assistant"
+        for c in content:
+            if not isinstance(c, dict):
+                continue
+            kind = c.get("type")
+            if kind == "text" and is_assistant:
+                parts.append(str(c.get("text", "")))
+            elif kind == "tool_result":
+                body = c.get("content")
+                if isinstance(body, str):
+                    parts.append(body)
+                elif isinstance(body, list):
+                    parts.extend(str(b.get("text", "")) for b in body
+                                 if isinstance(b, dict) and b.get("type") == "text")
+    return "\n".join(parts)
 
 
 def _grade(graders: list[dict], stream: str, tools: list[tuple[str, str]]) -> tuple[list, list]:
@@ -141,7 +274,11 @@ def _grade(graders: list[dict], stream: str, tools: list[tuple[str, str]]) -> tu
         elif kind in ("llm", "baseline"):
             unscored.append((name, f"{kind} grader needs a judge model — reported, not scored"))
         else:
-            unscored.append((name, f"unknown grader type {kind!r}"))
+            # Never demote an unevaluated grader to a dim line. A grader type
+            # this harness does not implement is a hole in the suite, and a
+            # suite with a hole in it did not pass.
+            _die(f"{name}: grader type {kind!r} is not implemented — this "
+                 "harness cannot score the case, so it must not report one")
     return scored, unscored
 
 
@@ -151,6 +288,12 @@ def main() -> int:
     ap.add_argument("--runs", type=int, default=1, help="runs per case (default 1)")
     ap.add_argument("--keep", action="store_true", help="keep sandboxes for debugging")
     args = ap.parse_args()
+
+    # `--runs 0` used to execute nothing and return 0, and the workflow's
+    # verdict announced that the skill evals passed. A suite that ran no
+    # session has no verdict to report.
+    if args.runs < 1:
+        _die(f"--runs {args.runs} would execute no session; that is not a pass")
 
     if shutil.which("claude") is None:
         _die("`claude` is not on PATH")
@@ -169,14 +312,21 @@ def main() -> int:
 
         for run in range(1, args.runs + 1):
             sandbox = Path(tempfile.mkdtemp(prefix=f"skill-eval-{case.name}-"))
+            plugin_root = Path(tempfile.mkdtemp(prefix=f"skill-eval-plugin-{case.name}-"))
             try:
                 _scaffold(case, sandbox)
                 stream = _run_agent(
-                    prompt, sandbox,
+                    prompt, sandbox, _plugin_dir(plugin_root),
                     ex.get("max_turns", 60), ex.get("timeout_seconds", 900),
                 )
                 tools = _tool_calls(stream)
-                scored, unscored = _grade(spec.get("graders", []), stream, tools)
+                scored, unscored = _grade(
+                    spec.get("graders", []), _transcript(stream), tools)
+                # `all([])` is True. A case whose graders all fell through to
+                # unscored would otherwise print PASS over nothing at all.
+                if not scored:
+                    _die(f"{case.name}: no grader could be scored; a case with "
+                         "nothing to check does not pass")
 
                 ok = all(p for _, p, _ in scored)
                 failed |= not ok
@@ -188,7 +338,16 @@ def main() -> int:
                     print(f"    {'ok  ' if passed else 'FAIL'} {name}  ({detail})")
                 for name, why in unscored:
                     print(f"    ----  {name}  ({why})")
+                if not ok:
+                    # "Read the job log" is what the workflow tells a reader to
+                    # do, and grader names alone do not explain a failure. Keep
+                    # the session next to the log so it can be read.
+                    log = _LOGS / f"{case.name}-run{run}.jsonl"
+                    log.parent.mkdir(parents=True, exist_ok=True)
+                    log.write_text(stream, encoding="utf-8")
+                    print(f"    session recorded: {log}")
             finally:
+                shutil.rmtree(plugin_root, ignore_errors=True)
                 if not args.keep:
                     shutil.rmtree(sandbox, ignore_errors=True)
                 else:
@@ -197,5 +356,22 @@ def main() -> int:
     return 1 if failed else 0
 
 
+def cli() -> int:
+    """`main`, with every unexpected failure mapped onto the could-not-run code.
+
+    Python exits 1 on an uncaught exception, and 1 is reserved here for "a case
+    ran and failed". A hung scaffold, a malformed case.yaml or a bad grader
+    pattern is the harness failing, and must not be read as the skill's
+    behaviour changing.
+    """
+    try:
+        return main()
+    except SystemExit:
+        raise
+    except BaseException as exc:  # noqa: BLE001 - the exit code is the point
+        _die(f"unhandled harness error: {type(exc).__name__}: {exc}")
+        raise  # unreachable; _die always raises
+
+
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(cli())

--- a/maintainers/ci-secure/scripts/run_skill_evals.py
+++ b/maintainers/ci-secure/scripts/run_skill_evals.py
@@ -173,16 +173,34 @@ def _run_agent(prompt: str, sandbox: Path, plugin: Path, max_turns: int,
         )
     except subprocess.TimeoutExpired:
         _die(f"agent run exceeded {timeout}s", 2)
-    if "early access" in r.stdout or "early access" in r.stderr:
-        _die("claude refused the run (early access gate)")
+
+    def _no_session(reason: str) -> None:
+        """Report a run that produced no session, verbatim.
+
+        Nothing here is special-cased to a known message. The first CI run of
+        this suite failed for a reason nobody could read, because the harness
+        kept only a substring test for "early access" and discarded the rest of
+        what `claude` said. Whatever the next non-start is, it lands in the log.
+        """
+        _die("\n".join([
+            reason,
+            f"  claude exit code: {r.returncode}",
+            f"  claude stderr: {r.stderr.strip()[-2000:] or '(empty)'}",
+            f"  claude stdout: {r.stdout.strip()[-2000:] or '(empty)'}",
+        ]))
+
     if r.returncode != 0:
-        _die(f"claude exited {r.returncode} — the session never ran. "
-             f"claude said: {(r.stderr.strip() or r.stdout.strip())[-600:]}")
+        _no_session("claude exited non-zero — the session never ran.")
     events = _events(r.stdout)
     if not any(e.get("type") == "system" and e.get("subtype") == "init"
                for e in events):
-        _die("claude exited 0 but the stream carries no session — nothing to "
-             f"grade. stderr: {r.stderr.strip()[-600:] or '(empty)'}")
+        _no_session("claude exited 0 but the stream carries no session.")
+    if not _tool_calls(r.stdout):
+        # Every case drives the agent to read files and execute the scanner. A
+        # completed session that called no tool at all did not do the work; it
+        # is a session that ended before it started, and grading it scores each
+        # negative grader as a pass while blaming the contract for the rest.
+        _no_session("the session completed without calling a single tool.")
     for e in events:
         if e.get("type") != "result":
             continue
@@ -190,8 +208,7 @@ def _run_agent(prompt: str, sandbox: Path, plugin: Path, max_turns: int,
             _die(f"the session hit its {max_turns}-turn cap; a truncated run is "
                  "not a graded run")
         if e.get("is_error"):
-            _die(f"the session ended in an error: "
-                 f"{str(e.get('result', ''))[:400]}")
+            _no_session("the session ended in an error result.")
     return r.stdout
 
 

--- a/maintainers/ci-secure/scripts/run_skill_evals.py
+++ b/maintainers/ci-secure/scripts/run_skill_evals.py
@@ -9,8 +9,12 @@ primitives instead:
                  an empty temp directory and makes it a git repo;
   2. run       - `claude -p ... --plugin-dir <skill> --output-format stream-json`
                  drives one headless session against that directory;
-  3. collect   - every tool call and message is read back out of the stream;
-  4. grade     - the case's own graders are applied to that record.
+  3. collect   - every tool call and message is read back out of the stream,
+                 and every file the session WROTE is read off disk: the skill
+                 renders its report to a file and prints a summary, so the
+                 transcript alone is only half of what the run produced;
+  4. grade     - the case's own graders are applied to that record, each regex
+                 against the corpus its `target` names.
 
 Maintainer-only, and deliberately outside `skills/`: it spends real tokens, so
 it is never part of `pytest`. Run it before shipping a change to SKILL.md, the
@@ -42,8 +46,11 @@ WHAT THIS HARNESS DOES NOT YET DO, and `claude plugin eval` does:
     checked against a session without the skill loaded.
   - `execution.model` and `runs: 3` in the case files are not honoured; the
     model is whatever the CLI defaults to and the run count comes from `--runs`.
-  - `target` (`trace` / `last_message` / `files`) and regex `flags` are ignored:
-    every regex grader is matched against the whole decoded transcript.
+  - regex `flags` are ignored; every pattern is matched case-sensitively.
+  - a `target` given as `{source: file, path: ...}` is not implemented. The
+    three word targets are: `trace` (the decoded transcript), `files` (what the
+    session wrote — see `_files_corpus`), and `last_message`. An unimplemented
+    target stops the harness rather than quietly grading another corpus.
 
 Each of those makes a pass weaker than the case author asked for. None of them
 makes a failure wrong.
@@ -52,6 +59,7 @@ makes a failure wrong.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -75,8 +83,13 @@ _PLUGIN_EXCLUDE = ("evals", "tests")
 # run that failed can be read rather than reproduced.
 _LOGS = Path("skill-eval-logs")
 
+# A ceiling on any single file entering the graded corpus. A report is tens of
+# kilobytes; anything past this is a lockfile, a cache or a binary the agent
+# happened to create, and reading it in would bloat every regex match.
+_MAX_CORPUS_FILE = 4 * 1024 * 1024
 
-def _env() -> dict:
+
+def _env(tmpdir: Path | None = None) -> dict:
     """A deliberately small environment for every subprocess.
 
     Inherited `GIT_DIR` / `GIT_WORK_TREE` are the hazard: the scaffold's own
@@ -86,6 +99,12 @@ def _env() -> dict:
     real repository — and what it commits is intentionally vulnerable workflow
     YAML. `_scaffold_common.sh` documents the minimal environment it is built
     against; this is that environment.
+
+    `tmpdir` points the session's TMPDIR at a directory this harness owns.
+    SKILL.md renders the report to `${TMPDIR:-/tmp}/ci-secure-report-<slug>.md`
+    and the findings to the matching `ci-secure-findings-<slug>.json`, so
+    setting it is what turns "collect what the run produced" into a contract
+    rather than a guess at where the files landed.
     """
     keep = ("PATH", "HOME", "TMPDIR", "TERM", "LANG", "LC_ALL",
             "ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "IS_SANDBOX",
@@ -93,6 +112,8 @@ def _env() -> dict:
     env = {k: v for k, v in os.environ.items() if k in keep and v is not None}
     env.setdefault("PATH", "/usr/local/bin:/usr/bin:/bin")
     env["GIT_CONFIG_NOSYSTEM"] = "1"
+    if tmpdir is not None:
+        env["TMPDIR"] = str(tmpdir)
     return env
 
 
@@ -150,7 +171,7 @@ def _plugin_dir(into: Path) -> Path:
 
 
 def _run_agent(prompt: str, sandbox: Path, plugin: Path, max_turns: int,
-               timeout: int) -> str:
+               timeout: int, tmpdir: Path | None = None) -> str:
     """One headless session against the sandbox. Returns the raw stream.
 
     Exits 2 rather than returning a stream no session produced. `claude` has
@@ -169,7 +190,7 @@ def _run_agent(prompt: str, sandbox: Path, plugin: Path, max_turns: int,
     try:
         r = subprocess.run(
             cmd, cwd=sandbox, capture_output=True, text=True, timeout=timeout,
-            env=_env(),
+            env=_env(tmpdir),
         )
     except subprocess.TimeoutExpired:
         _die(f"agent run exceeded {timeout}s", 2)
@@ -262,8 +283,98 @@ def _transcript(stream: str) -> str:
     return "\n".join(parts)
 
 
-def _grade(graders: list[dict], stream: str, tools: list[tuple[str, str]]) -> tuple[list, list]:
-    """(scored results, unscored llm graders)."""
+def _last_message(stream: str) -> str:
+    """The final assistant turn — what the session left on the reader's screen."""
+    texts = []
+    for ev in _events(stream):
+        if ev.get("type") != "assistant":
+            continue
+        content = (ev.get("message") or {}).get("content")
+        if not isinstance(content, list):
+            continue
+        turn = [str(c.get("text", "")) for c in content
+                if isinstance(c, dict) and c.get("type") == "text"]
+        if turn:
+            texts = turn
+    return "\n".join(texts)
+
+
+def _snapshot(roots: list[Path]) -> dict[str, str]:
+    """path -> content digest, for every readable file under `roots`."""
+    return {str(p): hashlib.sha256(p.read_bytes()).hexdigest()
+            for p in _corpus_files(roots)}
+
+
+def _corpus_files(roots: list[Path]) -> list[Path]:
+    """Every regular, non-`.git`, non-symlink file under `roots`, sorted.
+
+    Symlinks are skipped rather than followed: the sandbox is a directory an
+    agent had write access to, and a link out of it would pull an arbitrary file
+    into the graded corpus.
+    """
+    out = []
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for p in sorted(root.rglob("*")):
+            if p.is_symlink() or not p.is_file():
+                continue
+            if ".git" in p.relative_to(root).parts:
+                continue
+            out.append(p)
+    return out
+
+
+def _files_corpus(roots: list[Path], before: dict[str, str]) -> str:
+    """The files the SESSION produced, as one greppable text.
+
+    Not the whole sandbox. The scaffold hands the agent intentionally
+    vulnerable workflow YAML naming the very files several graders assert on,
+    so grading what the agent was handed would give those graders their answer
+    for free — the same trap `_PLUGIN_EXCLUDE` closes for `evals/` and
+    `tests/`. A file is in only if it did not exist before the session or its
+    contents changed during it.
+
+    Each file is introduced by a `=== <path> ===` header, relative to its root
+    so the corpus does not carry this run's temp directory name.
+    """
+    parts: list[str] = []
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for p in _corpus_files([root]):
+            try:
+                raw = p.read_bytes()
+            except OSError:
+                continue
+            if before.get(str(p)) == hashlib.sha256(raw).hexdigest():
+                continue  # handed to the session, not written by it
+            rel = p.relative_to(root).as_posix()
+            if len(raw) > _MAX_CORPUS_FILE:
+                # Never drop a file silently — a grader that cannot see its
+                # evidence must say so, not fail as though the run misbehaved.
+                parts.append(f"=== {rel} (NOT READ: {len(raw)} bytes) ===")
+                continue
+            try:
+                parts.append(f"=== {rel} ===\n{raw.decode('utf-8')}")
+            except UnicodeDecodeError:
+                parts.append(f"=== {rel} (NOT READ: not UTF-8 text) ===")
+    return "\n".join(parts)
+
+
+def _grade(graders: list[dict], stream: str, tools: list[tuple[str, str]],
+           files: str = "", last_message: str = "") -> tuple[list, list]:
+    """(scored results, unscored llm graders).
+
+    `stream` is the decoded transcript; `files` is what the session wrote.
+    A regex grader reads whichever its `target` names — the two corpora are
+    kept apart deliberately. `files` exists because the graders that pin a
+    finding to its real file and line are anchored on `report.py`'s evidence
+    bullets, which the skill renders into a file and does not print; grading
+    them against the transcript scored whether the agent happened to `cat` its
+    own report.
+    """
+    corpora = {"trace": stream, "files": files, "last_message": last_message}
     scored, unscored = [], []
     for g in graders:
         kind, name = g.get("type"), g.get("name", "?")
@@ -277,7 +388,23 @@ def _grade(graders: list[dict], stream: str, tools: list[tuple[str, str]]) -> tu
             scored.append((name, n >= lo and (hi is None or n <= hi), f"count={n}"))
         elif kind == "regex":
             pat, mode = g.get("pattern", ""), g.get("match", "contains")
-            found = bool(re.search(pat, stream))
+            # `target` used to be ignored outright, so a grader that said
+            # `files` was silently matched against the transcript — the wrong
+            # corpus, reported as a verdict. An unimplemented target is a hole
+            # in the suite, and a suite with a hole in it did not pass.
+            target = g.get("target", "trace")
+            if target not in corpora:
+                _die(f"{name}: grader target {target!r} is not implemented — "
+                     "this harness cannot score the case, so it must not "
+                     "report one")
+            if target == "files" and not files:
+                # An empty corpus scores every `contains` as a failure and every
+                # `not_contains` as a pass: the session's own behaviour reported
+                # from evidence that was never collected.
+                _die(f"{name}: targets `files`, but the session produced no "
+                     "readable file — nothing was graded, and that is not a "
+                     "behavioural failure")
+            found = bool(re.search(pat, corpora[target]))
             if mode == "not_contains":
                 scored.append((name, not found, "absent" if not found else "PRESENT"))
             elif mode.startswith("count:"):
@@ -330,15 +457,24 @@ def main() -> int:
         for run in range(1, args.runs + 1):
             sandbox = Path(tempfile.mkdtemp(prefix=f"skill-eval-{case.name}-"))
             plugin_root = Path(tempfile.mkdtemp(prefix=f"skill-eval-plugin-{case.name}-"))
+            # The session's TMPDIR, and the second half of the graded corpus:
+            # SKILL.md renders the report and the findings JSON under it.
+            artifacts = Path(tempfile.mkdtemp(prefix=f"skill-eval-out-{case.name}-"))
             try:
                 _scaffold(case, sandbox)
+                # AFTER the scaffold: what the fixture put there is what the
+                # agent was handed, and must not count as what it produced.
+                before = _snapshot([sandbox, artifacts])
                 stream = _run_agent(
                     prompt, sandbox, _plugin_dir(plugin_root),
                     ex.get("max_turns", 60), ex.get("timeout_seconds", 900),
+                    artifacts,
                 )
                 tools = _tool_calls(stream)
                 scored, unscored = _grade(
-                    spec.get("graders", []), _transcript(stream), tools)
+                    spec.get("graders", []), _transcript(stream), tools,
+                    files=_files_corpus([sandbox, artifacts], before),
+                    last_message=_last_message(stream))
                 # `all([])` is True. A case whose graders all fell through to
                 # unscored would otherwise print PASS over nothing at all.
                 if not scored:
@@ -363,12 +499,21 @@ def main() -> int:
                     log.parent.mkdir(parents=True, exist_ok=True)
                     log.write_text(stream, encoding="utf-8")
                     print(f"    session recorded: {log}")
+                    # A `files` grader failed on something the transcript does
+                    # not contain, so the transcript alone cannot explain it.
+                    corpus_log = _LOGS / f"{case.name}-run{run}.files.txt"
+                    corpus_log.write_text(
+                        _files_corpus([sandbox, artifacts], before),
+                        encoding="utf-8")
+                    print(f"    files the run produced: {corpus_log}")
             finally:
                 shutil.rmtree(plugin_root, ignore_errors=True)
                 if not args.keep:
                     shutil.rmtree(sandbox, ignore_errors=True)
+                    shutil.rmtree(artifacts, ignore_errors=True)
                 else:
                     print(f"    sandbox kept: {sandbox}")
+                    print(f"    session output kept: {artifacts}")
 
     return 1 if failed else 0
 

--- a/maintainers/ci-secure/tests/test_run_skill_evals.py
+++ b/maintainers/ci-secure/tests/test_run_skill_evals.py
@@ -13,6 +13,7 @@ for a suite that executed nothing.
 """
 import importlib.util
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -181,6 +182,46 @@ def test_the_plugin_copy_withholds_the_answer_key(tmp_path):
     assert not (plugin / "tests").exists()
 
 
+def test_no_file_the_plugin_copy_mounts_can_satisfy_a_grader(tmp_path):
+    """The name-based exclusion list is not the invariant -- this is.
+
+    `evals/` and `tests/` were excluded because someone noticed they held the
+    answer key. Nothing checked the REST of the tree, and the rest of the tree
+    grew: `CHANGELOG.md` ships inside the skill, `--plugin-dir` mounts it, and
+    it quotes banner strings verbatim while describing the graders that assert
+    on them. One `Grep` of the plugin directory then greens a grader with no
+    scan behind it -- a false PASS, which is the direction that never gets
+    investigated.
+
+    The shipped vacuity rule (`skills/ci-secure/tests/test_evals_cases.py`)
+    cannot cover this: it lives in the installed skill and has no idea what
+    this maintainer-side harness chooses to mount. So the check belongs here,
+    stated as the property rather than as a list of names, and it fails the day
+    any new file at the skill root quotes a grader's expected string.
+    """
+    import yaml
+
+    plugin = harness._plugin_dir(tmp_path)
+    mounted = {p: p.read_text(encoding="utf-8", errors="replace")
+               for p in sorted(plugin.rglob("*")) if p.is_file()}
+
+    offenders = []
+    for case in sorted((harness._SKILL / "evals").glob("*/case.yaml")):
+        for g in yaml.safe_load(case.read_text(encoding="utf-8"))["graders"]:
+            if g.get("type") != "regex" or g.get("match") == "not_contains":
+                continue
+            for path, text in mounted.items():
+                hit = re.search(g["pattern"], text)
+                if hit:
+                    offenders.append(
+                        f"{case.parent.name}/{g['name']} matches "
+                        f"{hit.group(0)!r} in {path.relative_to(plugin)}")
+    assert not offenders, (
+        "a file the harness mounts satisfies a grader without a scan behind "
+        "it -- the agent can read the answer instead of computing it:\n  "
+        + "\n  ".join(offenders))
+
+
 # --- the graded corpus is everything the run produced, not only what it printed
 #
 # ci-secure writes its report to a file and prints a summary. The graders that
@@ -207,10 +248,13 @@ def test_a_files_targeted_regex_reads_what_the_session_wrote(tmp_path):
         "the run rendered the evidence bullet; the grader must see the file")
 
 
-def test_a_files_targeted_regex_does_not_read_the_transcript(tmp_path):
-    """The two corpora stay separate in both directions. A `files` grader that
-    silently fell back to the trace would pass on the agent's prose — exactly
-    the model-phrasing dependence these anchors exist to avoid."""
+def test_an_uncollectable_corpus_is_not_scored_as_a_behavioural_failure(tmp_path):
+    """A `files` grader with no report to read is a collection failure, exit 2.
+
+    This used to be named for corpus separation, but it never tested it: the
+    empty-corpus guard fires before any corpus lookup, so it exits 2 whatever
+    `corpora["files"]` would have returned. Separation is now pinned by the test
+    below, and this one keeps the guard it actually exercises."""
     corpus = harness._files_corpus([tmp_path], {})
     graders = [{"type": "regex", "name": "report-only", "target": "files",
                 "pattern": r"ONLY-IN-THE-TRANSCRIPT", "match": "contains"}]
@@ -219,6 +263,30 @@ def test_a_files_targeted_regex_does_not_read_the_transcript(tmp_path):
     assert exc.value.code == 2, (
         "an empty files corpus under a files-targeted grader is a corpus that "
         "could not be collected — not a behavioural failure")
+
+
+def test_a_files_targeted_regex_does_not_read_the_transcript(tmp_path):
+    """The two corpora stay separate in BOTH directions.
+
+    The trace→files direction was covered; this one was not, and the asymmetry
+    was invisible because the test that claimed it only ever reached the
+    empty-corpus guard. A `files` grader that silently fell back to — or
+    concatenated in — the transcript would pass on the agent's prose, which is
+    the model-phrasing dependence these anchors exist to remove.
+
+    So the corpus here is real (it holds a report, clearing the collection
+    guard) and simply does not contain the needle, while the transcript does.
+    The grader must come back False."""
+    report = tmp_path / "ci-secure-report-abc.md"
+    report.write_text("a real report that never mentions the needle\n",
+                      encoding="utf-8")
+    corpus = harness._files_corpus([tmp_path], {})
+    graders = [{"type": "regex", "name": "report-only", "target": "files",
+                "pattern": r"ONLY-IN-THE-TRANSCRIPT", "match": "contains"}]
+    scored, _ = harness._grade(graders, "ONLY-IN-THE-TRANSCRIPT", [], files=corpus)
+    assert scored[0][1] is False, (
+        "the needle is only in the transcript; a `files` grader that saw it "
+        "read the wrong corpus")
 
 
 def test_a_trace_targeted_regex_does_not_read_the_files(tmp_path):
@@ -230,6 +298,54 @@ def test_a_trace_targeted_regex_does_not_read_the_files(tmp_path):
                 "pattern": r"ONLY-IN-THE-REPORT", "match": "contains"}]
     scored, _ = harness._grade(graders, "", [], files=corpus)
     assert scored[0][1] is False
+
+
+def test_a_corpus_without_the_report_is_a_collection_failure_not_a_red_case(tmp_path):
+    """The empty-corpus guard was written for "the report never reached the
+    harness", but it only fires when the corpus is COMPLETELY empty -- and a
+    session leaves scratch files, a fix branch, a stray note. One of those keeps
+    the corpus non-empty while the report is still missing, and then every
+    report-anchored grader fails as though the scan had misbehaved.
+
+    That is the exact wrong-diagnosis this PR exists to close, one level in: if
+    `claude` stops honouring TMPDIR, or a subprocess resets it, or SKILL.md
+    drifts to a literal path, the harness must say it could not collect the
+    evidence rather than report a behaviour change.
+    """
+    (tmp_path / "scratch-note.txt").write_text("thinking out loud\n", encoding="utf-8")
+    corpus = harness._files_corpus([tmp_path], {})
+    assert corpus, "precondition: the corpus is non-empty but holds no report"
+    graders = [{"type": "regex", "name": "finding-lands-on-the-vulnerable-workflow",
+                "target": "files",
+                "pattern": r"vulnerable\.yml:(?:8|14)\b[^\n]{0,20}jobs",
+                "match": "contains"}]
+    with pytest.raises(SystemExit) as exc:
+        harness._grade(graders, "", [], files=corpus)
+    assert exc.value.code == 2, (
+        "no report in the corpus means the graders anchored on it had no "
+        "evidence to read -- a harness failure, not a skill regression")
+
+
+def test_a_count_grader_counts_in_the_corpus_its_target_names(tmp_path):
+    """`count:` is the third match mode, and it read the transcript no matter
+    what `target` said -- the same wrong-corpus bug `contains` was just fixed
+    for, surviving in the branch beside it.
+
+    Silent, and wrong in both directions: a `files` grader counting `2` scores
+    the occurrences in the agent's prose, so a report that rendered exactly two
+    passes only if the session also happened to say it twice. No case uses
+    `count:` today, which is why it went unnoticed; the next author to write one
+    against `files` would get a verdict computed from the other corpus.
+    """
+    report = tmp_path / "ci-secure-report-abc.md"
+    report.write_text("HIT\nHIT\n", encoding="utf-8")
+    corpus = harness._files_corpus([tmp_path], {})
+    graders = [{"type": "regex", "name": "two-in-the-report", "target": "files",
+                "pattern": "HIT", "match": "count:2"}]
+    scored, _ = harness._grade(graders, "HIT", [], files=corpus)
+    assert scored[0][1] is True, (
+        "the report holds exactly two hits and the grader targets `files`; "
+        f"counting the one in the transcript instead gave {scored[0][2]}")
 
 
 def test_an_unknown_grader_target_is_not_graded_against_the_trace():

--- a/maintainers/ci-secure/tests/test_run_skill_evals.py
+++ b/maintainers/ci-secure/tests/test_run_skill_evals.py
@@ -1,0 +1,162 @@
+"""A session that never started must not be graded as a session that misbehaved.
+
+The first CI run of the eval workflow failed every grader on all five cases in
+1.6 seconds with zero tool calls: `claude` refused to start under
+`--permission-mode bypassPermissions` as root and exited immediately, printing
+its reason on stderr. The harness read the empty stdout, graded it, and
+announced "the agent's behaviour changed" — the wrong diagnosis, pointing at the
+wrong file, on the one check whose whole purpose is to be believed.
+
+These pin the distinction the harness documents: exit 2 when the agent could not
+run at all, exit 1 only for a real behavioural failure, and never a silent pass
+for a suite that executed nothing.
+"""
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_HARNESS = (Path(__file__).resolve().parents[1]
+            / "scripts" / "run_skill_evals.py")
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("run_skill_evals", _HARNESS)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+harness = _load()
+
+
+def _completed(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(
+        args=["claude"], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+_GOOD_STREAM = (
+    '{"type":"system","subtype":"init","session_id":"s"}\n'
+    '{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}\n'
+)
+
+
+def test_a_nonzero_claude_exit_is_a_harness_failure_not_a_graded_run(monkeypatch, capsys, tmp_path):
+    """The exact CI failure: claude refuses to start and exits 1 with a reason
+    on stderr. Grading that empty stream blames the contract for a run that
+    never happened."""
+    monkeypatch.setattr(harness.subprocess, "run", lambda *a, **k: _completed(
+        returncode=1, stdout="",
+        stderr="--dangerously-skip-permissions cannot be used with "
+               "root/sudo privileges for security reasons\n"))
+    with pytest.raises(SystemExit) as exc:
+        harness._run_agent("prompt", tmp_path, tmp_path, 60, 900)
+    assert exc.value.code == 2, "a failed agent start is exit 2, not a graded failure"
+    err = capsys.readouterr().err
+    assert "root/sudo" in err, "claude's own reason must be surfaced, not swallowed"
+
+
+def test_an_empty_stream_from_a_zero_exit_is_still_a_harness_failure(monkeypatch, capsys, tmp_path):
+    """Exit 0 with no session events means no session ran. Grading it scores
+    every negative grader as a pass."""
+    monkeypatch.setattr(harness.subprocess, "run",
+                        lambda *a, **k: _completed(returncode=0, stdout="", stderr=""))
+    with pytest.raises(SystemExit) as exc:
+        harness._run_agent("prompt", tmp_path, tmp_path, 60, 900)
+    assert exc.value.code == 2
+    assert "no session" in capsys.readouterr().err.lower()
+
+
+def test_a_real_stream_is_returned_unchanged(monkeypatch, tmp_path):
+    """The guard must not reject a session that actually started."""
+    monkeypatch.setattr(harness.subprocess, "run",
+                        lambda *a, **k: _completed(returncode=0, stdout=_GOOD_STREAM))
+    assert harness._run_agent("prompt", tmp_path, tmp_path, 60, 900) == _GOOD_STREAM
+
+
+def test_zero_runs_is_refused_rather_than_reported_as_a_pass(monkeypatch):
+    """`--runs 0` executed no sessions, left `failed` False, and returned 0 —
+    the verdict job then announced that the skill evals passed."""
+    monkeypatch.setattr(harness.sys, "argv", ["run_skill_evals.py", "--runs", "0"])
+    with pytest.raises(SystemExit) as exc:
+        harness.main()
+    assert exc.value.code == 2, "a run count that executes nothing is not a pass"
+
+
+def test_an_unexpected_harness_error_exits_2_not_1(monkeypatch, tmp_path):
+    """A hung scaffold, a malformed case.yaml, or a bad grader pattern is the
+    harness failing — not the agent misbehaving. Python's default exit 1 for an
+    uncaught exception collides with 'a case failed'."""
+    monkeypatch.setattr(harness.sys, "argv", ["run_skill_evals.py"])
+    monkeypatch.setattr(harness.shutil, "which", lambda _: "/usr/bin/claude")
+    monkeypatch.setattr(harness, "_cases", lambda only: [tmp_path / "boom"])
+    with pytest.raises(SystemExit) as exc:
+        harness.cli()
+    assert exc.value.code == 2, "an uncaught harness error must not read as a case failure"
+
+
+def test_a_grader_type_the_harness_cannot_score_is_not_a_pass():
+    """`tool_order` and `file_exists` are schema-legal. Demoting one to a dim
+    `----` line makes the harness's word for 'I could not check this' and its
+    word for 'this passed' the same word at the exit-code level."""
+    with pytest.raises(SystemExit) as exc:
+        harness._grade([{"type": "tool_order", "name": "scan-before-report"}], "", [])
+    assert exc.value.code == 2
+
+
+def test_regex_graders_see_decoded_lines_not_the_wire_format():
+    """`[^\n]` must mean 'on one line'. Against raw stream-json a newline is
+    the two characters backslash-n, so a same-line assertion silently matches
+    across lines — a false pass on the graders that pin a finding to its real
+    file and line."""
+    stream = json.dumps({
+        "type": "assistant",
+        "message": {"content": [{"type": "text", "text": "ci.yml (clean)\nline 11 elsewhere"}]},
+    })
+    graders = [{"type": "regex", "name": "same-line",
+                "pattern": r"ci\.yml[^\n]{0,30}?\b11\b", "match": "contains"}]
+    raw_scored, _ = harness._grade(graders, stream, [])
+    decoded_scored, _ = harness._grade(graders, harness._transcript(stream), [])
+    assert raw_scored[0][1] is True, "the wire format is what made this a false pass"
+    assert decoded_scored[0][1] is False, "the decoded transcript must not match across lines"
+
+
+def test_the_transcript_excludes_the_prompt_and_keeps_tool_output():
+    """A grader must not be satisfiable by the instructions the agent was
+    handed, and must still see what the tools it ran printed."""
+    stream = "\n".join(json.dumps(e) for e in [
+        {"type": "user", "message": {"content": [{"type": "text", "text": "PROMPT TEXT"}]}},
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "AGENT PROSE"}]}},
+        {"type": "user", "message": {"content": [
+            {"type": "tool_result", "content": [{"type": "text", "text": "0 of 10 vectors hit"}]}]}},
+    ])
+    got = harness._transcript(stream)
+    assert "PROMPT TEXT" not in got
+    assert "AGENT PROSE" in got
+    assert "0 of 10 vectors hit" in got
+
+
+def test_subprocesses_do_not_inherit_git_repository_selection(monkeypatch):
+    """An exported GIT_DIR would send the scaffold's `git init` / `git add` /
+    `git commit` at a real repository, and what it commits is intentionally
+    vulnerable workflow YAML. The scaffold's emptiness guard cannot catch it:
+    the temp directory really is empty."""
+    monkeypatch.setenv("GIT_DIR", "/somewhere/real/.git")
+    monkeypatch.setenv("GIT_WORK_TREE", "/somewhere/real")
+    env = harness._env()
+    assert "GIT_DIR" not in env and "GIT_WORK_TREE" not in env
+    assert env["GIT_CONFIG_NOSYSTEM"] == "1"
+
+
+def test_the_plugin_copy_withholds_the_answer_key(tmp_path):
+    """`--plugin-dir` mounts the whole skill tree. `evals/` holds every
+    grader's expected string and `tests/` holds rendered reports containing
+    them, so an agent that greps the plugin directory could satisfy the
+    graders without running a scan."""
+    plugin = harness._plugin_dir(tmp_path)
+    assert (plugin / "SKILL.md").is_file()
+    assert (plugin / "scripts").is_dir() and (plugin / "references").is_dir()
+    assert not (plugin / "evals").exists()
+    assert not (plugin / "tests").exists()

--- a/maintainers/ci-secure/tests/test_run_skill_evals.py
+++ b/maintainers/ci-secure/tests/test_run_skill_evals.py
@@ -14,6 +14,7 @@ for a suite that executed nothing.
 import importlib.util
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -178,3 +179,169 @@ def test_the_plugin_copy_withholds_the_answer_key(tmp_path):
     assert (plugin / "scripts").is_dir() and (plugin / "references").is_dir()
     assert not (plugin / "evals").exists()
     assert not (plugin / "tests").exists()
+
+
+# --- the graded corpus is everything the run produced, not only what it printed
+#
+# ci-secure writes its report to a file and prints a summary. The graders that
+# pin a finding to its real file and line are anchored on `report.py`'s evidence
+# bullets — `vulnerable.yml:8 — jobs: bench` — which is deliberate: a model can
+# paraphrase its summary a dozen ways, but that bullet is byte-identical every
+# run. Grading only the transcript threw that surface away, so two cases failed
+# on runs where the skill had behaved correctly and written the right report.
+
+
+def test_a_files_targeted_regex_reads_what_the_session_wrote(tmp_path):
+    """The report is output. A grader anchored on the renderer must be able to
+    see it, or it grades whether the agent happened to `cat` the file."""
+    report = tmp_path / "ci-secure-report-abc.md"
+    report.write_text("- `.github/workflows/vulnerable.yml:8` — jobs: `bench`\n",
+                      encoding="utf-8")
+    corpus = harness._files_corpus([tmp_path], {})
+    graders = [{"type": "regex", "name": "finding-lands-on-the-vulnerable-workflow",
+                "target": "files",
+                "pattern": r"vulnerable\.yml:(?:8|14)\b[^\n]{0,20}jobs",
+                "match": "contains"}]
+    scored, _ = harness._grade(graders, "", [], files=corpus)
+    assert scored[0][1] is True, (
+        "the run rendered the evidence bullet; the grader must see the file")
+
+
+def test_a_files_targeted_regex_does_not_read_the_transcript(tmp_path):
+    """The two corpora stay separate in both directions. A `files` grader that
+    silently fell back to the trace would pass on the agent's prose — exactly
+    the model-phrasing dependence these anchors exist to avoid."""
+    corpus = harness._files_corpus([tmp_path], {})
+    graders = [{"type": "regex", "name": "report-only", "target": "files",
+                "pattern": r"ONLY-IN-THE-TRANSCRIPT", "match": "contains"}]
+    with pytest.raises(SystemExit) as exc:
+        harness._grade(graders, "ONLY-IN-THE-TRANSCRIPT", [], files=corpus)
+    assert exc.value.code == 2, (
+        "an empty files corpus under a files-targeted grader is a corpus that "
+        "could not be collected — not a behavioural failure")
+
+
+def test_a_trace_targeted_regex_does_not_read_the_files(tmp_path):
+    """And the other direction: the transcript grader must not be satisfiable
+    by a file the agent wrote but never showed."""
+    (tmp_path / "report.md").write_text("ONLY-IN-THE-REPORT\n", encoding="utf-8")
+    corpus = harness._files_corpus([tmp_path], {})
+    graders = [{"type": "regex", "name": "trace-only", "target": "trace",
+                "pattern": r"ONLY-IN-THE-REPORT", "match": "contains"}]
+    scored, _ = harness._grade(graders, "", [], files=corpus)
+    assert scored[0][1] is False
+
+
+def test_an_unknown_grader_target_is_not_graded_against_the_trace():
+    """`target` used to be ignored outright, so `files` silently meant `trace`.
+    Whatever the next unimplemented target is, it must stop the harness rather
+    than quietly grade the wrong corpus."""
+    graders = [{"type": "regex", "name": "bogus", "target": "sandbox",
+                "pattern": "x", "match": "contains"}]
+    with pytest.raises(SystemExit) as exc:
+        harness._grade(graders, "x", [], files="x")
+    assert exc.value.code == 2
+
+
+def test_the_files_corpus_holds_only_what_the_session_created(tmp_path):
+    """The fixture the agent was HANDED is not evidence of what it did. The
+    scaffold writes intentionally vulnerable workflow YAML naming the very files
+    the graders assert on, so grading the whole sandbox would hand several
+    graders their answer the way `evals/` and `tests/` would."""
+    fixture = tmp_path / "handed.yml"
+    fixture.write_text("on: pull_request_target\n", encoding="utf-8")
+    edited = tmp_path / "edited.md"
+    edited.write_text("before\n", encoding="utf-8")
+    before = harness._snapshot([tmp_path])
+
+    (tmp_path / "written-by-the-run.md").write_text("NEW\n", encoding="utf-8")
+    edited.write_text("AFTER\n", encoding="utf-8")
+
+    corpus = harness._files_corpus([tmp_path], before)
+    assert "NEW" in corpus, "a file the session created belongs in the corpus"
+    assert "AFTER" in corpus, "a file the session rewrote belongs in the corpus"
+    assert "pull_request_target" not in corpus, (
+        "the untouched fixture is what the agent was handed, not what it produced")
+
+
+def test_the_files_corpus_names_each_file_relative_to_its_root(tmp_path):
+    """The corpus carries path headers so a grader can anchor on the file a
+    finding landed in. They must be the paths the run used, not the harness's
+    temp directory, which changes every run."""
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "ci-secure-report-abc.md").write_text("x\n", encoding="utf-8")
+    corpus = harness._files_corpus([tmp_path], {})
+    assert "sub/ci-secure-report-abc.md" in corpus
+    assert str(tmp_path) not in corpus
+
+
+def test_the_agent_writes_its_report_where_the_harness_can_read_it(tmp_path):
+    """SKILL.md line 194 renders to `${TMPDIR:-/tmp}/ci-secure-report-<slug>.md`.
+    Pointing TMPDIR at a directory the harness owns is what makes collecting the
+    report a contract rather than a guess at where it landed."""
+    env = harness._env(tmp_path)
+    assert env["TMPDIR"] == str(tmp_path)
+
+
+def test_skill_md_still_renders_its_report_under_tmpdir():
+    """The other half of that contract, and the half that can rot silently.
+
+    Collecting the report works only because SKILL.md keys its output paths to
+    `${TMPDIR:-/tmp}`. If that ever becomes a fixed `/tmp` or a path under the
+    repository, the harness would go on collecting an empty directory — and an
+    empty corpus fails every `files` grader as though the skill had regressed.
+    """
+    skill = (harness._SKILL / "SKILL.md").read_text(encoding="utf-8")
+    for artifact in ("ci-secure-findings-", "ci-secure-report-"):
+        assert f'"${{TMPDIR:-/tmp}}/{artifact}' in skill, (
+            f"SKILL.md no longer writes {artifact}* under TMPDIR; the eval "
+            "harness collects the session's output from there")
+
+
+def test_the_report_the_engine_renders_satisfies_the_graders_anchored_on_it(tmp_path):
+    """End to end over everything but the model.
+
+    Scaffold a real fixture, run the real engine the way SKILL.md tells the
+    agent to — output under TMPDIR — and check that the corpus the harness
+    would build satisfies the case's own `files` grader. This is what failed in
+    CI: the assertion was true of the run's output the whole time, and the
+    harness was reading somewhere else.
+    """
+    import subprocess as sp
+    import yaml
+
+    case = harness._EVALS / "pwn-request"
+    sandbox, artifacts = tmp_path / "repo", tmp_path / "out"
+    sandbox.mkdir()
+    artifacts.mkdir()
+    harness._scaffold(case, sandbox)
+    before = harness._snapshot([sandbox, artifacts])
+
+    scripts = harness._SKILL / "scripts"
+    findings = artifacts / "ci-secure-findings-deadbeef.json"
+    r = sp.run([sys.executable, str(scripts / "scan.py"), "--root", str(sandbox),
+                "--gh-impostor", "off"], capture_output=True, text=True,
+               env=harness._env(artifacts))
+    assert r.returncode == 0, r.stderr[-400:]
+    findings.write_text(r.stdout, encoding="utf-8")
+    r = sp.run([sys.executable, str(scripts / "report.py"), "--in", str(findings),
+                "--out", str(artifacts / "ci-secure-report-deadbeef.md")],
+               capture_output=True, text=True, env=harness._env(artifacts))
+    assert r.returncode == 0, r.stderr[-400:]
+
+    corpus = harness._files_corpus([sandbox, artifacts], before)
+    spec = yaml.safe_load((case / "case.yaml").read_text(encoding="utf-8"))
+    graders = [g for g in spec["graders"]
+               if g.get("type") == "regex" and g.get("target") == "files"]
+    assert graders, "pwn-request no longer has a files-targeted grader to check"
+    scored, _ = harness._grade(graders, "", [], files=corpus)
+    for name, passed, detail in scored:
+        assert passed, f"{name} does not match the report the engine renders ({detail})"
+
+    # The fixture FILES stay out. Their content still appears, quoted back by
+    # the engine's own evidence lines — that is the scanner's output, which is
+    # exactly what the corpus is for, and it is why the exclusion is checked on
+    # the corpus's file headers rather than on the text.
+    assert "=== .github/workflows/vulnerable.yml ===" not in corpus, (
+        "the fixture the agent was handed must not enter the graded corpus")
+    assert "=== ci-secure-report-deadbeef.md ===" in corpus

--- a/maintainers/ci-secure/tests/test_run_skill_evals.py
+++ b/maintainers/ci-secure/tests/test_run_skill_evals.py
@@ -39,6 +39,8 @@ def _completed(returncode=0, stdout="", stderr=""):
 
 _GOOD_STREAM = (
     '{"type":"system","subtype":"init","session_id":"s"}\n'
+    '{"type":"assistant","message":{"content":['
+    '{"type":"tool_use","name":"Bash","input":{"command":"ls"}}]}}\n'
     '{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}\n'
 )
 
@@ -67,6 +69,22 @@ def test_an_empty_stream_from_a_zero_exit_is_still_a_harness_failure(monkeypatch
         harness._run_agent("prompt", tmp_path, tmp_path, 60, 900)
     assert exc.value.code == 2
     assert "no session" in capsys.readouterr().err.lower()
+
+
+def test_a_completed_session_that_called_no_tool_is_a_harness_failure(monkeypatch, capsys, tmp_path):
+    """Every case drives the agent to read files and run the scanner. Zero tool
+    calls in a completed run is the signature of a session that ended before it
+    started — an authentication rejection, say — and grading it scores every
+    negative grader as a pass."""
+    stream = ('{"type":"system","subtype":"init","session_id":"s"}\n'
+              '{"type":"result","subtype":"success","is_error":false}\n')
+    monkeypatch.setattr(harness.subprocess, "run", lambda *a, **k: _completed(
+        stdout=stream, stderr="Invalid API key · Fix external API key"))
+    with pytest.raises(SystemExit) as exc:
+        harness._run_agent("prompt", tmp_path, tmp_path, 60, 900)
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "Invalid API key" in err, "claude's own words must reach the log"
 
 
 def test_a_real_stream_is_returned_unchanged(monkeypatch, tmp_path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,5 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["tests", "skills/ci-speedup/tests", "maintainers/ci-speedup/tests", "skills/ci-score/tests", "skills/ci-secure/tests", "maintainers/skills-registry-security/tests"]
+testpaths = ["tests", "skills/ci-speedup/tests", "maintainers/ci-speedup/tests", "skills/ci-score/tests", "skills/ci-secure/tests", "maintainers/ci-secure/tests", "maintainers/skills-registry-security/tests"]
 pythonpath = [".", "skills/ci-speedup/scripts", "maintainers/ci-speedup/scripts", "skills/ci-score/scripts", "skills/ci-secure/scripts", "maintainers/skills-registry-security/scripts"]

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -13,6 +13,21 @@ entries are dated (UTC). Format loosely follows
 
 ### Fixed
 
+- **2026-08-18** — **A grader that pins a finding to its real file and line is
+  read against the report, not against whatever the session happened to print.**
+  Three graders are anchored on `report.py`'s `<file>:<line> — jobs:` evidence
+  bullet, deliberately: a model can paraphrase its summary a dozen ways, but
+  that bullet is byte-identical every run. The skill renders it into a report
+  file and prints a summary, and the harness graded only the transcript — so
+  `pwn-request` and `impostor-check-skipped` failed on runs where the scan had
+  found the right thing, at the right line, and written exactly the asserted
+  text, while `template-injection` passed on the same pattern only because that
+  session happened to run `grep -n`. Those three now declare `target: files`,
+  and the harness collects what the session wrote off disk alongside the
+  transcript, keeping the two corpora separate. The vacuity rule extends to
+  `files` graders, because `report.py` inlines catalog prose into the report it
+  renders.
+
 - **2026-08-18** — **The behavioral eval cases are executed, and a session that
   never started no longer reads as a skill regression.** The five cases in
   `evals/` were written for `claude plugin eval`, which is gated behind early

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -13,6 +13,19 @@ entries are dated (UTC). Format loosely follows
 
 ### Fixed
 
+- **2026-08-18** — **The behavioral eval cases are executed, and a session that
+  never started no longer reads as a skill regression.** The five cases in
+  `evals/` were written for `claude plugin eval`, which is gated behind early
+  access, so nothing ran them and `evals/README.md` opened by saying so. They
+  now run on every pull request that touches this skill's contract, driven by a
+  maintainer-side harness. The README records what that harness does *not* do —
+  `llm` graders are reported rather than scored, and the cases' `allowed_tools`,
+  ablation arm, model pin and run count are not yet applied — so a pass under it
+  is not quoted as a pass under the runner the cases were written for. The
+  harness mounts a copy of the skill with `evals/` and `tests/` removed, closing
+  the free-pass half of the answer-key risk the vacuity rule documents: a graded
+  session can no longer read the expected strings out of the case files.
+
 - **2026-08-17** — **A partial checkout no longer reports as complete
   coverage.** Every detector reasons about the files it can see on disk, so a
   `git sparse-checkout`, a partial clone, or a locally-deleted workflow was

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -11,7 +11,55 @@ entries are dated (UTC). Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- **2026-08-18** — **The behavioral eval cases are executed, and a session that
+  never started no longer reads as a skill regression.** The five cases in
+  `evals/` were written for `claude plugin eval`, which is gated behind early
+  access, so nothing ran them and `evals/README.md` opened by saying so. They
+  now run on every pull request that touches this skill's contract, driven by a
+  maintainer-side harness. The README records what that harness does *not* do —
+  `llm` graders are reported rather than scored, and the cases' `allowed_tools`,
+  ablation arm, model pin and run count are not yet applied — so a pass under it
+  is not quoted as a pass under the runner the cases were written for. The
+  harness mounts a copy of the skill with the answer key removed, which closes
+  the free-pass half of the risk the vacuity rule documents *for that harness*;
+  under `claude plugin eval` the case files still ship and the residual stands.
+
 ### Fixed
+
+- **2026-08-18** — **A case no longer fails because the agent read the file it
+  was asked to clear.** `pwn-request` asserts that no finding is attributed to
+  the clean workflow, and it looked for that attribution in the transcript —
+  which carries the output of every tool the session ran, not just the agent's
+  own words. The clean fixture's line 7 is the literal YAML key `jobs:`, so a
+  `grep -n` over the workflows printed the file, the line and the key on one
+  line and satisfied the pattern. A session that inspected the clean file
+  carefully — which the sibling grader rewards — was scored as having reported
+  a false finding. That grader now reads the rendered report, where no
+  `path:line:` prefix can occur, and a new invariant holds every
+  transcript-targeted negative to the same rule.
+
+- **2026-08-18** — **Counting graders count in the corpus they name.** The
+  `count:` match mode read the transcript whichever corpus its `target`
+  selected — the same wrong-corpus defect fixed for `contains`, surviving in
+  the branch beside it. No case uses `count:` today, so nothing was misreported;
+  the next one written against the report would have been.
+
+- **2026-08-18** — **A report the harness could not collect is reported as a
+  collection failure, not as a skill regression.** The guard for this only
+  fired when the session produced no file at all, and a session leaves scratch
+  files — so a missing report with any other file beside it failed every
+  report-anchored grader as though the scan had misbehaved. The guard now asks
+  for the report itself.
+
+- **2026-08-18** — **The skill's own changelog is no longer readable by a
+  graded session.** The harness mounts the skill for the agent under test and
+  withheld `evals/` and `tests/` as the answer key, but the changelog narrates
+  the graders and quotes their expected banner strings verbatim — so one read
+  of it satisfied a grader with no scan behind it. It is withheld too, and the
+  rule is now stated as a property (no mounted file may satisfy a grader)
+  rather than as a list of names.
 
 - **2026-08-18** — **A grader that pins a finding to its real file and line is
   read against the report, not against whatever the session happened to print.**
@@ -27,19 +75,6 @@ entries are dated (UTC). Format loosely follows
   transcript, keeping the two corpora separate. The vacuity rule extends to
   `files` graders, because `report.py` inlines catalog prose into the report it
   renders.
-
-- **2026-08-18** — **The behavioral eval cases are executed, and a session that
-  never started no longer reads as a skill regression.** The five cases in
-  `evals/` were written for `claude plugin eval`, which is gated behind early
-  access, so nothing ran them and `evals/README.md` opened by saying so. They
-  now run on every pull request that touches this skill's contract, driven by a
-  maintainer-side harness. The README records what that harness does *not* do —
-  `llm` graders are reported rather than scored, and the cases' `allowed_tools`,
-  ablation arm, model pin and run count are not yet applied — so a pass under it
-  is not quoted as a pass under the runner the cases were written for. The
-  harness mounts a copy of the skill with `evals/` and `tests/` removed, closing
-  the free-pass half of the answer-key risk the vacuity rule documents: a graded
-  session can no longer read the expected strings out of the case files.
 
 - **2026-08-17** — **A partial checkout no longer reports as complete
   coverage.** Every detector reasons about the files it can see on disk, so a

--- a/skills/ci-secure/evals/README.md
+++ b/skills/ci-secure/evals/README.md
@@ -173,17 +173,28 @@ of the corpus on purpose, and a third with a caveat — all documented at
 renderer's exact output by construction; `evals/files/`, which *is* the input
 under audit, so a grader pinning a finding to its real `file:line` has to quote
 it; and the `case.yaml` files themselves, since every pattern is a literal in
-its own case file and including them would flag all fourteen trace regexes
-against themselves.
+its own case file and including them would flag all fifteen regexes against
+themselves.
 
 That third exclusion carries real residual risk, because `evals/` ships: an
 agent that greps the eval directory sees the answer key. The *fatal* half of it
 is covered unconditionally by a separate test — a `not_contains` pattern that
 matches its own declaration can never pass, and that is a silent failure, so
 `test_negative_regexes_do_not_match_the_case_file_that_declares_them` forbids
-it outright. The free-pass half is accepted and named here rather than papered
-over; the honest fix is to stop shipping `evals/` to end users at all, which is
-a larger change than this suite.
+it outright.
+
+The free-pass half now depends on **which runner you are on**, and the
+difference is worth stating precisely:
+
+- under `maintainers/ci-secure/scripts/run_skill_evals.py`, it is closed. The
+  harness mounts a copy of the skill with `evals/` and `tests/` removed, so
+  there is no answer key on disk for the session to grep;
+- under `claude plugin eval`, it is open and accepted rather than papered over.
+  The honest fix is to stop shipping `evals/` to end users at all, which is a
+  larger change than this suite.
+
+So the exclusion is still correct — it protects the gated runner, and it costs
+nothing on the harness.
 
 One consequence is worth stating plainly rather than leaving to be discovered.
 A pattern that is a plain literal — the banner-count graders are — necessarily
@@ -219,9 +230,10 @@ Verified, and re-checkable with `python3 -m pytest skills/ci-secure/tests/test_e
   `target`/`focus`, JavaScript-legal regex flags, patterns that compile,
   `min`/`max` pairs that are satisfiable;
 - no grader relies on a known trap (unscored `Skill` grader, unsatisfiable
-  `max: 0`, vacuous trace regex, untargeted regex, a count that matches inside a
-  larger number, a negative that matches its own declaration, an
-  ungrantable `allowed_tools` entry);
+  `max: 0`, a vacuous regex on either corpus, untargeted regex, a count that
+  matches inside a larger number, a negative that matches its own declaration,
+  a trace-targeted negative that `grep`'s own `path:line:text` output over the
+  fixtures would trip, an ungrantable `allowed_tools` entry);
 - every case carries at least one grader that a *completed* engine run
   satisfies and a failed one does not — matching `run.py`'s or `report.py`'s
   real output on that fixture while matching neither the skill's shipped text
@@ -254,9 +266,17 @@ confirmed to load as a plugin (`--plugin-dir skills/ci-secure` exposes
 line numbers, banner text, group-list ordering, `gh_checks` strings — was read
 off a real run of `run.py` and `report.py` against these fixtures, not assumed.
 
-**Not verified, because the runner is gated:**
+**Still not verified, because `claude plugin eval` itself is gated.** The list
+below was written when nothing ran at all. The harness above has since closed
+the first item and turned three others from predictions into observations
+(struck through, with what was seen); the rest stand, and every one of them
+stands *under the harness too* — a green run here is not evidence about any of
+them.
 
-- that any case scores anything at all — no case has been executed;
+- ~~that any case scores anything at all~~ — **all five now execute on every
+  pull request** that touches this skill's contract. What no run can establish
+  is the rest of this list, or anything the harness does not apply: `llm`
+  graders, `allowed_tools`, the ablation arm, `model`, and `runs: 3`;
 - **that the scanner exited successfully, as opposed to having been invoked and
   then described.** No grader type in this harness observes a tool's exit
   status or its output: `tool_used` matches the invocation's *input*, and
@@ -291,6 +311,17 @@ off a real run of `run.py` and `report.py` against these fixtures, not assumed.
   reads what the session wrote off disk rather than only what it printed. What
   remains unobserved is narrower: whether the `trace`-targeted graders that
   quote the terminal banner keep landing there across runs;
+- ~~whether a `trace`-targeted negative can be tripped by the agent's own tool
+  output~~ — **yes, and one was.** `_transcript` folds in the output of every
+  tool the agent ran, so `pwn-request`'s `safe-workflow-produces-no-finding`
+  (shaped `<file>:<line>…jobs`) was matched by `grep`'s `<path>:<line>:<text>`
+  rendering of the clean fixture, whose line 7 is the YAML key `jobs:`. Reading
+  the file under audit is correct behaviour — and the sibling `llm` grader
+  rewards it — so the case failed good sessions in proportion to how carefully
+  they worked. That grader now says `target: files`, where no `<path>:<line>:`
+  prefix can arise, and
+  `tests/test_evals_cases.py::test_negative_trace_regexes_do_not_match_grep_output_over_the_fixtures`
+  holds every trace-targeted negative to the rule;
 - whether the `llm` graders' rubrics discriminate in practice, and whether they
   also pass in the no-plugin arm. All seven are `focus: trace` and none is
   covered by the vacuity rule, which filters on `type == "regex"` — they are 7

--- a/skills/ci-secure/evals/README.md
+++ b/skills/ci-secure/evals/README.md
@@ -6,17 +6,37 @@ agent-facing contract in `SKILL.md`, which no other test in this repository
 covers: `pytest` exercises the deterministic scanner underneath the skill, not
 the behavior the skill promises on top of it.
 
-> ## This suite has never been executed
+> ## These cases run, on a harness that is not `claude plugin eval`
 >
 > `claude plugin eval` is in early access and is not enabled on the machine
 > these cases were written on — it prints ``` `plugin eval` is currently in
-> early access ``` and exits before running anything. **No case here has ever
-> produced a score.** Treat the suite as an unvalidated first draft, not as a
-> gate that is passing. What has and has not been checked is spelled out under
-> [What is verified](#what-is-verified) below; read it before quoting a result
-> from this directory.
+> early access ``` and exits before running anything. So the cases are executed
+> instead by `maintainers/ci-secure/scripts/run_skill_evals.py`, which scaffolds
+> each case, drives one headless `claude -p` session against it, and applies
+> that case's own mechanical graders. `.github/workflows/skill-evals.yml` runs
+> it on every pull request that touches this skill's contract.
+>
+> **That harness is narrower than the runner these cases were written for.** It
+> does not score `llm` graders, does not apply `execution.allowed_tools`, does
+> not run the no-plugin ablation arm, and does not honour `execution.model` or
+> the `runs: 3` each case declares. A pass under it is weaker than a pass under
+> `claude plugin eval` — read the harness's own docstring for the current list
+> before quoting a result from this directory.
 
 ## Running them
+
+```bash
+# from the repository root — the harness that actually runs today
+python3 maintainers/ci-secure/scripts/run_skill_evals.py --case clean-repo
+```
+
+Exit 0 means every scored grader passed; 1 means a case ran and failed one; 2
+means the harness could not run at all, which is never a pass.
+
+### The runner these cases were written for
+
+Once `claude plugin eval` is enabled, this is the invocation the case files are
+shaped around:
 
 ```bash
 # from the repository root

--- a/skills/ci-secure/evals/README.md
+++ b/skills/ci-secure/evals/README.md
@@ -151,6 +151,12 @@ already appears there passes for free, and a `not_contains` pattern that appears
 there can never pass at all. `tests/test_evals_cases.py::test_no_trace_regex_matches_the_skills_own_prose`
 makes that a hard failure.
 
+`files` graders are held to the same rule, for a reason that is easy to miss:
+`report.py` **inlines catalog text** into the report it renders, so the skill's
+own shipped prose is inside the file corpus too. A `files` pattern quoting the
+catalog would pass on the report having been rendered at all, whatever the scan
+found.
+
 It is not a theoretical concern. Three of the first drafts of these graders
 (`P14.10`, `did NOT run`, `Impostor-SHA check (P14.11): ran`) are quotations
 from `SKILL.md` and were flagged by that test; a fourth (`No critical attack
@@ -275,10 +281,16 @@ off a real run of `run.py` and `report.py` against these fixtures, not assumed.
   grants `Write` or `Edit`, and Phase 5 subagents edit workflow YAML. No grader
   asserts it, so it would fail as a stated-but-unreachable outcome rather than
   as a red case;
-- whether the graders' assertions actually land in the `trace`. Several depend
-  on contract-mandated `grep`/`python3` calls surfacing report content into the
-  transcript; that is what `SKILL.md` says happens, but it has not been observed
-  here;
+- ~~whether the graders' assertions actually land in the `trace`~~ — **observed,
+  and they did not.** Three graders anchored on `report.py`'s `<file>:<line> —
+  jobs:` evidence bullet assumed the agent would surface the report into the
+  transcript. It renders the report to a file and prints a summary instead, so
+  two cases failed on runs where the skill had behaved correctly and written
+  exactly the asserted bullet, and the third passed only because that session
+  happened to `grep -n`. Those three now say `target: files`, and the harness
+  reads what the session wrote off disk rather than only what it printed. What
+  remains unobserved is narrower: whether the `trace`-targeted graders that
+  quote the terminal banner keep landing there across runs;
 - whether the `llm` graders' rubrics discriminate in practice, and whether they
   also pass in the no-plugin arm. All seven are `focus: trace` and none is
   covered by the vacuity rule, which filters on `type == "regex"` — they are 7

--- a/skills/ci-secure/evals/impostor-check-skipped/case.yaml
+++ b/skills/ci-secure/evals/impostor-check-skipped/case.yaml
@@ -50,9 +50,14 @@ graders:
   # "The scan completes without gh": the nine static vectors need no network, so
   # the template injection in this fixture must still be found, at its real
   # file and line. A degraded run that quietly produced nothing would fail here.
+  #
+  # `files`: report.py renders `ci.yml:11` into the report, and the skill's
+  # terminal summary carries the file without the line. Against the transcript
+  # this passed only when the agent happened to `grep -n` -- luck on a correct
+  # run, and it came up tails.
   - type: regex
     name: static-scan-still-completed-and-found-the-injection
-    target: trace
+    target: files
     pattern: 'ci\.yml[^\n]{0,30}?\b11\b'
     match: contains
 

--- a/skills/ci-secure/evals/pwn-request/case.yaml
+++ b/skills/ci-secure/evals/pwn-request/case.yaml
@@ -61,9 +61,14 @@ graders:
   # entirely would still have passed. The occurrence LINES are what only the
   # engine knows: P14.9 at :8 and P14.25 at :14, each rendered by report.py with
   # the job list after it.
+  #
+  # `files`, not `trace`, because that bullet is rendered INTO the report file
+  # and the skill prints a summary rather than the evidence section. Graded
+  # against the transcript this asserted that the agent happened to `cat` its
+  # own report, and it failed a run where the report said exactly this.
   - type: regex
     name: finding-lands-on-the-vulnerable-workflow
-    target: trace
+    target: files
     pattern: 'vulnerable\.yml:(?:8|14)\b[^\n]{0,20}jobs'
     match: contains
 
@@ -76,6 +81,12 @@ graders:
   # and this case's sibling llm grader actively rewards the agent for showing it
   # inspected safe.yml -- so the two graders pulled against each other and a
   # correct run could fail this one on a `grep -n` it was praised for.
+  #
+  # Deliberately still `trace` while its positive twin above moved to `files`.
+  # The two halves guard different things: the positive asks what the RENDERER
+  # attributed, which only the report holds, while a false clean-file finding
+  # reaching the user is something the agent SAYS. Moving this one too would
+  # stop covering the summary the reader actually gets.
   - type: regex
     name: safe-workflow-produces-no-finding
     target: trace

--- a/skills/ci-secure/evals/pwn-request/case.yaml
+++ b/skills/ci-secure/evals/pwn-request/case.yaml
@@ -76,20 +76,34 @@ graders:
   # skill reports is rendered as `<workflow file>:<line> — jobs: ...`, so this
   # means a finding was attributed to the file that is supposed to be clean.
   #
-  # The `jobs` tail is load-bearing rather than decoration. A bare
-  # `safe\.yml:\d+` also matches the Grep tool's own `path:line:text` output,
-  # and this case's sibling llm grader actively rewards the agent for showing it
-  # inspected safe.yml -- so the two graders pulled against each other and a
-  # correct run could fail this one on a `grep -n` it was praised for.
+  # `files`, like its positive twin, and for a sharper reason than symmetry.
   #
-  # Deliberately still `trace` while its positive twin above moved to `files`.
-  # The two halves guard different things: the positive asks what the RENDERER
-  # attributed, which only the report holds, while a false clean-file finding
-  # reaching the user is something the agent SAYS. Moving this one too would
-  # stop covering the summary the reader actually gets.
+  # The `jobs` tail was added here to keep a bare `safe\.yml:\d+` off the Grep
+  # tool's own `path:line:text` output, because this case's sibling llm grader
+  # actively rewards the agent for showing it inspected safe.yml. The tail does
+  # not do that job: the clean fixture's line 7 IS the literal YAML key `jobs:`,
+  # so `grep -n jobs .github/workflows/*.yml` prints that filename, that line
+  # number and that key on a single line -- and this pattern matched it.
+  # Against `trace` -- which folds in tool output -- the grader therefore failed
+  # correct sessions for reading the file they were asked to clear.
+  #
+  # The literal grep line is deliberately not written out here: a `not_contains`
+  # pattern that matches its own case file can never pass once anything greps
+  # `evals/`, which the sibling test above pins.
+  #
+  # Against `files` it cannot: that corpus introduces each file the session
+  # WROTE as `=== <path> ===` plus its raw bytes, so no `<path>:<line>:` prefix
+  # arises, and the fixture the agent was handed is excluded from it outright.
+  # What is left is exactly the question worth asking -- did the RENDERER
+  # attribute an occurrence to the file that is supposed to be clean. The
+  # summary the reader gets is still covered, by the llm grader below.
+  #
+  # `skills/ci-secure/tests/test_evals_cases.py::
+  # test_negative_trace_regexes_do_not_match_grep_output_over_the_fixtures`
+  # holds every trace-targeted negative to this rule now.
   - type: regex
     name: safe-workflow-produces-no-finding
-    target: trace
+    target: files
     pattern: 'safe\.yml:\d+[^\n]{0,20}jobs'
     match: not_contains
 

--- a/skills/ci-secure/evals/template-injection/case.yaml
+++ b/skills/ci-secure/evals/template-injection/case.yaml
@@ -60,16 +60,22 @@ graders:
   # -- outcome ---------------------------------------------------------------
   - type: regex
     name: injection-reported-at-its-real-file-and-line
-    target: trace
+    target: files
     # Ground truth, re-derived from the engine while authoring this case.
-    # Tolerant of the report's own `<file>:<line>` rendering and of prose alike,
-    # because the contract fixes the fact and not the phrasing.
+    # Anchored on the report's own `<file>:<line>` rendering.
     #
     # This one is falsifiable but carries NO ablation signal, and the grader
     # below is why it is not left to stand alone: the occurrence sits on the
     # last line of a very short fixture, so a `grep -n` over the workflow prints
     # the same file and line, and an agent with no skill loaded, eyeballing the
     # YAML, matches it too.
+    #
+    # `files` rather than `trace` for exactly that reason. The skill renders
+    # this into the report and prints a summary that carries the file without
+    # the line, so on the transcript the grader passed or failed on whether the
+    # agent happened to `grep -n` -- it scored the tool the agent reached for,
+    # not the finding. Its sibling in impostor-check-skipped, the same pattern
+    # on the same fixture, came up tails and failed a correct run.
     pattern: 'ci\.yml[^\n]{0,30}?\b11\b'
     match: contains
 

--- a/skills/ci-secure/tests/test_evals_cases.py
+++ b/skills/ci-secure/tests/test_evals_cases.py
@@ -15,8 +15,10 @@ transcript of a run WITH the skill loaded contains the text of ``SKILL.md`` and
 of any reference file the agent opened. So a ``contains`` pattern that already
 appears in the skill's own prose passes without the skill ever having done
 anything, and a ``not_contains`` pattern that appears there can never pass at
-all. Both directions collapse to one rule: a trace-targeted regex must not match
-the skill's shipped text. This is not hypothetical -- natural choices for these
+all. Both directions collapse to one rule: the regex must not match the skill's
+shipped text. It binds ``files``-targeted graders too, because ``report.py``
+inlines catalog prose into the report it renders, so shipped text reaches that
+corpus as well. This is not hypothetical -- natural choices for these
 graders (``P14.10``, ``did NOT run``, ``Impostor-SHA check (P14.11): ran``) are
 quotations from ``SKILL.md``, and each was replaced with a scanner- or
 renderer-produced string after this test flagged it.
@@ -25,6 +27,15 @@ The corpus the rule reads is defined by ``_agent_readable_sources()`` and is
 deliberately wider than the prose files -- ``scripts/*.py`` ships too, and a
 ``not_contains`` grader anchored on a literal in ``scan.py`` is the silent,
 never-passing direction of the same trap.
+
+A third face of the trap has its own test
+(``test_negative_trace_regexes_do_not_match_grep_output_over_the_fixtures``) and
+is the nastiest, because it fires on a run that did everything right: the
+transcript carries the output of every TOOL the agent ran, so a trace-targeted
+``not_contains`` shaped like ``<file>:<line>...<word>`` is matched by ``grep``'s
+own ``<path>:<line>:<text>`` rendering of the fixture the agent was told to
+audit. The more carefully a session inspects the file it is supposed to clear,
+the likelier it fails.
 
 Patterns are compiled with Python's ``re`` while the harness uses JavaScript's
 ``RegExp``. The suite deliberately stays inside the syntax both accept
@@ -592,6 +603,76 @@ def test_negative_regexes_do_not_match_the_case_file_that_declares_them(
             f"{case_dir.name}/case.yaml, which ships inside the skill. One Grep "
             "of the eval directory makes it unpassable on a run that behaved "
             "perfectly -- and a not_contains that can never pass fails silently")
+
+
+def _grep_shaped_fixture_output(case_dir: Path) -> str:
+    """The fixture workflows re-rendered the way a `grep -n` prints them.
+
+    ``grep`` writes one line per hit as ``<path>:<line>:<text>``, and the agent
+    reaches the fixtures at two paths depending on where it runs: bare
+    bare from inside the workflows directory and prefixed with
+    ``.github/workflows/`` from the repository root. Both are rendered, because
+    a pattern can be safe against one and not the other.
+
+    Deliberately NARROWER than the reachable-text corpus in
+    ``test_every_case_anchors_on_output_the_agent_could_not_have_written``,
+    which serves the opposite direction (disqualifying weak POSITIVE anchors)
+    and so casts the widest net it can, including a ``<path>:<line> <text>``
+    variant. Only grep's true ``<path>:<line>:<text>`` shape belongs here: it is
+    a shape tools emit and ``report.py`` never does, which is what makes a match
+    proof of contamination rather than of a real finding. Widening this one
+    would forbid negatives that legitimately quote the renderer.
+    """
+    case = _load(case_dir)
+    script = case_dir / (case.get("context") or {}).get("scaffold_script", "")
+    slugs = re.findall(r"^FIXTURE_SLUG=(\S+)", script.read_text(encoding="utf-8"),
+                       flags=re.M)
+    workflows = _EVALS / "files" / slugs[0] / "dot-github" / "workflows"
+    lines = []
+    for fixture in sorted(workflows.glob("*.yml.fixture")):
+        name = fixture.name[: -len(".fixture")]
+        for n, text in enumerate(fixture.read_text(encoding="utf-8").splitlines(), 1):
+            lines.append(f"{name}:{n}:{text}")
+            lines.append(f".github/workflows/{name}:{n}:{text}")
+    return "\n".join(lines)
+
+
+@pytest.mark.parametrize("case_dir", _case_dirs(), ids=lambda p: p.name)
+def test_negative_trace_regexes_do_not_match_grep_output_over_the_fixtures(
+    case_dir: Path,
+) -> None:
+    """The third face of the vacuity trap, and the one that fires on a GOOD run.
+
+    A ``trace``-targeted grader reads ``_transcript``, which folds in the output
+    of every tool the agent ran -- not just the agent's own prose. So a
+    ``not_contains`` pattern shaped like ``<file>:<line>...<word>`` is matched by
+    ``grep``'s own ``<path>:<line>:<text>`` rendering of the fixture the agent
+    was told to audit. The case then reports a behavioural regression for a
+    session that did exactly the right thing, and the harder the agent looks at
+    the file it is supposed to clear, the likelier it fails.
+
+    This is not hypothetical: ``pwn-request``'s clean fixture has the literal
+    YAML key ``jobs:`` on line 7, so ``grep -n jobs .github/workflows/*.yml`` --
+    which that case's sibling llm grader actively rewards the agent for running
+    -- emits ``safe.yml:7:jobs:``.
+
+    Only ``trace`` is held to this rule. The ``files`` corpus introduces each
+    file as ``=== <path> ===`` followed by its raw bytes, so a ``<path>:<line>:``
+    sequence cannot arise there.
+    """
+    grep_output = _grep_shaped_fixture_output(case_dir)
+    for grader in _graders(_load(case_dir)):
+        if (grader.get("type") != "regex"
+                or grader.get("match") != "not_contains"
+                or grader.get("target") != "trace"):
+            continue
+        hit = re.search(grader["pattern"], grep_output)
+        assert not hit, (
+            f"not_contains grader {grader.get('name')!r} matches {hit.group(0)!r} "
+            "-- which is what `grep -n` prints for this case's own fixture, not "
+            "anything the skill reported. Reading the file under audit is "
+            "correct behaviour, so this grader fails correct runs. Anchor it on "
+            "the renderer's shape, or move it to `target: files`")
 
 
 @pytest.mark.parametrize("case_dir", _case_dirs(), ids=lambda p: p.name)

--- a/skills/ci-secure/tests/test_evals_cases.py
+++ b/skills/ci-secure/tests/test_evals_cases.py
@@ -322,7 +322,7 @@ def test_the_agent_readable_corpus_spans_more_than_the_prose_files() -> None:
     for literal, why in (
         ("ran: no sha-pinned actions found", "scripts/scan.py"),
         ("Critical exploit-chain checks only", "scripts/report.py"),
-        ("This suite has never been executed", "evals/README.md"),
+        ("These cases run, on a harness that is not", "evals/README.md"),
     ):
         assert literal in corpus, (
             f"the agent-readable corpus no longer reaches {why} -- the vacuity "

--- a/skills/ci-secure/tests/test_evals_cases.py
+++ b/skills/ci-secure/tests/test_evals_cases.py
@@ -335,19 +335,26 @@ def test_no_trace_regex_matches_the_skills_own_prose() -> None:
     so a trace-targeted pattern that matches the skill's own prose asserts
     nothing about behavior: ``contains`` passes for free, ``not_contains`` can
     never pass. Both are silent failures of the suite, which is why this is a
-    test and not a review note."""
+    test and not a review note.
+
+    ``files``-targeted regexes are held to the same rule, and for a reason that
+    is easy to miss: ``report.py`` INLINES catalog text into the report it
+    renders, so the skill's own shipped prose is inside the file corpus too. A
+    ``files`` pattern quoting the catalog would pass on the report having been
+    rendered at all, never mind what the scan found."""
     prose = _agent_readable_text()
     offenders = []
     for case_dir, case in _all_cases():
         for grader in _graders(case):
-            if grader.get("type") != "regex" or grader.get("target") != "trace":
+            if (grader.get("type") != "regex"
+                    or grader.get("target") not in {"trace", "files"}):
                 continue
             pattern = grader["pattern"]
             if re.search(pattern, prose):
                 offenders.append(f"{case_dir.name}/{grader['name']}: {pattern!r}")
     assert not offenders, (
-        "these trace regexes match the skill's own shipped prose, so they grade "
-        "the agent having READ the skill rather than the agent having RUN it -- "
+        "these regexes match the skill's own shipped prose, so they grade the "
+        "agent having READ the skill rather than the agent having RUN it -- "
         "re-anchor each on a string only the scanner or the renderer produces:\n  "
         + "\n  ".join(offenders))
 
@@ -525,9 +532,9 @@ def test_scaffold_still_materializes_the_tree_in_an_empty_sandbox(
 @pytest.mark.parametrize("case_dir", _case_dirs(), ids=lambda p: p.name)
 def test_regex_graders_declare_a_target(case_dir: Path) -> None:
     """``target`` is optional in the harness's schema, and the vacuity rule only
-    inspects graders whose target is ``trace``. So omitting the line is a
-    one-token bypass of the rule: a verbatim ``SKILL.md`` quotation with no
-    ``target:`` passes every test in this file. Requiring it here closes that."""
+    inspects graders that name one. So omitting the line is a one-token bypass
+    of the rule: a verbatim ``SKILL.md`` quotation with no ``target:`` passes
+    every test in this file. Requiring it here closes that."""
     for grader in _graders(_load(case_dir)):
         if grader.get("type") != "regex":
             continue

--- a/tests/test_ci_secure_install_surface.py
+++ b/tests/test_ci_secure_install_surface.py
@@ -53,6 +53,10 @@ _FORBIDDEN_FILE_NAMES = {
     "loop-summary.schema.json",
     "draft_detector.py",
     "aggregate_lessons.py",
+    # The behavioral-eval harness. It drives a real, billed agent session per
+    # case, so it must never reach an end user's install and must never be
+    # collected by the ordinary `pytest` run.
+    "run_skill_evals.py",
 }
 
 # Directory names that mark the same thing.

--- a/tests/test_ci_secure_install_surface.py
+++ b/tests/test_ci_secure_install_surface.py
@@ -8,13 +8,18 @@ no ``.skillignore`` / frontmatter allowlist / dotfile exclusion. So the ONLY way
 to keep maintainer-only files out of an end-user install is to keep them out of
 ``skills/ci-secure/`` entirely.
 
-This guard is FORWARD-LOOKING. ci-secure has no maintainer-loop tree in this
-repo today, so nothing here is currently leaking; the point is that the day one
-is added it lands under ``maintainers/ci-secure/`` and not under the skill. The
-leak shape to expect is ci-speedup's: self-improvement loop infra (loop prompts,
-a summary schema, drafting scripts) plus the runtime capture directories those
-loops write into, which on a maintainer's machine hold third-party job logs and
-session transcripts. Rooted under the skill, every one of them would ship.
+ci-secure now HAS a maintainer-only tree — ``maintainers/ci-secure/`` holds
+``MAINTAINERS.md`` plus the behavioral-eval harness (``scripts/run_skill_evals.py``
+and its tests), which drives real ``claude -p`` sessions and is of no use to
+someone who installed the skill. So this guard is no longer purely
+forward-looking: it pins where that tree lives, and ``run_skill_evals.py`` is a
+forbidden basename under ``skills/ci-secure/`` for exactly that reason.
+
+The leak shape still to expect is ci-speedup's: self-improvement loop infra
+(loop prompts, a summary schema, drafting scripts) plus the runtime capture
+directories those loops write into, which on a maintainer's machine hold
+third-party job logs and session transcripts. Rooted under the skill, every one
+of them would ship.
 
 Independent checks (each its own test function, so a broken assertion in one
 never silently disables the others), plus a positive control. Every other

--- a/tests/test_skill_evals_workflow.py
+++ b/tests/test_skill_evals_workflow.py
@@ -1,0 +1,155 @@
+"""The skill-evals gate cannot go green over a session that did not happen.
+
+This workflow exists to run ci-secure's behavioural cases against a live agent.
+Its entire value is that a green `skill evals` check means five real sessions ran
+and behaved. Every way that decays is invisible in the check list: a fork PR that
+reports green having reached no API key, a verdict job that exits 0 on a skip, a
+harness that could not start and is read as a behaviour change, a floating CLI
+version that turns an upstream release into a "skill regression".
+
+A text reading of the YAML cannot see an added permissive clause, so the verdict
+script is EXECUTED here over every result it can be handed — the same technique
+tests/test_ci_required_check_verdict.py uses on ci.yml. No network, no agent, no
+token: this is the offline guard on the gate that costs money to run.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+_REPO = Path(__file__).resolve().parents[1]
+_WORKFLOW = _REPO / ".github" / "workflows" / "skill-evals.yml"
+_EVALS = _REPO / "skills" / "ci-secure" / "evals"
+
+
+def _doc() -> dict:
+    return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _job(job_id: str) -> dict:
+    jobs = _doc()["jobs"]
+    assert job_id in jobs, f"job {job_id!r} is gone; found {sorted(jobs)}"
+    return jobs[job_id]
+
+
+def _squash(expr: object) -> str:
+    return re.sub(r"\s+", " ", str(expr)).strip()
+
+
+def test_the_verdict_never_reports_on_a_fork_pull_request():
+    """The bug this pins: the verdict used to `exit 0` on a fork PR, so an
+    external contribution got a green check named `skill evals` with no session
+    run at all — a `::warning::` annotation is not a check status."""
+    cond = _squash(_job("verdict").get("if", ""))
+    assert "always()" in cond, "a verdict that can be skipped can be bypassed"
+    assert "head.repo.full_name != github.repository" in cond, (
+        "the verdict must exclude fork PRs; a green 'skill evals' on a fork is "
+        "a pass over a session that could not happen")
+    assert cond.lstrip().startswith("always() &&"), (
+        "always() must gate the whole expression, or a cancelled evals job "
+        "reports the verdict as skipped, which GitHub reads as green")
+
+
+def test_the_fork_gap_is_carried_by_a_check_whose_name_says_so():
+    """registry-scan.yml's pattern: report the gap rather than blocking an
+    outside contributor, but name the check so green cannot be misread."""
+    fork = _job("fork-did-not-run")
+    name = str(fork.get("name", ""))
+    assert "NOT RUN" in name, (
+        f"the fork check's name is the message; got {name!r}")
+    assert "fork" in name.lower()
+
+
+def test_the_fork_and_verdict_conditions_are_exact_complements():
+    """Exactly one of the two reports on any event. Overlap prints a green
+    'skill evals' next to the NOT RUN notice; a gap prints neither."""
+    fork_clause = ("github.event_name == 'pull_request' && "
+                   "github.event.pull_request.head.repo.full_name != github.repository")
+    assert _squash(_job("fork-did-not-run")["if"]) == fork_clause
+    assert _squash(_job("verdict")["if"]) == f"always() && !({fork_clause})"
+
+
+def test_only_the_verdict_job_carries_the_check_name_skill_evals():
+    named = [jid for jid, j in _doc()["jobs"].items()
+             if str(j.get("name", jid)) == "skill evals"]
+    assert named == ["verdict"], (
+        f"exactly one job may report the check name 'skill evals'; got {named}")
+
+
+@pytest.mark.parametrize("result,expected", [
+    ("success", 0),
+    ("failure", 1),
+    ("cancelled", 1),
+    ("skipped", 1),
+    ("", 1),
+    ("neutral", 1),
+])
+def test_the_verdict_script_passes_only_on_a_real_success(result, expected):
+    """Executed, not read. `skipped` reads as green to branch protection, so the
+    verdict must turn every non-success into a non-zero exit itself."""
+    script = _job("verdict")["steps"][0]["run"]
+    proc = subprocess.run(
+        ["bash", "-c", script], env={"RESULT": result, "PATH": "/usr/bin:/bin"},
+        capture_output=True, text=True)
+    assert proc.returncode == expected, (
+        f"RESULT={result!r} exited {proc.returncode}, expected {expected}: "
+        f"{proc.stdout}{proc.stderr}")
+
+
+def test_the_agent_step_declares_the_sandbox_the_cli_requires_under_root():
+    """The first CI run failed every grader in 1.6 seconds: the runner is root,
+    and `claude` refuses `--permission-mode bypassPermissions` under uid 0
+    unless a deliberate sandbox is declared. Dropping this env var silently
+    reverts the workflow to grading five sessions that never started."""
+    step = next(s for s in _job("evals")["steps"]
+                if s.get("name") == "Run the eval cases")
+    assert step["env"].get("IS_SANDBOX") == "1"
+
+
+def test_the_agent_step_preserves_the_could_not_run_exit_code():
+    """Exit 2 is the harness saying "nothing was verified". Collapsing it into
+    the same red as exit 1 tells the reader the agent's behaviour changed when
+    the truth is that no agent ran."""
+    step = next(s for s in _job("evals")["steps"]
+                if s.get("name") == "Run the eval cases")
+    assert "-eq 2" in step["run"], "the step must branch on the harness's exit 2"
+    assert "DID NOT RUN" in step["run"]
+
+
+def test_the_claude_cli_is_pinned():
+    """A suite whose failure message asserts "the agent's behaviour changed"
+    must hold the runtime still, or an upstream release reads as a regression."""
+    step = next(s for s in _job("evals")["steps"]
+                if s.get("name") == "Install Claude Code")
+    assert re.search(r"@anthropic-ai/claude-code@\d+\.\d+\.\d+", step["run"]), (
+        f"pin the CLI version; got {step['run'].strip()!r}")
+
+
+def test_the_job_budget_exceeds_the_harness_own_worst_case():
+    """A slow-but-healthy suite killed by the job timeout is reported as a
+    behaviour change."""
+    worst_seconds = 0
+    for case in sorted(_EVALS.glob("*/case.yaml")):
+        spec = yaml.safe_load(case.read_text(encoding="utf-8"))
+        worst_seconds += (spec.get("execution") or {}).get("timeout_seconds", 900)
+    assert _job("evals")["timeout-minutes"] >= worst_seconds / 60, (
+        f"{worst_seconds / 60:.0f} minutes of per-run budget under a "
+        f"{_job('evals')['timeout-minutes']}-minute job timeout")
+
+
+def test_every_third_party_action_is_pinned_to_a_sha():
+    for jid, job in _doc()["jobs"].items():
+        for step in job.get("steps", []):
+            uses = step.get("uses")
+            if uses:
+                assert re.fullmatch(r"[^@]+@[0-9a-f]{40}", uses), (
+                    f"{jid}: {uses} is not pinned to a full commit SHA")
+
+
+def test_the_workflow_asks_for_no_more_than_read_access():
+    assert _doc()["permissions"] == {"contents": "read"}


### PR DESCRIPTION
## TL;DR

ci-secure ships five eval cases describing how the skill must behave in a live session: run the deterministic engine rather than reading YAML by hand, report a zero-findings run plainly, never present a check that did not run as a pass, and commit or push nothing. Nothing executed them, because they were written for `claude plugin eval`, which is gated behind early access and refuses to run. This adds a harness that runs them on primitives that are actually available, and a workflow that fires on the pull requests able to break them. It also grades what a run wrote, not only what it printed: the skill renders its findings to a report file, and graders anchored on that file were being matched against the terminal transcript instead.

```
before:  five cases  ->  nothing runs them        ->  contract unverified
after:   PR touches SKILL.md / references / scripts / evals
                     ->  scaffold fixtures into a temp repo
                     ->  one headless `claude -p` session per case
                     ->  apply that case's own graders to the recorded run
```

## What the first CI run showed, and what changed because of it

The workflow ran on this pull request and **failed all five cases in 1.6 seconds with zero tool calls**. A real session takes minutes, so nothing ran: `claude` declined before the first turn in all five. One cause is established — the self-hosted runner executes as root, and the CLI refuses `--permission-mode bypassPermissions` under uid 0 unless a deliberate sandbox is declared, printing its reason and exiting. Whether anything else also blocked the run is **not** established, and the reason it is not is the harness itself: it kept a substring test for one known refusal message, discarded the exit code and everything `claude` wrote, graded the empty stream, and announced *"the agent's behaviour changed"*.

That is the same defect this workflow exists to prevent, one level up: a check reporting a cause it had not established. Three things changed:

```
before:  claude refuses to start  ->  empty stream  ->  graded  ->  "the agent's behaviour changed"  (wrong file, wrong cause)
after:   claude refuses to start  ->  exit 2 + claude's own words  ->  "SKILL EVALS DID NOT RUN — nothing was verified"
```

- The eval step declares `IS_SANDBOX: "1"`, which is what the job already is: a throwaway checkout on an ephemeral runner, with the agent confined to a temp directory the harness creates and deletes.
- The harness refuses to grade a session that did not happen. A non-zero `claude` exit, a stream carrying no session, an exhausted turn cap, or an errored result now exits 2 — the could-not-run code — and prints what `claude` actually said. Exit 1 is reserved for a case that ran and failed a grader, and the workflow keeps the two apart in what it tells the reader.
- A guard suite pins both, offline: `maintainers/ci-secure/tests/test_run_skill_evals.py` and `tests/test_skill_evals_workflow.py`. Each assertion was run against the unfixed code first and observed to fail.

Four further defects found in review and fixed here, each of which could have produced a green check over nothing: a run count of zero executed no session and returned success; a case whose graders all fell through to "unscored" printed PASS over an empty list; a grader type the harness cannot evaluate was demoted to a dim line instead of failing; and an uncaught harness error exited 1, the code reserved for a real behavioural failure.

**Still unverified: whether a bare headless `claude -p` can authenticate here at all.** `ANTHROPIC_API_KEY` is an organization secret and was present and non-empty in the failing job, and it works for `anthropics/claude-code-action` in `claude.yml` — but that action does its own setup, and the run died too early to tell whether a bare CLI session gets as far as using it. The `7 of 7` measured locally does not settle it either: that machine authenticates through a claude.ai login and has no `ANTHROPIC_API_KEY` set, so "it worked locally" and "it works in CI" have never been the same claim. The next run answers it from the log rather than from inference, because the harness now prints the exit code, stdout and stderr of any session that failed to start.

## What the second CI run showed, and what changed because of it

The sessions ran. Five real agent sessions, seven minutes, roughly ten tool calls each — so the open question of whether a bare headless session can authenticate on the runner is answered, and it is yes. Three cases passed. Two failed, and reading the recorded sessions showed the skill had been right both times.

Three graders pin a finding to its real file and line, anchored on the exact evidence bullet `report.py` renders — `vulnerable.yml:8 — jobs: bench`. That anchor is the point: an agent can paraphrase its summary a dozen ways, but that bullet is byte-identical on every run. The skill renders it into a report file and prints a summary, and the harness graded only the transcript. So the assertion was true of what the run produced, and the grader was reading somewhere else.

```
before:  session -> transcript ------------------> every regex grader
         session -> report .md -> (discarded)

after:   session -> transcript ---> target: trace
         session -> report .md ---> target: files
```

Both failing runs found the right thing at the right line and wrote exactly the asserted text: `vulnerable.yml:8` and `:14` on the pwn-request fixture with `safe.yml` clean, and the injection at `ci.yml:11` with the network-gated check marked SKIPPED rather than passed. The third grader, in `template-injection`, carries the identical pattern and passed — not because the harness saw the report, but because that session happened to run `grep -n`. That green was luck, and it would have flipped on a correct run that greped differently.

What changed:

- The harness collects the files a session wrote alongside the transcript, and each regex grader reads the corpus its `target` names. The session's `TMPDIR` points at a directory the harness owns, which makes collecting the report a contract rather than a guess — `SKILL.md` renders under `${TMPDIR:-/tmp}`, and a test fails if that stops being true.
- The corpus holds only what the session created or changed. The scaffold hands the agent vulnerable workflow YAML naming the very files these graders assert on, so grading what it was handed is the same trap the `evals/` and `tests/` exclusion closes. Measured, no current grader is actually satisfied by the untouched fixtures — the filter is hygiene against the next one, not a leak being plugged.
- Two silent outcomes are refused. A `files` grader with an empty corpus exits 2, because an empty corpus fails every positive and passes every negative — a verdict from evidence nobody collected. An unrecognized target exits 2 rather than quietly grading the transcript, which is the defect itself.
- `pwn-request`'s `safe-workflow-produces-no-finding` deliberately stays on `trace`. Its twin asks what the renderer attributed; a false finding on the clean file reaching the reader is something the agent says.
- The vacuity rule extends to `files` graders, because `report.py` inlines catalog text into the report it renders — a pattern quoting the catalog would otherwise pass on the report having been rendered at all.

## What a run proves

Measured on `clean-repo` from a local session before these changes: **7 of 7 mechanical graders pass**. Cases carry seven or eight mechanical graders each. That local measurement is weaker evidence than it looks — the machine it ran on also has ci-secure installed ambiently, so the session could have used either copy. A clean attribution needs the CI run.

The assertions that carry the weight cannot be satisfied by an agent that skipped the scan and paraphrased its own instructions. `0 of 10 vectors hit` is computed by `report.py` for that specific run, and SKILL.md's worked example says `2 of 10`, so no prose the agent was handed contains it. Graders are applied to the decoded transcript — the agent's own output and the output of the tools it ran, never the prompt it was given. The negatives are equally concrete: `git commit` and `git push` must appear exactly zero times.

Two things the session can no longer reach. `--plugin-dir` used to mount the whole skill tree, which ships `evals/` (every grader's expected string) and `tests/` (rendered reports containing them), so an agent that grepped the plugin directory could satisfy a grader without scanning anything. The harness now mounts a copy with both removed. And every subprocess gets a scrubbed environment: an inherited `GIT_DIR` would have sent the scaffold's `git init` / `git add` / `git commit` at a real repository, and what it commits is intentionally vulnerable workflow YAML — a hazard the scaffold's own emptiness guard cannot see, because an empty temp directory really is empty.

Two earlier claims corrected. The string does exist elsewhere on disk, in `skills/ci-secure/tests/test_report.py` and in a committed example report, so "nowhere on disk" was wrong; what holds is that it is absent from the prose the agent reads. And graders used to be matched against the raw stream-json rather than the transcript, where `[^\n]` no longer means "on one line" — a same-line assertion could match across two, which is a false pass on exactly the graders that pin a finding to its real file and line.

## When it runs, and when it does not

**Automatically** on any pull request touching `skills/ci-secure/SKILL.md`, `references/**`, `scripts/**`, `evals/**`, the harness, or this workflow. Every other pull request is untouched, because each case is a real agent session and a README change should not pay for one. A pull request that changes behaviour without touching a filtered path gets no check at all — that is the reason this cannot simply be switched to required later.

**On demand** via `workflow_dispatch`:

```
gh workflow run skill-evals.yml --ref my-branch
gh workflow run skill-evals.yml --ref main -f case=clean-repo -f runs=3
```

**Never on fork pull requests**, which cannot reach `ANTHROPIC_API_KEY`. GitHub counts a skipped check as a pass, so the name of the check is the message: a fork pull request gets `skill evals NOT RUN (fork PR — no agent session)` and no `skill evals` check at all. That mirrors how `registry-scan.yml` already reports its own fork gap, and it replaces an earlier version that exited 0 from a job named `skill evals` — a green check over a session that could not happen, which is the thing this suite exists to make impossible.

**Never inside `pytest`.** The harness lives under `maintainers/`, so it never reaches an install and never runs in the ordinary suite. It spends real tokens; a unit test suite must not. The offline guards over its exit-code contract do run there.

## Advisory, not required

An agent can reach a correct outcome by a different route, so a required check here would be flaky, and a flaky gate is one that gets disabled or ignored. It reports. Promoting it needs more than a settings toggle, because a path-filtered workflow leaves a required check permanently pending on unrelated pull requests.

## Deliberate limits

`llm` graders are reported and **not scored**: judging prose quality needs a judge model, and scoring without one would be inventing a verdict. An unimplemented grader type or `target` is no longer demoted to a dim line — it fails the run, because a suite with a hole in it did not pass. `file_exists` is the one exception, still reported unscored; no case uses it.

What the case files declare that this harness does not yet apply, each of which makes a pass weaker than the author asked for, and none of which makes a failure wrong:

- `execution.allowed_tools` is not enforced; the session runs with the full tool set.
- The no-plugin ablation arm (`arm: both`) is not run, so no grader is checked against a session without the skill loaded.
- `execution.model` and the cases' `runs: 3` are not honoured.
- Regex `flags` are ignored; every pattern is matched case-sensitively. A `target` given as a file object is not implemented, and now stops the harness rather than being ignored.

A passing run means the agent behaved correctly on that run. It is evidence, not proof.

## Verification

The eval workflow's first two runs on this pull request are described above: the first failed before any session started, the second ran five real sessions and failed on the corpus the graders were read against. Each cause is fixed and pinned by an offline test.

The nine harness tests added with that fix were run against the unfixed harness first; eight fail there. The ninth asserts that `SKILL.md` still renders under `TMPDIR` — a contract-rot guard on a file this change does not touch, so it is named as such rather than counted as a red proof. The retargeted graders are checked against the report the real engine renders for the real fixtures — scaffold, `scan.py`, `report.py`, then the case's own patterns — so the anchor is verified against engine output rather than against a hand-written sample. The offline suite is green: 4190 passed. The Claude CLI is pinned to a version, so an upstream release cannot read as a skill regression.

The last link — that a live session's report lands in the collected corpus — has since been measured. The third eval run drove five real sessions and passed all five cases, including all three retargeted graders.

## Review round

Adversarial review found four more instances of the defect above: the harness reaching for evidence in the wrong place and scoring the difference as a behaviour change.

- `pwn-request`'s negative grader failed correct sessions. It asserts that no finding is attributed to the clean workflow, and read the transcript — which carries the output of every tool the agent ran. That fixture's line 7 is the literal key `jobs:`, so an ordinary `grep -n` over the workflows satisfied the pattern, and the more carefully a session inspected the file it was asked to clear, the likelier it failed. It now reads the rendered report, where no `path:line:` prefix can occur.
- `match: count:N` ignored `target` and always counted in the transcript — the wrong-corpus defect surviving in the one branch the fix did not touch.
- The "corpus could not be collected" guard only fired when the session produced no file at all, so a single scratch file turned a missing report into a set of failing graders. It now asks for the report itself.
- The mounted skill copy withheld `evals/` and `tests/` but not `CHANGELOG.md`, which narrates the graders and quotes their expected strings — so reading it satisfied a grader with no scan behind it. That is a false pass, the direction nobody investigates.

Each fix ships with a test proven to fail against the unfixed code first. Two of the new guards state a property rather than a list of names: no file the harness mounts may satisfy a grader, and no transcript-targeted negative may match what `grep -n` prints for its own fixture.

One finding is recorded and not fixed here: the eval workflow's budget comment says the case files declare a 900s per-run cap, but `many-findings` declares 1500s, making the real worst case 85 minutes against a 90-minute timeout rather than the 75 the comment implies. The guard that computes it is correct; only the prose is wrong. That file is left untouched because it carries an unrelated in-flight edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


