### PR TITLE
docs: record the attestation verdict and the storage boundary

### DIFF
--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -6,7 +6,9 @@ references ship inside the skill and go one level deeper:
 - [`skills/ci-speedup/references/wall-clock-methodology.md`](../skills/ci-speedup/references/wall-clock-methodology.md)
   — the critical-path / long-pole model (the ranking axis).
 - [`skills/ci-speedup/references/savings-methodology.md`](../skills/ci-speedup/references/savings-methodology.md)
-  — the two-axis sizing rules (wall-clock vs runner-minutes).
+  — the two-axis sizing rules (wall-clock vs runner-minutes). Those two axes
+  are the whole denomination: storage is deliberately out of scope, so nothing
+  here is sized in gigabytes and no saving claimed reduces a storage charge.
 
 ## Measured, not estimated
 

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -11,6 +11,19 @@ entries are dated (UTC). Format loosely follows
 
 ## [Unreleased]
 
+### Changed
+
+- **2026-08-20** — **Build provenance and artifact attestation now have a
+  recorded verdict.** The rejection record in `references/why-these-ten.md`
+  accounts for every adjacent practice that was considered and left out, and
+  attestation — `actions/attest-build-provenance`, cosign / sigstore, SLSA —
+  appeared nowhere, so a reader could only guess whether it had been weighed or
+  forgotten. It is now evaluated against the document's own three tests and
+  excluded on the record: attestation protects the consumers of what CI emits,
+  not the pipeline this skill scans, which is the same boundary that leaves code
+  scanning, dependency scanning and secret scanning outside the skill.
+  Documentation only — no detector, catalog entry, pattern id or count changes.
+
 ### Fixed
 
 - **2026-08-19** — **A deferred file that cannot be read is now a stop, not an

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -15,14 +15,16 @@ entries are dated (UTC). Format loosely follows
 
 - **2026-08-20** — **Build provenance and artifact attestation now have a
   recorded verdict.** The rejection record in `references/why-these-ten.md`
-  accounts for every adjacent practice that was considered and left out, and
-  attestation — `actions/attest-build-provenance`, cosign / sigstore, SLSA —
-  appeared nowhere, so a reader could only guess whether it had been weighed or
+  accounted for the patterns the descope removed, and attestation —
+  `actions/attest-build-provenance`, cosign / sigstore, SLSA — appeared
+  nowhere, so a reader could only guess whether it had been weighed or
   forgotten. It is now evaluated against the document's own three tests and
-  excluded on the record: attestation protects the consumers of what CI emits,
-  not the pipeline this skill scans, which is the same boundary that leaves code
-  scanning, dependency scanning and secret scanning outside the skill.
-  Documentation only — no detector, catalog entry, pattern id or count changes.
+  excluded on the record: attestation defends the consumers of what CI emits,
+  downstream of the pipeline this skill scans, and adopting it is a program
+  rather than a same-day edit. Because the entry carries no pattern id, the
+  census equality that pins every other rejection cannot see it, so a guard now
+  holds the verdict and its three adjudications in place. Documentation only —
+  no detector, catalog entry, pattern id or count changes.
 
 ### Fixed
 

--- a/skills/ci-secure/references/why-these-ten.md
+++ b/skills/ci-secure/references/why-these-ten.md
@@ -2,7 +2,8 @@
 
 ci-secure deliberately detects **ten** attack vectors, not the 25 patterns
 its catalog once held — the ten kept, and the 15 the rejection record below
-names and accounts for. This document is the reasoning, shipped with the skill
+names and accounts for, plus one adjacent practice recorded there as
+considered and excluded. This document is the reasoning, shipped with the skill
 so every finding can answer "why is this one of only ten?" — and so every
 future "shouldn't we add pattern X?" is tested against a written criterion
 instead of instinct. A census test binds the list below to the scanner's
@@ -152,40 +153,39 @@ while it remains a critical finding by membership).
 The removed patterns are not shipped with the skill; re-admitting any entry
 means passing this document's three tests and updating the census.
 
-### Build provenance and artifact attestation — considered, excluded
+### Build provenance and artifact attestation, evaluated against the three tests
 
-**Build provenance / artifact attestation** — `actions/attest-build-provenance`,
-cosign / sigstore signing, SLSA levels — was never a catalog pattern, and is
-recorded here anyway: it is the practice a reader is most likely to expect
-beside these ten, so leaving it unmentioned reads as an oversight rather than
-as a decision. Against the three tests:
+**Build provenance / artifact attestation** —
+`actions/attest-build-provenance`, cosign / sigstore signing, SLSA levels —
+was never a catalog pattern. Its evaluation is stated here so the absence is a
+decision on the record:
 
-1. **Outsider-chain test — fails, and this is the decisive one.** Attestation
-   does not sit between an outsider and a compromise of *this* pipeline. It
-   changes nothing an attacker can do to the workflows in this repo: the fork
-   PR still runs, the poisoned cache is still restored, the interpolated title
-   still reaches the shell. What it adds is a signed statement that the
-   **consumers** of what CI emits can verify downstream — a different party,
-   defending a different chain (a substituted or forged artifact somewhere
-   between this repo and them). That is the same boundary that leaves code
-   scanning, dependency scanning and secret scanning outside the skill: each is
-   a control over what CI produces or ingests, not a link in an outsider →
-   this-pipeline chain.
-2. **Incident test — not reached.** All three tests are required, so test 1
-   already settles the verdict; and the incidents the practice answers are
-   consumer-side substitutions, downstream of the pipeline this skill scans.
+1. **Outsider-chain test — fails.** Attestation does not sit between an
+   outsider and a compromise of *this* pipeline. It changes nothing an attacker
+   can do to the workflows in this repo: the fork PR still runs, the poisoned
+   cache is still restored, the interpolated title still reaches the shell.
+   What it adds is a signed statement that the **consumers** of what CI emits
+   can verify downstream — a different party, defending a different chain (a
+   substituted or forged artifact somewhere between this repo and them). The
+   one direction that does touch this pipeline is verifying what a workflow
+   *consumes* — `gh attestation verify` on a downloaded installer before
+   running it — and that is a second mitigation for a chain already in the ten
+   (P14.24), whose same-day fix is pinning. It adds no chain the catalog lacks.
+2. **Incident test — passes, and is not decisive.** Build-system compromise
+   and artifact substitution have happened in public; that is not in dispute.
+   The incidents the practice answers are consumer-side substitutions,
+   downstream of the pipeline this skill scans, so a pass here admits nothing
+   once test 1 has failed.
 3. **Same-day-fix test — fails.** "Attest your builds" is a program, not an
    edit: it needs a decision about which artifacts count as releases, an
    identity to attest to, and — the load-bearing half — a verifier on the
-   consuming side. Attestations nobody verifies move no one's security posture,
-   and the consumer is usually not the maintainer reading the finding.
+   consuming side. That value is realized by the consumer, who is usually not
+   the maintainer reading the finding.
 
-**Verdict: excluded.** A maintainer whose repo is clean against the ten is not
-"attestation-deficient", and saying so would be exactly the unactionable noise
-the descope removed. If ci-secure ever grows a second axis for *what CI ships to
-others*, attestation belongs at the top of it; it does not belong among the ten.
-It is not a catalog pattern, carries no pattern id, and does not change the
-counts the census checks.
+The exclusion stands. A maintainer whose repo is clean against the ten is not
+"attestation-deficient", and saying so would be a finding a maintainer reads
+and cannot act on. It is not a catalog pattern, carries no pattern id, and does
+not change the counts the census checks.
 
 ## What "critical" means here
 

--- a/skills/ci-secure/references/why-these-ten.md
+++ b/skills/ci-secure/references/why-these-ten.md
@@ -152,6 +152,41 @@ while it remains a critical finding by membership).
 The removed patterns are not shipped with the skill; re-admitting any entry
 means passing this document's three tests and updating the census.
 
+### Build provenance and artifact attestation — considered, excluded
+
+**Build provenance / artifact attestation** — `actions/attest-build-provenance`,
+cosign / sigstore signing, SLSA levels — was never a catalog pattern, and is
+recorded here anyway: it is the practice a reader is most likely to expect
+beside these ten, so leaving it unmentioned reads as an oversight rather than
+as a decision. Against the three tests:
+
+1. **Outsider-chain test — fails, and this is the decisive one.** Attestation
+   does not sit between an outsider and a compromise of *this* pipeline. It
+   changes nothing an attacker can do to the workflows in this repo: the fork
+   PR still runs, the poisoned cache is still restored, the interpolated title
+   still reaches the shell. What it adds is a signed statement that the
+   **consumers** of what CI emits can verify downstream — a different party,
+   defending a different chain (a substituted or forged artifact somewhere
+   between this repo and them). That is the same boundary that leaves code
+   scanning, dependency scanning and secret scanning outside the skill: each is
+   a control over what CI produces or ingests, not a link in an outsider →
+   this-pipeline chain.
+2. **Incident test — not reached.** All three tests are required, so test 1
+   already settles the verdict; and the incidents the practice answers are
+   consumer-side substitutions, downstream of the pipeline this skill scans.
+3. **Same-day-fix test — fails.** "Attest your builds" is a program, not an
+   edit: it needs a decision about which artifacts count as releases, an
+   identity to attest to, and — the load-bearing half — a verifier on the
+   consuming side. Attestations nobody verifies move no one's security posture,
+   and the consumer is usually not the maintainer reading the finding.
+
+**Verdict: excluded.** A maintainer whose repo is clean against the ten is not
+"attestation-deficient", and saying so would be exactly the unactionable noise
+the descope removed. If ci-secure ever grows a second axis for *what CI ships to
+others*, attestation belongs at the top of it; it does not belong among the ten.
+It is not a catalog pattern, carries no pattern id, and does not change the
+counts the census checks.
+
 ## What "critical" means here
 
 **Criticality is membership in this list.** The catalog's `severity` field

--- a/skills/ci-secure/tests/test_census_why_these_ten.py
+++ b/skills/ci-secure/tests/test_census_why_these_ten.py
@@ -331,3 +331,29 @@ def test_every_incident_why_these_ten_cites_is_recorded_in_the_catalog():
             f"why-these-ten.md cites {token!r}, but no entry in the catalog's "
             "Reference incidents section is ABOUT it — the reader has no source "
             "to follow (a mention inside another entry's prose is not one)")
+
+
+def test_the_rejection_record_keeps_its_attestation_verdict():
+    """Build provenance / attestation is the practice a reader is most likely
+    to expect beside these ten, and its exclusion is the first entry in the
+    rejection record that carries no pattern id — so the census equality above
+    (`len(removed) == 15`), which pins every other entry, cannot see it. It
+    could be deleted, reversed or contradicted with the whole suite green.
+    No test can prove the reasoning is right; what a test can do is stop the
+    verdict being dropped the next time this file is trimmed, which is the
+    same contract the deferred-file rule in test_reference_links.py carries.
+    """
+    why = _WHY.read_text()
+    section = why.split("### Build provenance and artifact attestation", 1)
+    assert len(section) == 2, (
+        "why-these-ten.md no longer records a verdict for build provenance / "
+        "artifact attestation — the practice a reader most expects beside the "
+        "ten is back to unexplained silence, and the census equality above "
+        "cannot see it because the entry carries no pattern id")
+    body = section[1].split("\n## ", 1)[0]
+    for token in ("Outsider-chain test", "Incident test", "Same-day-fix test"):
+        assert token in body, (
+            f"the attestation entry no longer adjudicates the {token!r} — the "
+            "record is only auditable if every entry answers all three")
+    assert "The exclusion stands." in body, (
+        "the attestation entry no longer states its verdict")

--- a/skills/ci-secure/tests/test_reference_links.py
+++ b/skills/ci-secure/tests/test_reference_links.py
@@ -140,7 +140,7 @@ def test_skill_md_still_links_every_reference_it_depends_on():
 def test_every_section_link_resolves_to_a_real_heading():
     """A link that names a section is a pointer to a RULE, not to a file. SKILL.md
     sends the agent to "Adding a pattern — the mechanical checklist" inside a
-    162-line reference; renaming or deleting that heading lands the agent at the
+    ~230-line reference; renaming or deleting that heading lands the agent at the
     top of the file with no sign anything is missing, which is worse than a link
     that visibly 404s. File existence alone does not catch it."""
     dangling = []

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -130,6 +130,14 @@ unversioned and updates by reinstall from `main`.
 
 ### Changed
 
+- **2026-08-20** — **The storage boundary is stated instead of implied.**
+  `references/savings-methodology.md` sizes every finding on two axes — runner
+  minutes and wall clock — and said nothing about artifact and cache storage,
+  which is a separate line on the GitHub bill governed by `retention-days` and
+  cache eviction. The silence read as an oversight; it is a decision, and the
+  methodology now says so: no finding is sized in gigabytes and no saving
+  claimed reduces a storage charge. Documentation only — no behavior change.
+
 - **2026-07-30** — **Two gating poles ⇒ both get their own menu slot.** The
   ≤4-option fold used to collapse the second pole into "Fix all," leaving no
   way to pick pole 2 alone — a live user who had just fixed pole 1 had no

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -135,8 +135,11 @@ unversioned and updates by reinstall from `main`.
   minutes and wall clock — and said nothing about artifact and cache storage,
   which is a separate line on the GitHub bill governed by `retention-days` and
   cache eviction. The silence read as an oversight; it is a decision, and the
-  methodology now says so: no finding is sized in gigabytes and no saving
-  claimed reduces a storage charge. Documentation only — no behavior change.
+  methodology now says so: nothing in it is sized in gigabytes, no saving it
+  claims reduces a storage charge, and storage that a fix adds is not netted
+  against the minutes it saves. A scope-claim guard holds the boundary in
+  place, since the file carries no substance floor of its own. Documentation
+  only — no behavior change.
 
 - **2026-07-30** — **Two gating poles ⇒ both get their own menu slot.** The
   ≤4-option fold used to collapse the second pole into "Fix all," leaving no

--- a/skills/ci-speedup/references/savings-methodology.md
+++ b/skills/ci-speedup/references/savings-methodology.md
@@ -6,6 +6,12 @@ Every finding is sized on **two axes**: a **runner-minute axis** (billing/cost
 two different things; a finding can be large on one and zero (or negative) on
 the other.
 
+Those two axes are the whole denomination: **runner minutes and wall-clock
+seconds**. **Storage is deliberately out of scope** — artifact and cache storage
+is a separate line on the GitHub bill, governed by `retention-days` and cache
+eviction rather than by how long a job runs, so no finding here is sized in
+gigabytes and no saving claimed here reduces a storage charge.
+
 The report **ranks the findings table and drives the headline** on the
 **wall-clock axis** (developer wait — see `wall-clock-methodology.md` §1); the
 runner-minute axis is computed per finding. Measured runner-minute findings with

--- a/skills/ci-speedup/references/savings-methodology.md
+++ b/skills/ci-speedup/references/savings-methodology.md
@@ -7,10 +7,13 @@ two different things; a finding can be large on one and zero (or negative) on
 the other.
 
 Those two axes are the whole denomination: **runner minutes and wall-clock
-seconds**. **Storage is deliberately out of scope** — artifact and cache storage
-is a separate line on the GitHub bill, governed by `retention-days` and cache
-eviction rather than by how long a job runs, so no finding here is sized in
-gigabytes and no saving claimed here reduces a storage charge.
+seconds**. **Storage is deliberately out of scope** — artifact and cache
+storage is a separate line on the GitHub bill, governed by `retention-days`
+and cache eviction rather than by how long a job runs, so no finding here is
+sized in gigabytes and no saving claimed here reduces a storage charge. Nor is
+storage netted the other way: a fix that adds a cache or an artifact hand-off
+increases storage and cache-eviction pressure, and that cost is not subtracted
+from the minutes it saves.
 
 The report **ranks the findings table and drives the headline** on the
 **wall-clock axis** (developer wait — see `wall-clock-methodology.md` §1); the

--- a/skills/ci-speedup/tests/test_claim_scope_guards.py
+++ b/skills/ci-speedup/tests/test_claim_scope_guards.py
@@ -190,3 +190,28 @@ def test_bare_pr_scope_regex_distinguishes_qualified_from_bare():
         "every PR matching the path filter",
     ):
         assert not _BARE_PR_SCOPE.search(qualified), qualified
+
+
+def test_the_methodology_states_its_storage_boundary():
+    """A third scope-claim class, held in prose rather than in a detector: what
+    the skill's savings are DENOMINATED in. Every finding is sized in runner
+    minutes and wall-clock seconds; artifact and cache storage is a separate
+    line on the GitHub bill and is deliberately out of scope. That decision
+    lives only in `references/savings-methodology.md`, which carries no
+    substance floor of its own, so the paragraph can vanish silently and leave
+    a reader to infer the boundary from silence — the same silence the
+    paragraph was written to end. This pins the claim, not its wording beyond
+    the load-bearing phrases.
+    """
+    text = (_SKILL_DIR / "references" / "savings-methodology.md").read_text(
+        encoding="utf-8")
+    assert "Storage is deliberately out of scope" in text, (
+        "savings-methodology.md no longer states that storage is out of scope "
+        "— the two-axis denomination is back to being implied, and a reader "
+        "cannot tell an omission from a decision")
+    assert "sized in\ngigabytes" in text or "sized in gigabytes" in text, (
+        "savings-methodology.md dropped the 'no finding is sized in gigabytes' "
+        "half of the storage boundary")
+    assert "netted the other way" in text, (
+        "savings-methodology.md dropped the direction a user actually asks "
+        "about: storage a fix ADDS is not subtracted from the minutes it saves")


### PR DESCRIPTION
## TL;DR

This is a documentation change; nothing ships behaviorally and no scan, score or saving moves. Two scope questions a reader can reasonably ask were answered nowhere in the skills: whether signing and attesting build artifacts had been considered for the security engine, and whether the speed engine's savings include storage. Both are now stated as decisions, with reasoning, so the silence stops reading as an oversight. Two small guards hold those decisions in place, because nothing in the suite could see either of them.

## What changed

**The security engine's rejection record now carries a verdict on build provenance and artifact attestation.** That document records which catalog patterns the descope removed and why, each tested against three stated admission tests. Attestation was never a catalog pattern, so it appeared nowhere and a reader could only guess whether it had been weighed or forgotten. It is now evaluated against the same three tests and excluded on the record.

The reasoning: attestation defends the *consumers* of what CI produces, downstream of the pipeline — the fork PR still runs, the poisoned cache is still restored, the interpolated title still reaches the shell. The one direction that does touch the scanned pipeline is verifying what a workflow consumes before running it, and that is a second mitigation for a chain already among the ten, whose same-day fix is pinning. It also fails the same-day-fix test, since adopting it is a program (choose what to attest, stand up a verifier on the consuming side), not an edit a maintainer makes the day they read a finding.

```
attestation defends:   this repo's CI  ──emits artifact──>  [ consumer verifies ]
                                                             ^^^^^^^^^^^^^^^^^^
                                                             different party,
                                                             different chain

this skill defends:    outsider  ──>  [ this repo's CI ]  ──>  compromise
                                       ^^^^^^^^^^^^^^^^
```

Attestation is not a catalog pattern and carries no pattern id, so the catalog census and the counts stated in that document are unchanged.

**The speed engine's savings methodology now states its storage boundary.** Every finding is sized on two axes — runner minutes and wall clock. Artifact and cache storage is a separate line on the GitHub bill, governed by retention settings and cache eviction rather than by how long a job runs, and it is deliberately out of scope in both directions: no finding is sized in gigabytes, no saving claimed reduces a storage charge, and storage that a fix *adds* is not netted against the minutes it saves either. The public front-door methodology page states the same boundary, since that is the surface a non-installing reader meets first.

Each touched skill gets a dated changelog bullet.

## Guards

Both decisions shipped unpinned in the first draft. The attestation entry is the first in the rejection record with no pattern id, so the census equality that pins every other entry cannot see it; the savings methodology carries no substance floor at all. Either could have been deleted, reversed or contradicted with the whole suite green. Two presence guards now hold them, following the precedent set one commit earlier: a prose rule and its guard land together.

## Review

An adversarial pass over the first draft found the prose asserting a precedent the document does not contain (a scanner-exclusion boundary that is recorded elsewhere for a different stated reason), contradicting two of the ten vectors it sits beside, overstating one verdict in a way a reader could falsify in one command, and declining to adjudicate one of the three tests it claimed to apply. All four are corrected in the second commit, and the section was brought into its sibling's voice.

## Tests

The prose corrections have no behavior to regress, so the red-first rule is exempt for the wording. It is **not** exempt for the two new guards: both were run against the pre-PR content and both failed, then passed once the content was restored. The failure is quoted in the commit message.

Full suite from the repo root: **4250 passed, 14 skipped** (4248 before, plus the two guards).

CI on this head is green on every required check (`test`, `ci-secure`, `python floor`) and on CodeQL, Greptile and the self-hosted runs. `registry scan` is red and is **not** caused by this change: the vendor CLI it drives stopped accepting the flag the workflow passes, so both its control scan and its gating scan exit on an argument error. The same job fails identically on `main`. It is not a required check, and fixing it belongs in a workflow change, not here.

