### PR TITLE
ci-secure: report a test suite whose failure cannot fail the build

### DIFF
--- a/.github/scripts/ci_secure_gate.py
+++ b/.github/scripts/ci_secure_gate.py
@@ -427,9 +427,15 @@ def main() -> int:
     # engine's JSON, and on a fork pull request the engine is attacker code: a
     # newline in any of them would start a new line in `body`, which is printed
     # to stdout where Actions parses `::workflow commands::`.
+    # A check that does not apply left `applicable_count`, so the headline
+    # would otherwise count fewer facts than the rows printed below it and
+    # give the reader no way to reconcile the two.
+    na = score.get("not_applicable")
+    na_note = (f" ({len(na)} not applicable)"
+               if isinstance(na, list) and na else "")
     lines = ["## ci-secure", "",
              f"{flat(score.get('passed'))}/{flat(score.get('scored_count'))} facts pass"
-             f" of {flat(score.get('applicable_count'))} applicable, "
+             f" of {flat(score.get('applicable_count'))} applicable{na_note}, "
              f"{flat(scan.get('scanned_workflows'))} workflow file(s) scanned", ""]
     if ADVISORY:
         lines += ["> **Advisory mode:** failed facts are reported but do not "

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -99,8 +99,13 @@ entries are dated (UTC). Format loosely follows
   vanishes, or one folded into "all checks pass", reads as a pass. **The
   config-fact aggregate this skill hands ci-advisor
   changes shape**: nine facts instead of eight, so the blended CI Score's
-  security third moves for any repository that has a suite. Census row and
-  full scope statement in `references/security-facts.md`.
+  security third moves for any repository that has a suite. What counts as
+  running the suite is read as a COMMAND, past any wrapper, interpreter,
+  leading path or shell keyword — `if ! pytest -q; then` and `for … do pytest`
+  run it, and missing them would drop the whole repository out of the fact's
+  denominator — while a here-doc body is text on its way to a file, so writing
+  a tolerant wrapper script is never read as swallowing a suite. Census row
+  and full scope statement in `references/security-facts.md`.
 
 ### Changed
 

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -25,15 +25,19 @@ entries are dated (UTC). Format loosely follows
   recognised suite commands, so a `run:` block whose purpose the YAML cannot
   establish is never failed, and `continue-on-error` on an upload, report, or
   notification step (codecov, `upload-artifact`, `upload-sarif`, a webhook
-  curl) is exempt by construction — that shape belongs to ci-speedup, and
-  billing one configuration to two engines would be a defect. A repository
-  whose workflows run no suite at all is NOT APPLICABLE, never a pass: it
+  curl) does not reach it, because a step is judged only by its own `run:`
+  line — that shape belongs to ci-speedup, and billing one configuration to
+  two engines would be a defect. A repository whose workflows run no suite at
+  all is NOT APPLICABLE, never a pass: it
   leaves the denominator rather than earning a green for having no tests,
   which is the shape ci-score settled on for the same question. The facts
   block therefore gained a `not_applicable` list beside `unmeasured`, and
   `applicable_count` now excludes a fact that does not apply — an unmeasured
   fact is a coverage gap and stays in the count; a not-applicable one is not a
-  gap and does not. **The config-fact aggregate this skill hands ci-advisor
+  gap and does not. The report renders the not-applicable row rather than
+  dropping it, and SKILL.md's spoken close says it as itself — a row that
+  vanishes, or one folded into "all checks pass", reads as a pass. **The
+  config-fact aggregate this skill hands ci-advisor
   changes shape**: nine facts instead of eight, so the blended CI Score's
   security third moves for any repository that has a suite. Census row and
   full scope statement in `references/security-facts.md`.

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -11,6 +11,33 @@ entries are dated (UTC). Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- **2026-08-20** — **A test suite whose failure cannot fail its job is now a
+  config fact.** `sec.gate.test-failure-fatal` fails when a job that runs the
+  test or lint suite discards the suite's exit code — `|| true`, `|| :`,
+  `|| echo …`, a trailing `exit 0`, `set +e` with no later re-check, or
+  `continue-on-error: true` on the suite's own step or its job. It is the
+  sibling of `sec.required-checks.skippable`: that fact catches a required
+  check that reports green because it was SKIPPED, this one catches a check
+  that RAN and reports green whatever the tests did. Same consequence — the
+  merge gate is decorative — same reader, same fix. Scope is an ALLOWLIST of
+  recognised suite commands, so a `run:` block whose purpose the YAML cannot
+  establish is never failed, and `continue-on-error` on an upload, report, or
+  notification step (codecov, `upload-artifact`, `upload-sarif`, a webhook
+  curl) is exempt by construction — that shape belongs to ci-speedup, and
+  billing one configuration to two engines would be a defect. A repository
+  whose workflows run no suite at all is NOT APPLICABLE, never a pass: it
+  leaves the denominator rather than earning a green for having no tests,
+  which is the shape ci-score settled on for the same question. The facts
+  block therefore gained a `not_applicable` list beside `unmeasured`, and
+  `applicable_count` now excludes a fact that does not apply — an unmeasured
+  fact is a coverage gap and stays in the count; a not-applicable one is not a
+  gap and does not. **The config-fact aggregate this skill hands ci-advisor
+  changes shape**: nine facts instead of eight, so the blended CI Score's
+  security third moves for any repository that has a suite. Census row and
+  full scope statement in `references/security-facts.md`.
+
 ### Changed
 
 - **2026-08-20** — **Build provenance and artifact attestation now have a

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -24,6 +24,9 @@ entries are dated (UTC). Format loosely follows
   (`bash ci/test.sh || true`) is now UNMEASURED with the steps named — a
   coverage gap that stays in the denominator — instead of not-applicable,
   which would have claimed no gap existed. (2026-08-20)
+- ci-secure: `set +e` and the suite written on one line (`set +e; pytest -q`)
+  is recognised as the same swallow as the two-line form; ordering the two by
+  line alone put them at one index and read it as a pass. (2026-08-20)
 - ci-secure: two more swallow shapes are recognised — `exit 0` followed by an
   inline comment, and a one-line `npm test; exit 0` — and a `set -e` that
   lands AFTER the suite already ran no longer counts as restoring its status.

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -13,6 +13,13 @@ entries are dated (UTC). Format loosely follows
 
 ### Added
 
+- ci-secure: `set +e; set -e; pytest -q` is recognised as a correctly wired
+  suite. Reading the restore by physical line left an empty slice where all
+  three share one line, failing a suite whose failure does end the job.
+  (2026-08-20)
+- ci-secure: printing the exit status no longer counts as re-raising it. An
+  `echo "rc=$?"` after a swallowed suite was read as a rescue and reported
+  the swallow as a pass. (2026-08-20)
 - ci-secure: `sec.gate.test-failure-fatal` matches the COMMAND a step runs,
   not any occurrence of a tool's name on the line. An allowlisted name inside
   an image tag, a process pattern, a directory, a filename, a message body or

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -13,6 +13,23 @@ entries are dated (UTC). Format loosely follows
 
 ### Added
 
+- ci-secure: `sec.gate.test-failure-fatal` matches the COMMAND a step runs,
+  not any occurrence of a tool's name on the line. An allowlisted name inside
+  an image tag, a process pattern, a directory, a filename, a message body or
+  an install argument — `docker pull ghcr.io/org/mypy:latest || true`,
+  `pkill -f karma || true`, `tar czf out.tgz .tox || true`,
+  `git checkout -- jest.config.js || true`,
+  `gh pr comment --body "eslint found 3 issues" || true`,
+  `npx playwright install --with-deps || true`, `npm i -D jest || true` —
+  was failing the check on repositories whose tests are perfectly fatal.
+  Interpreter runners and leading paths (`python -m pytest`,
+  `poetry run pytest`, `./mvnw test`) are still recognised. (2026-08-20)
+- ci-secure: `workflow_call` counts as a merge-gate trigger. A reusable
+  workflow is where a large repository usually keeps its suite, and out of
+  scope it left the denominator entirely rather than being judged.
+  (2026-08-20)
+- ci-secure: `|| exit 0` and `|| /bin/true` are recognised as the discards
+  they are; `|| exit 0` had been reported as a clean bill. (2026-08-20)
 - ci-secure: `sec.gate.test-failure-fatal` now judges only workflows that can
   report a check on a pull request. A nightly `schedule` job or a
   `workflow_dispatch`-only smoke run reports on no pull request, so a tolerant

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -13,6 +13,29 @@ entries are dated (UTC). Format loosely follows
 
 ### Added
 
+- ci-secure: `sec.gate.test-failure-fatal` now judges only workflows that can
+  report a check on a pull request. A nightly `schedule` job or a
+  `workflow_dispatch`-only smoke run reports on no pull request, so a tolerant
+  `|| true` there is not the decorative merge gate the fact describes and is
+  no longer failed for one. (2026-08-20)
+- ci-secure: `sec.gate.test-failure-fatal` separates "nothing here to check"
+  from "nothing here this scan recognises". A repository whose only discarded
+  exit status sits on a command the allowlist cannot identify
+  (`bash ci/test.sh || true`) is now UNMEASURED with the steps named — a
+  coverage gap that stays in the denominator — instead of not-applicable,
+  which would have claimed no gap existed. (2026-08-20)
+- ci-secure: two more swallow shapes are recognised — `exit 0` followed by an
+  inline comment, and a one-line `npm test; exit 0` — and a `set -e` that
+  lands AFTER the suite already ran no longer counts as restoring its status.
+  (2026-08-20)
+- ci-secure: a check that does not apply is now disclosed in words on both
+  reader surfaces — a sentence in the report's hygiene section and a
+  `(1 not applicable)` note in the gate headline — so the count line can be
+  reconciled against the rows above it. (2026-08-20)
+- ci-secure: swallowed-suite evidence names the offending step by its `name:`
+  as well as its position, and reports `|| :` as `|| :` rather than as
+  `|| true`, so the string in the evidence is the string in the file.
+  (2026-08-20)
 - **2026-08-20** — **A test suite whose failure cannot fail its job is now a
   config fact.** `sec.gate.test-failure-fatal` fails when a job that runs the
   test or lint suite discards the suite's exit code — `|| true`, `|| :`,

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -31,6 +31,16 @@ entries are dated (UTC). Format loosely follows
   inline comment, and a one-line `npm test; exit 0` — and a `set -e` that
   lands AFTER the suite already ran no longer counts as restoring its status.
   (2026-08-20)
+- ci-secure: the trailing-`exit 0` swallow shape is now judged against the
+  step's effective shell. GitHub's default `run` shell carries errexit
+  (`bash -e {0}`), so a failing suite aborts the step before a trailing
+  `exit 0` is reached — flagging it was a false accusation against a job
+  that already fails. The arm now fires only where the discard is real:
+  `pwsh`, `powershell`, or `cmd`, declared on the step, the job or workflow
+  `defaults.run.shell`, or implied by a `windows-*` runner's `pwsh` default.
+  Every arm of the suite-command allowlist is also now pinned by a test, so
+  a dropped arm cannot silently flip a repository from fail to
+  not-applicable. (2026-08-20)
 - ci-secure: a check that does not apply is now disclosed in words on both
   reader surfaces — a sentence in the report's hygiene section and a
   `(1 not applicable)` note in the gate headline — so the count line can be

--- a/skills/ci-secure/SKILL.md
+++ b/skills/ci-secure/SKILL.md
@@ -192,8 +192,8 @@ Contract lines, all mandatory:
   report's `## 🧰 Config hygiene checks — pass/fail` table and NAME what
   failed: `One hygiene gap: no reviewer rule covers your workflow files.` Two
   or more: name each, one short clause apiece. All passing: `All config
-  hygiene checks pass.` Anything the report marks unmeasured is a coverage
-  gap and is said as one, never folded into "pass".
+  hygiene checks pass.` Unmeasured is a coverage gap, n/a did not apply to
+  this repo: say each as itself, never as a pass and never as nothing.
 - **Then the vector map** — the line-item receipt, so the user sees what they
   are good on and what did not run without opening the file. Head it exactly
   `Vector scan — 10 attack vectors checked, N hit:` (N from the banner), so

--- a/skills/ci-secure/references/security-facts.md
+++ b/skills/ci-secure/references/security-facts.md
@@ -7,7 +7,7 @@
 
 ---
 
-ci-secure computes eight deterministic, pass/fail configuration facts as
+ci-secure computes nine deterministic, pass/fail configuration facts as
 MACHINE-ONLY inputs for a future blended score (the ci-advisor door, not yet
 public). They are aggregated `100 × passed / scored` with no weights and no
 partial credit (registered 2026-08-03) — but **that aggregate is never a number
@@ -18,9 +18,9 @@ vector detectors are lexical rather than confirmed exploit proofs, and a public
 number must not grade a stranger's repo down on an unconfirmed match.
 
 **The denominator is token-dependent, so the aggregate is not comparable
-across scans run under different auth.** Two of the eight facts read the GitHub
-API. A scan with no repository or no token measures six of eight and scores
-`100 × passed / 6`; the same repository scanned with a token scores over eight.
+across scans run under different auth.** Two of the nine facts read the GitHub
+API. A scan with no repository or no token measures seven of nine and scores
+`100 × passed / 7`; the same repository scanned with a token scores over nine.
 The unmeasured ids are named in the block's `unmeasured` list and the caveat, so
 a consumer — ci-advisor above all — can tell the two apart, but only if it
 checks: comparing the raw numbers across differently-authenticated scans
@@ -28,7 +28,7 @@ compares different measurements.
 
 **The aggregate is machine-only.** ci-secure's own report and close render
 these facts as a pass/fail table and **no number** by design: a hygiene
-aggregate labelled "Security score" overclaims what eight config observations
+aggregate labelled "Security score" overclaims what nine config observations
 can say, and printed beside a ten-vector scan it read as a contradiction. The
 `security_score` block in the findings JSON keeps its shape — same keys, same `fact_id`s, same outcomes, same aggregate; only prose the
 report prints was reworded so it stops naming a score the reader never sees.
@@ -40,6 +40,17 @@ A fact that cannot be measured — an unscannable workflow file, or, for the two
 API-gated facts, no repository and no token — is **unmeasured, never a silent
 pass**: it scores nothing, stays in the applicable count as a
 named coverage gap, and the block says so.
+
+A fact that **does not apply** is a different state and is treated differently.
+"This could not be checked" is a coverage gap; "there is nothing here to check"
+is not, and counting it as one would report a gap that does not exist. A
+not-applicable fact scores nothing and leaves the applicable count entirely —
+the same treatment ci-score gives a check it rules not applicable — while its
+row still renders, because a row that quietly vanishes reads as a pass. Its id
+is listed in the block's `not_applicable` list, separate from `unmeasured`, so
+a consumer never has to guess which of the two it is looking at. Only
+`sec.gate.test-failure-fatal` can reach that state today, and only in a
+repository whose workflows run no test or lint suite at all.
 
 ## The disjointness census
 
@@ -59,6 +70,7 @@ instead of shipping.
 | `sec.secrets.no-blanket-inherit` | — none | No ci-score check reads `secrets:` on reusable-workflow calls. |
 | `sec.required-checks.skippable` | — none | Branch protection is not workflow YAML; no ci-score check reads the API. The workflow-side edit this fact asks for (add an always-running verdict job that `needs:` the conditional ones) touches no key any ci-score check reads. |
 | `sec.fork-approval.effective` | — none | A repository Actions setting, not workflow YAML at all; no ci-score check reads it, and no YAML edit can move it. |
+| `sec.gate.test-failure-fatal` | `ci.parallel.test-sharding` | Both look at the jobs that run the suite, and neither edit moves the other: sharding is a `strategy.matrix` on the job, this fact is the `run:` line's exit code and the step's `continue-on-error`. A sharded suite can still swallow every shard's failure, and an unsharded one can be perfectly fatal. Also bounded against the OTHER engine: `continue-on-error` on an upload, report, or notification step is a speed and reliability question that ci-speedup owns, and this fact cannot fire on one, because only a step whose command runs a recognised suite is in scope. |
 | `sec.checkout.credentials-scoped` | `ci.checkout.shallow-clone` | Both read checkout steps, but different keys: `fetch-depth` there, `persist-credentials` here — two `with:` entries, two edits. This fact also applies only on untrusted-trigger workflows (excluding the payload-less `fork`/`watch` notification events); shallow-clone applies on PR-gating ones. |
 
 **Residual correlation, disclosed:** a repo with careless
@@ -157,3 +169,47 @@ two moved numbers.
   can read it. Trusted-trigger workflows are not this fact's business — nor are
   the payload-less `fork`/`watch` notification events, which carry no
   attacker-influenced execution that could read a persisted token.
+- **`sec.gate.test-failure-fatal`** — no job that runs the test or lint suite
+  swallows its own exit code. This is the sibling of
+  `sec.required-checks.skippable`, and it belongs here for the same reason that
+  one does: that fact is "a required check that was SKIPPED reports green"; this
+  one is "a check that RAN reports green regardless of what the suite did."
+  The failure mode is identical — the merge gate is decorative, and the repo
+  believes it is gated — the reader is the same person, and so is the fix:
+  let the failure reach the job's exit status. It is a pass/fail configuration
+  fact, not an attack vector: nothing here is an exploit chain, no finding is
+  raised, and it is not a candidate for the ten (`why-these-ten.md` governs
+  those, and this is not one of them).
+
+  The failing shapes are `|| true`, `|| :`, `|| echo …`, a trailing `exit 0`,
+  `set +e` with no later re-check of the status it stopped enforcing, and
+  `continue-on-error: true` on the suite's own step (or on the job that runs
+  it). A quoted `'true'` counts; an expression like
+  `continue-on-error: ${{ matrix.experimental }}` does not — it is true on some
+  matrix legs and false on others, and the YAML cannot say which.
+
+  **Scope, deliberately narrow.** Only a `run:` line that a shipped allowlist
+  recognises as a test, lint, or build-verification suite can fail this fact.
+  Two things follow, both intended. A `run:` block the allowlist does not
+  recognise — `./scripts/ci.sh || true` — is never failed: it may be swallowing
+  a suite or a cleanup, the YAML cannot say which, and a false accusation
+  against a stranger's repository costs more than a miss in a fact that feeds a
+  published score. And `continue-on-error: true` on an **upload, report, or
+  notification** step — codecov, `upload-artifact`, `upload-sarif`, a Slack
+  webhook — is exempt by construction, since no such step runs a suite. Making
+  a reporting step non-fatal is a deliberate, usually correct choice about
+  speed and reliability, and it is already ci-speedup's business; billing one
+  configuration to two engines would be a defect, not thoroughness. A `|| true`
+  on a utility line sitting beside the suite (`grep … || true`) swallows the
+  grep, not the tests, and is not this fact's business either.
+
+  **A repository with no suite at all is NOT APPLICABLE, not a pass.** There is
+  nothing to swallow, so there is nothing to certify: a green here would read as
+  "this repo's tests are wired to fail the build" about a repo with no tests.
+  It is not unmeasured either — nothing was unreadable. It leaves the
+  denominator, which is the shape ci-score settled on for the same question
+  (its test-sharding check is not applicable when no test-like job exists).
+  **To fix a fail**: drop the swallow so the suite's exit status reaches the
+  job — and if the intent was to see the failure without blocking, keep the
+  reporting and re-raise the status (`… || { echo "suite failed"; exit 1; }`,
+  or capture `$?` under `set +e` and `exit` it at the end).

--- a/skills/ci-secure/references/security-facts.md
+++ b/skills/ci-secure/references/security-facts.md
@@ -191,7 +191,16 @@ two moved numbers.
   `continue-on-error: ${{ matrix.experimental }}` does not — it is true on some
   matrix legs and false on others, and the YAML cannot say which.
 
-  **Scope, deliberately narrow.** Only a `run:` line that a shipped allowlist
+  **Scope, deliberately narrow.** Only a workflow that can report a check on a
+  pull request is judged at all — a `pull_request`, `pull_request_target`,
+  `push` or `merge_group` trigger. A nightly `schedule` job or a
+  `workflow_dispatch`-only smoke run reports on no pull request, so a tolerant
+  `|| true` there is not the decorative merge gate this fact describes, and
+  failing it would be the false accusation the rest of this paragraph rules
+  out. An `on:` block that cannot be read stays in scope: dropping it would
+  turn an unreadable trigger into a silent pass.
+
+  Within those workflows, only a `run:` line that a shipped allowlist
   recognises as a test, lint, or build-verification suite can fail this fact.
   Two things follow, both intended. A `run:` block the allowlist does not
   recognise — `./scripts/ci.sh || true` — is never failed: it may be swallowing
@@ -212,12 +221,22 @@ two moved numbers.
   suite (`grep … || true`) swallows the grep, not the tests, and is not this
   fact's business either.
 
-  **A repository with no suite at all is NOT APPLICABLE, not a pass.** There is
-  nothing to swallow, so there is nothing to certify: a green here would read as
-  "this repo's tests are wired to fail the build" about a repo with no tests.
-  It is not unmeasured either — nothing was unreadable. It leaves the
-  denominator, which is the shape ci-score settled on for the same question
-  (its test-sharding check is not applicable when no test-like job exists).
+  **A repository with nothing to check is NOT APPLICABLE, not a pass.** There
+  is nothing to swallow, so there is nothing to certify: a green here would
+  read as "this repo's tests are wired to fail the build" about a repo with no
+  tests. It leaves the denominator, which is the shape ci-score settled on for
+  the same question (its test-sharding check is not applicable when no
+  test-like job exists).
+
+  **"Nothing to check" is a stronger claim than "nothing recognised", and the
+  fact does not confuse the two.** Not-applicable requires BOTH that no
+  recognised suite ran AND that no step threw an exit status away. Where the
+  allowlist recognised nothing but something *did* discard a status —
+  `bash ci/test.sh || true`, the canonical unknown-purpose shape — the two
+  readings are opposite (a swallowed suite, or a tolerated cleanup) and the
+  YAML settles neither. That is UNMEASURED, with the steps named: a coverage
+  gap that stays in the denominator, because "there is nothing here to check"
+  would assert no gap exists on the one shape where one demonstrably does.
   **To fix a fail**: drop the swallow so the suite's exit status reaches the
   job — and if the intent was to see the failure without blocking, keep the
   reporting and re-raise the status (`… || { echo "suite failed"; exit 1; }`,

--- a/skills/ci-secure/references/security-facts.md
+++ b/skills/ci-secure/references/security-facts.md
@@ -215,9 +215,17 @@ two moved numbers.
   out. An `on:` block that cannot be read stays in scope: dropping it would
   turn an unreadable trigger into a silent pass.
 
-  Within those workflows, only a `run:` line that a shipped allowlist
+  Within those workflows, only a `run:` line whose COMMAND a shipped allowlist
   recognises as a test, lint, or build-verification suite can fail this fact.
-  Two things follow, both intended. A `run:` block the allowlist does not
+  The command, not the line: `docker pull ghcr.io/org/mypy:latest || true`,
+  `pkill -f karma || true`, `tar czf out.tgz .tox || true` and
+  `gh pr comment --body "eslint found 3 issues" || true` each carry an
+  allowlisted name in an image tag, a process pattern, a directory and a
+  message body, and none of them runs a suite. The allowlist is therefore
+  anchored to the head of the command, after any environment assignment,
+  privilege or timing wrapper, interpreter runner (`python -m pytest`,
+  `poetry run pytest`) and leading path (`./mvnw test`). Two things follow,
+  both intended. A `run:` block the allowlist does not
   recognise — `./scripts/ci.sh || true` — is never failed: it may be swallowing
   a suite or a cleanup, the YAML cannot say which, and a false accusation
   against a stranger's repository costs more than a miss in a fact that feeds a

--- a/skills/ci-secure/references/security-facts.md
+++ b/skills/ci-secure/references/security-facts.md
@@ -19,8 +19,11 @@ number must not grade a stranger's repo down on an unconfirmed match.
 
 **The denominator is token-dependent, so the aggregate is not comparable
 across scans run under different auth.** Two of the nine facts read the GitHub
-API. A scan with no repository or no token measures seven of nine and scores
-`100 × passed / 7`; the same repository scanned with a token scores over nine.
+API. In a repository where every fact applies, a scan with no repository or no
+token measures seven of nine and scores `100 × passed / 7`; the same repository
+scanned with a token scores over nine. A fact that does not apply to the
+repository at all leaves the denominator on top of that (see below), so both
+numbers drop by one in a repository whose workflows run no suite.
 The unmeasured ids are named in the block's `unmeasured` list and the caveat, so
 a consumer — ci-advisor above all — can tell the two apart, but only if it
 checks: comparing the raw numbers across differently-authenticated scans
@@ -70,7 +73,7 @@ instead of shipping.
 | `sec.secrets.no-blanket-inherit` | — none | No ci-score check reads `secrets:` on reusable-workflow calls. |
 | `sec.required-checks.skippable` | — none | Branch protection is not workflow YAML; no ci-score check reads the API. The workflow-side edit this fact asks for (add an always-running verdict job that `needs:` the conditional ones) touches no key any ci-score check reads. |
 | `sec.fork-approval.effective` | — none | A repository Actions setting, not workflow YAML at all; no ci-score check reads it, and no YAML edit can move it. |
-| `sec.gate.test-failure-fatal` | `ci.parallel.test-sharding` | Both look at the jobs that run the suite, and neither edit moves the other: sharding is a `strategy.matrix` on the job, this fact is the `run:` line's exit code and the step's `continue-on-error`. A sharded suite can still swallow every shard's failure, and an unsharded one can be perfectly fatal. Also bounded against the OTHER engine: `continue-on-error` on an upload, report, or notification step is a speed and reliability question that ci-speedup owns, and this fact cannot fire on one, because only a step whose command runs a recognised suite is in scope. |
+| `sec.gate.test-failure-fatal` | `ci.parallel.test-sharding` | Both look at the jobs that run the suite, and neither edit moves the other: sharding is a `strategy.matrix` on the job, this fact is the `run:` line's exit code and the step's `continue-on-error`. A sharded suite can still swallow every shard's failure, and an unsharded one can be perfectly fatal. Also bounded against the OTHER engine: `continue-on-error` on an upload, report, or notification step is a speed and reliability question that ci-speedup owns, and it does not reach this fact, because only a step whose own `run:` command the allowlist recognises as a suite is in scope — a `uses:` upload action has no `run:` line at all. Residual, disclosed: a reporting step whose command *does* match the allowlist is in scope here too, as is a suite step carrying `continue-on-error: true` that has been red for every run (ci-speedup's OPT68); the bound is on the command, not on the step's stated purpose. |
 | `sec.checkout.credentials-scoped` | `ci.checkout.shallow-clone` | Both read checkout steps, but different keys: `fetch-depth` there, `persist-credentials` here — two `with:` entries, two edits. This fact also applies only on untrusted-trigger workflows (excluding the payload-less `fork`/`watch` notification events); shallow-clone applies on PR-gating ones. |
 
 **Residual correlation, disclosed:** a repo with careless
@@ -196,12 +199,18 @@ two moved numbers.
   against a stranger's repository costs more than a miss in a fact that feeds a
   published score. And `continue-on-error: true` on an **upload, report, or
   notification** step — codecov, `upload-artifact`, `upload-sarif`, a Slack
-  webhook — is exempt by construction, since no such step runs a suite. Making
-  a reporting step non-fatal is a deliberate, usually correct choice about
-  speed and reliability, and it is already ci-speedup's business; billing one
-  configuration to two engines would be a defect, not thoroughness. A `|| true`
-  on a utility line sitting beside the suite (`grep … || true`) swallows the
-  grep, not the tests, and is not this fact's business either.
+  webhook — does not reach this fact, because a step is judged only by its own
+  `run:` line: a `uses:` action has no `run:` line at all, and a webhook `curl`
+  matches nothing on the allowlist. Making a reporting step non-fatal is a
+  deliberate, usually correct choice about speed and reliability, and it is
+  already ci-speedup's business; billing one configuration to two engines would
+  be a defect, not thoroughness. **Residual, disclosed:** that exemption is a
+  property of the COMMAND, not of the step's name or intent, so a reporting
+  step whose `run:` line does match the allowlist — `npm run
+  test:upload-coverage`, `make check-links || true` — is in scope here and can
+  be billed by both engines. A `|| true` on a utility line sitting beside the
+  suite (`grep … || true`) swallows the grep, not the tests, and is not this
+  fact's business either.
 
   **A repository with no suite at all is NOT APPLICABLE, not a pass.** There is
   nothing to swallow, so there is nothing to certify: a green here would read as

--- a/skills/ci-secure/references/security-facts.md
+++ b/skills/ci-secure/references/security-facts.md
@@ -191,6 +191,21 @@ two moved numbers.
   `continue-on-error: ${{ matrix.experimental }}` does not — it is true on some
   matrix legs and false on others, and the YAML cannot say which.
 
+  The trailing-`exit 0` shape is judged against the step's **effective
+  shell**, resolved the way GitHub resolves it — the step's `shell:`, then
+  the job's `defaults.run.shell`, then the workflow's, then the runner
+  default. Where errexit applies — the platform default `bash -e {0}` on
+  Linux and macOS, `sh -e`, an explicit `shell: bash` (invoked with
+  `-eo pipefail`) — a failing suite aborts the step before a trailing
+  `exit 0` is ever reached, so the step already fails and flagging it would
+  be a false accusation against a fatally wired job. The arm therefore fires
+  only where the discard is real: `pwsh`, `powershell`, or `cmd`, declared
+  at any of those levels or implied by a `windows-*` runner's `pwsh`
+  default. A shell expression or a template this list does not recognise
+  resolves to errexit-bearing, for the same miss-beats-accusation reason.
+  The other shapes need no such gate: `|| true` and `|| :` succeed under
+  any shell, and `set +e` is itself the act of turning errexit off.
+
   **Scope, deliberately narrow.** Only a workflow that can report a check on a
   pull request is judged at all — a `pull_request`, `pull_request_target`,
   `push` or `merge_group` trigger. A nightly `schedule` job or a

--- a/skills/ci-secure/references/security-facts.md
+++ b/skills/ci-secure/references/security-facts.md
@@ -224,7 +224,13 @@ two moved numbers.
   message body, and none of them runs a suite. The allowlist is therefore
   anchored to the head of the command, after any environment assignment,
   privilege or timing wrapper, interpreter runner (`python -m pytest`,
-  `poetry run pytest`) and leading path (`./mvnw test`). Two things follow,
+  `poetry run pytest`), leading path (`./mvnw test`) and shell keyword. The
+  keyword matters as much as the wrappers do: `if ! pytest -q; then` and
+  `for m in $MODULES; do pytest -q; done` run the suite exactly as a bare line
+  does, and a suite the anchor cannot see does not merely go unjudged — it
+  takes the whole repository out of this fact's denominator as not applicable,
+  which is a silent loss of coverage rather than a miss on one line.
+  Two things follow,
   both intended. A `run:` block the allowlist does not
   recognise — `./scripts/ci.sh || true` — is never failed: it may be swallowing
   a suite or a cleanup, the YAML cannot say which, and a false accusation
@@ -242,7 +248,11 @@ two moved numbers.
   test:upload-coverage`, `make check-links || true` — is in scope here and can
   be billed by both engines. A `|| true` on a utility line sitting beside the
   suite (`grep … || true`) swallows the grep, not the tests, and is not this
-  fact's business either.
+  fact's business either. Neither is a **here-doc body**: the lines between
+  `cat > run.sh <<'EOF'` and its closing delimiter are text on its way to a
+  file, so a step that WRITES a tolerant wrapper script is not a step that
+  runs one, and judging that text as shell would fail a job whose own suite is
+  fatal.
 
   **A repository with nothing to check is NOT APPLICABLE, not a pass.** There
   is nothing to swallow, so there is nothing to certify: a green here would

--- a/skills/ci-secure/scaffold/gate.py
+++ b/skills/ci-secure/scaffold/gate.py
@@ -427,9 +427,15 @@ def main() -> int:
     # engine's JSON, and on a fork pull request the engine is attacker code: a
     # newline in any of them would start a new line in `body`, which is printed
     # to stdout where Actions parses `::workflow commands::`.
+    # A check that does not apply left `applicable_count`, so the headline
+    # would otherwise count fewer facts than the rows printed below it and
+    # give the reader no way to reconcile the two.
+    na = score.get("not_applicable")
+    na_note = (f" ({len(na)} not applicable)"
+               if isinstance(na, list) and na else "")
     lines = ["## ci-secure", "",
              f"{flat(score.get('passed'))}/{flat(score.get('scored_count'))} facts pass"
-             f" of {flat(score.get('applicable_count'))} applicable, "
+             f" of {flat(score.get('applicable_count'))} applicable{na_note}, "
              f"{flat(scan.get('scanned_workflows'))} workflow file(s) scanned", ""]
     if ADVISORY:
         lines += ["> **Advisory mode:** failed facts are reported but do not "

--- a/skills/ci-secure/scripts/config.py
+++ b/skills/ci-secure/scripts/config.py
@@ -173,12 +173,17 @@ def setup_logging(
 
 BLOCKING_OUTCOMES: Final[frozenset[str]] = frozenset({"fail"})
 
-KNOWN_OUTCOMES: Final[frozenset[str]] = frozenset({"pass", "fail", "unmeasured"})
+KNOWN_OUTCOMES: Final[frozenset[str]] = frozenset(
+    {"pass", "fail", "unmeasured", "not_applicable"})
 
 OUTCOME_MARKS: Final[dict[str, str]] = {
     "pass": "PASS",
     "fail": "**FAIL**",
     "unmeasured": "UNMEASURED",
+    # Distinct from UNMEASURED on purpose: "this could not be checked" and
+    # "there is nothing here to check" read the same to a maintainer only
+    # until they go looking for the gap that does not exist.
+    "not_applicable": "N/A",
 }
 
 

--- a/skills/ci-secure/scripts/config_facts.py
+++ b/skills/ci-secure/scripts/config_facts.py
@@ -583,7 +583,10 @@ _MENTIONS_BUT_DOES_NOT_RUN = re.compile(
 # The swallow shapes. Each leaves the shell's last exit status at 0 for a
 # command that failed, so the step — and with it the job, and with it the
 # required check — reports success.
-_SWALLOW_OR_TRUE = re.compile(r"\|\|\s*(?:true\b|:(?=\s*(?:$|[;&|)}])))")
+# `#` terminates the `:` arm alongside `;&|)}`: the form this shape is actually
+# written in carries the author's reason on the same line — `pytest || :  #
+# tolerate flakes` — and a comment ends the command exactly as those do.
+_SWALLOW_OR_TRUE = re.compile(r"\|\|\s*(?:true\b|:(?=\s*(?:$|[;&|)}#])))")
 _SWALLOW_OR_ECHO = re.compile(r"\|\|\s*echo\b")
 _EXIT_ZERO = re.compile(r"(?:^|;)\s*exit\s+0\s*(?:#.*)?$")
 _RELAX_ERREXIT = re.compile(r"^set\s+\+[a-z]*e[a-z]*\b")

--- a/skills/ci-secure/scripts/config_facts.py
+++ b/skills/ci-secure/scripts/config_facts.py
@@ -634,12 +634,57 @@ def _code_lines(run: str) -> list[str]:
             if ln.strip() and not ln.strip().startswith("#")]
 
 
-def _swallow_reason(run: str) -> str | None:
+# Shells with no errexit: a trailing `exit 0` after a failed command really
+# runs there. Everywhere GitHub's default applies — `bash -e {0}` on Linux and
+# macOS runners, `sh -e` where bash is absent, and an explicit `shell: bash`,
+# which the runner invokes with `-eo pipefail` — a failing suite aborts the
+# step before a trailing `exit 0` is reached: the step already fails and the
+# "swallow" is unreachable code. Custom templates and shells this list does
+# not name resolve to errexit-bearing, because the failure direction of a
+# mis-read here is a false accusation against a fatally wired job, and a miss
+# beats that.
+_NO_ERREXIT_SHELLS = frozenset({"pwsh", "powershell", "cmd"})
+
+
+def _defaults_shell(node: dict) -> str | None:
+    """The `defaults.run.shell` of a job or workflow mapping, if declared."""
+    defaults = node.get("defaults")
+    if isinstance(defaults, dict) and isinstance(defaults.get("run"), dict):
+        shell = defaults["run"].get("shell")
+        if isinstance(shell, str) and shell.strip():
+            return shell
+    return None
+
+
+def _exit_zero_can_swallow(step: dict, job: dict, doc: dict) -> bool:
+    """Whether this step's effective shell lets a trailing `exit 0` run.
+
+    Resolution order is GitHub's: the step's `shell:`, then the job's
+    `defaults.run.shell`, then the workflow's, then the runner default —
+    `pwsh` on a `windows-*` runner, `bash -e` everywhere else. An
+    expression or an unrecognised value resolves to errexit-bearing
+    (see `_NO_ERREXIT_SHELLS` above).
+    """
+    raw = step.get("shell")
+    shell = (raw if isinstance(raw, str) and raw.strip()
+             else _defaults_shell(job) or _defaults_shell(doc))
+    if shell:
+        return shell.strip().split()[0].lower() in _NO_ERREXIT_SHELLS
+    runs_on = job.get("runs-on")
+    text = " ".join(str(r) for r in runs_on)         if isinstance(runs_on, list) else str(runs_on)
+    return "${{" not in text and "windows" in text.lower()
+
+
+def _swallow_reason(run: str, exit_zero_live: bool = True) -> str | None:
     """How this block swallows its suite's exit code, or None if it does not.
 
     Scoped to the SUITE line: `grep … || true` sitting beside `pytest` swallows
     the grep, not the tests, and failing the fact on it would be a false
     accusation about a shape that is usually correct.
+
+    ``exit_zero_live`` is `_exit_zero_can_swallow`'s verdict for the step
+    this block came from: the trailing-`exit 0` arm may only fire where the
+    shell would actually reach that `exit 0` after a failure.
     """
     code = _code_lines(run)
     suite_at = [i for i, ln in enumerate(code) if _runs_verification_suite(ln)]
@@ -674,7 +719,7 @@ def _swallow_reason(run: str) -> str | None:
     # — `npm test; exit 0` is the same discard as the two-line form, and which
     # whitespace separates them is no part of the shape.
     last = code[-1]
-    zero = _EXIT_ZERO.search(last)
+    zero = _EXIT_ZERO.search(last) if exit_zero_live else None
     if zero and (suite_at[0] < len(code) - 1
                  or _runs_verification_suite(last[:zero.start()])):
         return "exit 0"
@@ -798,7 +843,8 @@ def _suite_failure_swallowed(rel: str,
             if _continue_on_error_is_literally_true(step):
                 offences.append(f"{where} — `continue-on-error: true`")
                 continue
-            reason = _swallow_reason(run)
+            reason = _swallow_reason(
+                run, exit_zero_live=_exit_zero_can_swallow(step, job, doc))
             if reason:
                 offences.append(f"{where} — `{reason}`")
         if job_runs_suite and _continue_on_error_is_literally_true(job):

--- a/skills/ci-secure/scripts/config_facts.py
+++ b/skills/ci-secure/scripts/config_facts.py
@@ -645,6 +645,19 @@ _RESTORES_ERREXIT = re.compile(r"^set\s+-[a-z]*e[a-z]*\b")
 _SEGMENT_SPLIT = re.compile(r"\|\||&&|[;|]")
 
 
+# `echo "exit code was $?"` reports the status; it does not re-raise it.
+# Counting a mention as a rescue certifies a job that still exits zero, so a
+# `$?` that appears only inside a reporting command does not count.
+_REPORTS_ONLY = re.compile(r"^(?:echo|printf)\b")
+
+
+def _reraises_status(text: str) -> bool:
+    """Whether any COMMAND in this text re-raises a failure."""
+    return any(_RERAISES_STATUS.search(seg)
+               for seg in _SEGMENT_SPLIT.split(text)
+               if not _REPORTS_ONLY.match(_command_head(seg)))
+
+
 def _runs_verification_suite(line: str) -> bool:
     """True when one COMMAND on this line runs a suite.
 
@@ -715,6 +728,19 @@ def _exit_zero_can_swallow(step: dict, job: dict, doc: dict) -> bool:
     return "${{" not in text and "windows" in text.lower()
 
 
+def _restored_before_the_suite_on_one_line(line: str) -> bool:
+    """`set -e` sits between the `set +e` and the suite, all on one line."""
+    segments = _SEGMENT_SPLIT.split(line)
+    suite_at = next(
+        (k for k, seg in enumerate(segments)
+         if _VERIFICATION_RE.match(_command_head(seg))
+         and not _MENTIONS_BUT_DOES_NOT_RUN.search(seg)), None)
+    if suite_at is None:
+        return False
+    return any(_RESTORES_ERREXIT.match(seg.strip())
+               for seg in segments[:suite_at])
+
+
 def _swallow_reason(run: str, exit_zero_live: bool = True) -> str | None:
     """How this block swallows its suite's exit code, or None if it does not.
 
@@ -732,7 +758,7 @@ def _swallow_reason(run: str, exit_zero_live: bool = True) -> str | None:
         return None
 
     def rescued_from(index: int) -> bool:
-        return any(_RERAISES_STATUS.search(ln) for ln in code[index:])
+        return any(_reraises_status(ln) for ln in code[index:])
 
     for i in suite_at:
         line = code[i]
@@ -747,7 +773,7 @@ def _swallow_reason(run: str, exit_zero_live: bool = True) -> str | None:
             shown = shown or re.sub(r"\s+", " ", match.group(0).strip())
             # The rest of the SAME line counts too: `… || { echo …; exit 1; }`
             # reports the failure and still fails the job.
-            if _RERAISES_STATUS.search(line[match.end():]):
+            if _reraises_status(line[match.end():]):
                 continue
             if rescued_from(i + 1):
                 continue
@@ -776,7 +802,14 @@ def _swallow_reason(run: str, exit_zero_live: bool = True) -> str | None:
         # A rescue on that shared line counts too — `set +e; pytest; rc=$?;
         # exit $rc` re-raises the status it captured — so the same-line
         # remainder is searched before the lines below it.
-        if not after or _RERAISES_STATUS.search(line) or rescued_from(i + 1):
+        if not after or _reraises_status(line) or rescued_from(i + 1):
+            continue
+        # Where the relaxation and the suite share a line, the restore between
+        # them shares it too, and a slice of LINES between them is empty. Read
+        # that line's own segments in order instead: `set +e; set -e; pytest`
+        # puts errexit back before the suite runs, and failing it would red a
+        # correctly wired suite.
+        if after[0] == i and _restored_before_the_suite_on_one_line(line):
             continue
         # `set -e` restored BEFORE the suite runs puts the suite back under
         # `errexit`, so its failure still fails the job. Restored after, it

--- a/skills/ci-secure/scripts/config_facts.py
+++ b/skills/ci-secure/scripts/config_facts.py
@@ -576,9 +576,45 @@ _VERIFICATION_RE = re.compile("|".join(_VERIFICATION_CMDS))
 # `&&` chain) is therefore missed rather than guessed at.
 _MENTIONS_BUT_DOES_NOT_RUN = re.compile(
     r"\b(?:pip3?|uv|pipx|npm|pnpm|yarn|bun|apt|apt-get|brew|gem|go|cargo|"
-    r"dotnet|conda|poetry|asdf)\s+(?:pip\s+)?(?:install|add|get)\b"
+    r"dotnet|conda|poetry|asdf)\s+(?:pip\s+)?(?:install|add|get|i)\b"
+    r"|\bnpx\s+\S+\s+install\b"
+    r"|\b(?:playwright|puppeteer|cypress)\s+install\b"
     r"|\b(?:cat|echo|ls|rm|cp|mv|head|tail|touch|grep|sed|awk|which|"
     r"printf)\b")
+
+# A suite is a COMMAND, not a word. `docker pull ghcr.io/org/mypy:latest`,
+# `pkill -f karma`, `tar czf out.tgz .tox`, `gh pr comment --body "eslint
+# found 3 issues"` and `git checkout -- jest.config.js` all carry a name from
+# the allowlist in an image tag, a process pattern, a directory, a message
+# body and a filename respectively. Searching the whole segment read every
+# one of them as a test run and failed the fact on repositories whose tests
+# are perfectly fatal — the false accusation this fact exists to avoid, and
+# the one direction its own scope statement rules out. So the allowlist is
+# anchored to the head of the command instead.
+#
+# What may still precede the command, because it does not change what is
+# being run: environment assignments, privilege and timing wrappers, and the
+# interpreter runners that are how a suite is normally invoked in the first
+# place (`python -m pytest`, `poetry run pytest`, `uv run pytest`).
+_COMMAND_PREFIXES = (
+    r"[A-Za-z_][A-Za-z0-9_]*=\S*",
+    r"sudo(?:\s+-\S+)*", r"command", r"exec", r"nice(?:\s+-n\s*-?\d+)?",
+    r"env(?:\s+[A-Za-z_][A-Za-z0-9_]*=\S*)*",
+    r"time", r"timeout\s+\S+", r"xvfb-run(?:\s+-a)?", r"retry(?:\s+-\S+)*",
+    r"(?:python3?|py)\s+-m", r"poetry\s+run", r"pipenv\s+run",
+    r"(?:uv|pdm|hatch|rye)\s+run", r"conda\s+run(?:\s+-n\s+\S+)?",
+    r"(?:pnpm|npm)\s+exec", r"yarn\s+dlx", r"bun\s+x",
+)
+_SEGMENT_LEAD = re.compile(r"^\s*(?:(?:%s)\s+)*" % "|".join(_COMMAND_PREFIXES))
+# A leading path is part of how the command is spelled, not part of its name:
+# `./mvnw test`, `bin/rspec`, `/usr/bin/pytest`.
+_PATH_PREFIX = re.compile(r"^(?:\.{0,2}/)?(?:[\w.-]+/)*")
+
+
+def _command_head(segment: str) -> str:
+    """The segment reduced to the command it actually runs."""
+    head = segment[_SEGMENT_LEAD.match(segment).end():]
+    return head[_PATH_PREFIX.match(head).end():]
 
 # The swallow shapes. Each leaves the shell's last exit status at 0 for a
 # command that failed, so the step — and with it the job, and with it the
@@ -586,7 +622,11 @@ _MENTIONS_BUT_DOES_NOT_RUN = re.compile(
 # `#` terminates the `:` arm alongside `;&|)}`: the form this shape is actually
 # written in carries the author's reason on the same line — `pytest || :  #
 # tolerate flakes` — and a comment ends the command exactly as those do.
-_SWALLOW_OR_TRUE = re.compile(r"\|\|\s*(?:true\b|:(?=\s*(?:$|[;&|)}#])))")
+# `|| exit 0` states the discard outright and was the one shape certified as
+# a clean bill; `/bin/true` is `true` by absolute path.
+_SWALLOW_OR_TRUE = re.compile(
+    r"\|\|\s*(?:(?:/(?:usr/)?bin/)?true\b|exit\s+0\b"
+    r"|:(?=\s*(?:$|[;&|)}#])))")
 _SWALLOW_OR_ECHO = re.compile(r"\|\|\s*echo\b")
 _EXIT_ZERO = re.compile(r"(?:^|;)\s*exit\s+0\s*(?:#.*)?$")
 _RELAX_ERREXIT = re.compile(r"^set\s+\+[a-z]*e[a-z]*\b")
@@ -613,7 +653,7 @@ def _runs_verification_suite(line: str) -> bool:
     beside it, and the `tox.ini` in `cat tox.ini` must not be read as a run
     just because the line also ends in `|| true`.
     """
-    return any(_VERIFICATION_RE.search(part)
+    return any(_VERIFICATION_RE.match(_command_head(part))
                and not _MENTIONS_BUT_DOES_NOT_RUN.search(part)
                for part in _SEGMENT_SPLIT.split(line))
 
@@ -704,8 +744,7 @@ def _swallow_reason(run: str, exit_zero_live: bool = True) -> str | None:
             # Quote the shape that is actually in the file: a maintainer told
             # their workflow says `|| true` will grep for a string it does not
             # contain.
-            shown = shown or ("|| :" if match.group(0).rstrip().endswith(":")
-                              else "|| true")
+            shown = shown or re.sub(r"\s+", " ", match.group(0).strip())
             # The rest of the SAME line counts too: `… || { echo …; exit 1; }`
             # reports the failure and still fails the job.
             if _RERAISES_STATUS.search(line[match.end():]):
@@ -761,8 +800,13 @@ def _continue_on_error_is_literally_true(node: dict) -> bool:
                              and value.strip().lower() == "true")
 
 
+# `workflow_call` is in the set because a called workflow reports its job
+# status into the calling pull-request run: it is where a large repository
+# usually keeps its suite. Leaving it out did not merely miss those repos, it
+# dropped them out of the denominator entirely — certifying, by silence, the
+# exact gate this fact describes.
 _GATE_TRIGGERS = frozenset({"pull_request", "pull_request_target", "push",
-                            "merge_group"})
+                            "merge_group", "workflow_call"})
 
 
 def _can_report_on_a_pull_request(doc: dict) -> bool:
@@ -786,7 +830,8 @@ def _can_report_on_a_pull_request(doc: dict) -> bool:
 
 
 _DISCARDS_A_STATUS = re.compile(
-    r"\|\|\s*(?:true\b|:(?=\s*(?:$|[;&|)}]))|echo\b)"
+    r"\|\|\s*(?:(?:/(?:usr/)?bin/)?true\b|exit\s+0\b"
+    r"|:(?=\s*(?:$|[;&|)}]))|echo\b)"
     r"|(?:^|;)\s*exit\s+0\s*(?:#.*)?$|^set\s+\+[a-z]*e[a-z]*\b",
     re.MULTILINE)
 

--- a/skills/ci-secure/scripts/config_facts.py
+++ b/skills/ci-secure/scripts/config_facts.py
@@ -684,8 +684,15 @@ def _swallow_reason(run: str) -> str | None:
     for i, line in enumerate(code):
         if not _RELAX_ERREXIT.match(line):
             continue
-        after = [j for j in suite_at if j > i]
-        if not after or rescued_from(i + 1):
+        # `>= i`, not `> i`: `set +e; pytest -q` puts both on one line and so
+        # at one index. `_RELAX_ERREXIT` is anchored to the start of the line,
+        # so where the two share an index the relaxation is necessarily the
+        # earlier command and the suite runs under it.
+        after = [j for j in suite_at if j >= i]
+        # A rescue on that shared line counts too — `set +e; pytest; rc=$?;
+        # exit $rc` re-raises the status it captured — so the same-line
+        # remainder is searched before the lines below it.
+        if not after or _RERAISES_STATUS.search(line) or rescued_from(i + 1):
             continue
         # `set -e` restored BEFORE the suite runs puts the suite back under
         # `errexit`, so its failure still fails the job. Restored after, it

--- a/skills/ci-secure/scripts/config_facts.py
+++ b/skills/ci-secure/scripts/config_facts.py
@@ -14,7 +14,7 @@ of ci-score's check ids. The one near-collision the review found is handled by
 construction: ci-score's `ci.security.scoped-id-token` owns `id-token:` scoping,
 so the per-job-scoping fact here covers permissions OTHER than `id-token` only.
 
-THE EIGHT FACTS
+THE FACTS
 
   F1 sec.permissions.workflow-declares    every workflow declares `permissions:`
                                           (top level, or on every job)
@@ -35,6 +35,9 @@ THE EIGHT FACTS
                                           (API-gated)
   F8 sec.fork-approval.effective          fork-PR CI approval gates more than
                                           accounts new to GitHub (API-gated)
+  F9 sec.gate.test-failure-fatal          no job that runs the test/lint suite
+                                          swallows its own exit code (n/a when
+                                          no workflow runs one)
 
 F7 and F8 read the GitHub API, not workflow YAML, so they are TOKEN-GATED: no
 repo or no token means UNMEASURED with the reason stated — the same contract
@@ -51,7 +54,7 @@ this number. P14.9's own docstring reserves the middle tier for exactly this
 fact ("the bare trigger without the head checkout ... belongs to the scored
 config checks").
 
-WHAT IS NEVER A SILENT PASS. Facts F1/F2/F4/F5/F6/F7 are universal claims
+WHAT IS NEVER A SILENT PASS. Facts F1/F2/F4/F5/F6/F7/F9 are universal claims
 over
 every workflow file, so ANY unscannable workflow (`scan_incomplete`) forces
 them to UNMEASURED — no pass, no fail, a stated reason, and they stay in the
@@ -519,6 +522,197 @@ def _unpersisted_checkout_violations(doc: dict) -> list[str]:
                 out.append(name)
                 break
     return out
+
+
+# --- F9: a verification suite whose failure cannot fail its job --------------
+#
+# The sibling of `sec.required-checks.skippable`. That fact catches a required
+# check that reports green because the job was SKIPPED; this one catches a
+# check that RAN and reports green whatever the suite did. Same consequence —
+# the merge gate is decorative — and the same fix shape: let the failure reach
+# the job's exit status.
+#
+# ALLOWLIST, NOT A HEURISTIC. Only a `run:` line this list recognises as a
+# test, lint, or build-verification suite can fail the fact. Two consequences,
+# both deliberate:
+#
+#   * a `run:` block the list does not recognise (`./scripts/ci.sh || true`) is
+#     never failed. It may be swallowing a suite or a cleanup, and the YAML
+#     cannot say which — accusing a stranger's repo on a guess is worse than
+#     missing a case, especially for a fact that feeds a published score;
+#   * `continue-on-error: true` on an UPLOAD, REPORT, or NOTIFICATION step —
+#     codecov, upload-artifact, upload-sarif, a Slack curl — is EXEMPT by
+#     construction, because no such step runs a suite. Non-fatal reporting
+#     steps are a speed and reliability question another engine already owns;
+#     reporting them here too would bill one configuration to two engines.
+_VERIFICATION_CMDS = (
+    r"pytest\b", r"py\.test\b", r"\btox\b", r"\bnox\b", r"pre-commit\s+run\b",
+    r"\b(?:npm|pnpm|yarn|bun)\s+(?:run\s+)?(?:test|lint|typecheck|check)\b",
+    r"\bnpx\s+(?:jest|vitest|eslint|playwright|tsc)\b",
+    r"\b(?:jest|vitest|mocha|karma)\b",
+    r"\bplaywright\s+test\b", r"\bcypress\s+run\b",
+    r"\bgo\s+(?:test|vet)\b", r"\bgolangci-lint\s+run\b",
+    r"\bcargo\s+(?:test|clippy)\b",
+    r"\bmvnw?\b[^|&;]*\s(?:test|verify)\b",
+    r"\bgradlew?\b[^|&;]*\s(?:test|check)\b",
+    r"\bdotnet\s+test\b", r"\bswift\s+test\b", r"\bctest\b",
+    r"\bbazel\s+test\b",
+    r"\b(?:bundle\s+exec\s+)?(?:rspec|rubocop)\b",
+    r"\brake\s+(?:test|spec)\b",
+    r"\bphpunit\b", r"\bcomposer\s+(?:test|lint)\b",
+    r"\bmake\s+[^|&;]*\b(?:test|tests|lint|check|checks|verify)\b",
+    r"\b(?:ruff|flake8|pylint|mypy|pyright|eslint|stylelint|shellcheck|"
+    r"hadolint|actionlint|tflint)\b",
+    r"\bblack\b[^|&;]*--check\b",
+)
+_VERIFICATION_RE = re.compile("|".join(_VERIFICATION_CMDS))
+
+# Commands that MENTION a suite without running one. `pip install pytest || true`
+# and `cat tox.ini || true` both carry a name from the list above, and neither
+# swallows a test result — the first tolerates a failed install, the second a
+# missing file. Reading them as suite runs would fail the fact on a repository
+# whose tests are perfectly fatal, which is the false accusation this fact is
+# built to avoid. A line that both installs and runs (rare, and usually a
+# `&&` chain) is therefore missed rather than guessed at.
+_MENTIONS_BUT_DOES_NOT_RUN = re.compile(
+    r"\b(?:pip3?|uv|pipx|npm|pnpm|yarn|bun|apt|apt-get|brew|gem|go|cargo|"
+    r"dotnet|conda|poetry|asdf)\s+(?:pip\s+)?(?:install|add|get)\b"
+    r"|\b(?:cat|echo|ls|rm|cp|mv|head|tail|touch|grep|sed|awk|which|"
+    r"printf)\b")
+
+# The swallow shapes. Each leaves the shell's last exit status at 0 for a
+# command that failed, so the step — and with it the job, and with it the
+# required check — reports success.
+_SWALLOW_OR_TRUE = re.compile(r"\|\|\s*(?:true\b|:(?=\s*(?:$|[;&|)}])))")
+_SWALLOW_OR_ECHO = re.compile(r"\|\|\s*echo\b")
+_EXIT_ZERO = re.compile(r"(?:^|;)\s*exit\s+0\s*$")
+_RELAX_ERREXIT = re.compile(r"^set\s+\+[a-z]*e[a-z]*\b")
+# What RESCUES a swallow: the block still re-raises a failure afterwards.
+# `exit 1`, `exit $rc`, a restored `set -e`, or any read of `$?` means the
+# author kept a path to a non-zero exit, and this fact does not second-guess
+# it — the shapes below are the ones with no such path left.
+_RERAISES_FAILURE = re.compile(
+    r"""\$\?|\bexit\s+(?:[1-9]|\$|["']\$)|^set\s+-[a-z]*e[a-z]*\b""")
+
+
+_SEGMENT_SPLIT = re.compile(r"\|\||&&|[;|]")
+
+
+def _runs_verification_suite(line: str) -> bool:
+    """True when one COMMAND on this line runs a suite.
+
+    Segment by segment, because a line is usually several commands: the
+    `echo` in `go test ./... || echo failed` must not clear the `go test`
+    beside it, and the `tox.ini` in `cat tox.ini` must not be read as a run
+    just because the line also ends in `|| true`.
+    """
+    return any(_VERIFICATION_RE.search(part)
+               and not _MENTIONS_BUT_DOES_NOT_RUN.search(part)
+               for part in _SEGMENT_SPLIT.split(line))
+
+
+def _block_runs_verification_suite(run: str) -> bool:
+    """Whether ANY executable line of a `run:` block runs a suite.
+
+    Line by line, never over the joined text: the exclusions above are
+    line-scoped, so an `echo` on one line would otherwise clear the `pytest`
+    on the next.
+    """
+    return any(_runs_verification_suite(ln) for ln in _code_lines(run))
+
+
+def _code_lines(run: str) -> list[str]:
+    """Executable lines of a `run:` block — comments and blanks dropped."""
+    return [ln.strip() for ln in run.splitlines()
+            if ln.strip() and not ln.strip().startswith("#")]
+
+
+def _swallow_reason(run: str) -> str | None:
+    """How this block swallows its suite's exit code, or None if it does not.
+
+    Scoped to the SUITE line: `grep … || true` sitting beside `pytest` swallows
+    the grep, not the tests, and failing the fact on it would be a false
+    accusation about a shape that is usually correct.
+    """
+    code = _code_lines(run)
+    suite_at = [i for i, ln in enumerate(code) if _runs_verification_suite(ln)]
+    if not suite_at:
+        return None
+
+    def rescued_from(index: int) -> bool:
+        return any(_RERAISES_FAILURE.search(ln) for ln in code[index:])
+
+    for i in suite_at:
+        line = code[i]
+        for pattern, shown in ((_SWALLOW_OR_TRUE, "|| true"),
+                               (_SWALLOW_OR_ECHO, "|| echo")):
+            match = pattern.search(line)
+            if not match:
+                continue
+            # The rest of the SAME line counts too: `… || { echo …; exit 1; }`
+            # reports the failure and still fails the job.
+            if _RERAISES_FAILURE.search(line[match.end():]):
+                continue
+            if rescued_from(i + 1):
+                continue
+            return shown
+
+    # `exit 0` as the block's last word: everything above it, suite included,
+    # is discarded.
+    if _EXIT_ZERO.search(code[-1]) and suite_at[0] < len(code) - 1:
+        return "exit 0"
+
+    # `set +e` before the suite, and nothing afterwards that re-raises the
+    # status it stopped enforcing.
+    for i, line in enumerate(code):
+        if not _RELAX_ERREXIT.match(line):
+            continue
+        if any(j > i for j in suite_at) and not rescued_from(i + 1):
+            return "set +e"
+    return None
+
+
+def _continue_on_error_is_literally_true(node: dict) -> bool:
+    """A literal `true` only.
+
+    `continue-on-error: ${{ matrix.experimental }}` is true on some matrix legs
+    and false on others, and the YAML cannot say which — an expression is
+    therefore not judged. GitHub also accepts the quoted string, which parses
+    as a str and means the same thing, so that counts.
+    """
+    value = node.get("continue-on-error")
+    return value is True or (isinstance(value, str)
+                             and value.strip().lower() == "true")
+
+
+def _suite_failure_swallowed(rel: str, doc: dict) -> tuple[list[str], bool]:
+    """(offences, whether this workflow runs any verification suite at all)."""
+    offences: list[str] = []
+    saw_suite = False
+    for job_name, job in _jobs(doc):
+        steps = job.get("steps")
+        if not isinstance(steps, list):
+            continue
+        job_runs_suite = False
+        for position, step in enumerate(steps, 1):
+            if not isinstance(step, dict):
+                continue
+            run = step.get("run")
+            if not isinstance(run, str) or \
+                    not _block_runs_verification_suite(run):
+                continue
+            job_runs_suite = saw_suite = True
+            where = f"{rel}: job `{job_name}` step {position}"
+            if _continue_on_error_is_literally_true(step):
+                offences.append(f"{where} — `continue-on-error: true`")
+                continue
+            reason = _swallow_reason(run)
+            if reason:
+                offences.append(f"{where} — `{reason}`")
+        if job_runs_suite and _continue_on_error_is_literally_true(job):
+            offences.append(f"{rel}: job `{job_name}` — job-level "
+                            "`continue-on-error: true`")
+    return offences, saw_suite
 
 
 # --- F7: required checks that a job can skip ---------------------------------
@@ -1505,6 +1699,31 @@ def compute_config_facts(
         "repo passes)",
         False, fa_outcome == "pass", fa_evidence, outcome=fa_outcome)
 
+    swallowed: list[str] = []
+    any_suite = False
+    for rel, doc in docs:
+        offences, saw_suite = _suite_failure_swallowed(rel, doc)
+        swallowed += offences
+        any_suite = any_suite or saw_suite
+    add("sec.gate.test-failure-fatal",
+        "no job that runs the test or lint suite swallows its own exit code "
+        "(a suite whose failure cannot fail its job leaves the merge gate "
+        "green whatever the tests did)",
+        True, not swallowed,
+        (_capped(swallowed, 4) if swallowed else
+         ("no test or lint step discards its exit status" if any_suite else
+          "not applicable: no workflow step runs a test, lint, or "
+          "build-verification suite this scan recognises, so there is no "
+          "exit code to swallow")),
+        # Applicability, following the shape ci-score's test-sharding check
+        # uses: a repository whose workflows run no recognised suite has
+        # nothing to swallow. That is NOT a pass — a free green for having no
+        # tests would reward the very absence the fact is about — and it is
+        # not unmeasured either, which claims a coverage gap where there is
+        # none. It leaves the denominator, exactly as an n/a check does in
+        # ci-score.
+        outcome=None if any_suite else "not_applicable")
+
     add("sec.checkout.credentials-scoped",
         "on untrusted-trigger workflows, every checkout sets "
         "persist-credentials: false (GitHub's default persists the token into "
@@ -1527,14 +1746,24 @@ def facts_to_score(facts: list[dict[str, Any]]) -> dict[str, Any]:
     """
     scored = [f for f in facts if f["outcome"] in ("pass", "fail")]
     unmeasured = [f["fact_id"] for f in facts if f["outcome"] == "unmeasured"]
+    # NOT APPLICABLE IS NOT A COVERAGE GAP. An unmeasured fact stays in the
+    # applicable count as a named gap ("this could not be checked"); a fact
+    # that does not apply to this repository ("there is nothing here to
+    # check") leaves the count entirely, the same treatment ci-score gives an
+    # n/a check. Collapsing the two would either invent a gap or hand out a
+    # free pass, and both distort the aggregate ci-advisor blends.
+    not_applicable = [f["fact_id"] for f in facts
+                      if f["outcome"] == "not_applicable"]
+    applicable = [f for f in facts if f["outcome"] != "not_applicable"]
     passed = sum(1 for f in scored if f["outcome"] == "pass")
     out: dict[str, Any] = {
         "facts": facts,
         "score": round(100.0 * passed / len(scored), 1) if scored else None,
         "passed": passed,
         "scored_count": len(scored),
-        "applicable_count": len(facts),
+        "applicable_count": len(applicable),
         "unmeasured": unmeasured,
+        "not_applicable": not_applicable,
         "constants": {"rule": "100 * passed / scored; pass/fail only, "
                               "no weights, no partial credit"},
         "registered": REGISTERED,
@@ -1552,5 +1781,5 @@ def facts_to_score(facts: list[dict[str, Any]]) -> dict[str, Any]:
         out["caveat"] = (
             "scored over %d of %d applicable facts: %s could not be "
             "measured; this is a COVERAGE GAP, not a clean result"
-            % (len(scored), len(facts), ", ".join(unmeasured)))
+            % (len(scored), len(applicable), ", ".join(unmeasured)))
     return out

--- a/skills/ci-secure/scripts/config_facts.py
+++ b/skills/ci-secure/scripts/config_facts.py
@@ -596,7 +596,16 @@ _MENTIONS_BUT_DOES_NOT_RUN = re.compile(
 # being run: environment assignments, privilege and timing wrappers, and the
 # interpreter runners that are how a suite is normally invoked in the first
 # place (`python -m pytest`, `poetry run pytest`, `uv run pytest`).
-_COMMAND_PREFIXES = (
+# Shell KEYWORDS belong on that list too. `if ! pytest -q; then`, `while …`
+# and `for m in $MODULES; do pytest` all run the suite; the keyword in front
+# of it is grammar, not the command being run. Anchoring the allowlist to the
+# head of the segment without them stopped recognising a suite written inside
+# a conditional or a loop at all — and a suite the scan cannot see takes the
+# whole repository out of this fact's denominator as NOT APPLICABLE, which is
+# a silent loss of coverage rather than a miss on one line.
+_SHELL_KEYWORDS = (r"if", r"then", r"else", r"elif", r"do", r"while",
+                   r"until", r"!")
+_COMMAND_PREFIXES = _SHELL_KEYWORDS + (
     r"[A-Za-z_][A-Za-z0-9_]*=\S*",
     r"sudo(?:\s+-\S+)*", r"command", r"exec", r"nice(?:\s+-n\s*-?\d+)?",
     r"env(?:\s+[A-Za-z_][A-Za-z0-9_]*=\S*)*",
@@ -682,9 +691,32 @@ def _block_runs_verification_suite(run: str) -> bool:
 
 
 def _code_lines(run: str) -> list[str]:
-    """Executable lines of a `run:` block — comments and blanks dropped."""
-    return [ln.strip() for ln in run.splitlines()
-            if ln.strip() and not ln.strip().startswith("#")]
+    """Executable lines of a `run:` block — comments, blanks and here-doc
+    bodies dropped.
+
+    A here-doc body is TEXT ON ITS WAY TO A FILE, not shell the step runs:
+    `cat > run.sh <<'EOF' … pytest -q || true … EOF` writes a wrapper script,
+    and reading its body as executable failed the fact on a job whose own
+    suite is perfectly fatal — the false accusation this fact's scope rules
+    out. The opener line itself stays (it is a real command); the body and its
+    closing delimiter go. Delimiter recognition is the scan module's, quote
+    aware and `<<<`-safe, rather than a second regex here that could drift
+    from it.
+    """
+    delimiter = _scan()._heredoc_delimiter
+    lines: list[str] = []
+    ends: str | None = None
+    for raw in run.splitlines():
+        line = raw.strip()
+        if ends is not None:
+            if line == ends:
+                ends = None
+            continue
+        if not line or line.startswith("#"):
+            continue
+        lines.append(line)
+        ends = delimiter(line)
+    return lines
 
 
 # Shells with no errexit: a trailing `exit 0` after a failed command really

--- a/skills/ci-secure/scripts/config_facts.py
+++ b/skills/ci-secure/scripts/config_facts.py
@@ -585,14 +585,18 @@ _MENTIONS_BUT_DOES_NOT_RUN = re.compile(
 # required check — reports success.
 _SWALLOW_OR_TRUE = re.compile(r"\|\|\s*(?:true\b|:(?=\s*(?:$|[;&|)}])))")
 _SWALLOW_OR_ECHO = re.compile(r"\|\|\s*echo\b")
-_EXIT_ZERO = re.compile(r"(?:^|;)\s*exit\s+0\s*$")
+_EXIT_ZERO = re.compile(r"(?:^|;)\s*exit\s+0\s*(?:#.*)?$")
 _RELAX_ERREXIT = re.compile(r"^set\s+\+[a-z]*e[a-z]*\b")
 # What RESCUES a swallow: the block still re-raises a failure afterwards.
-# `exit 1`, `exit $rc`, a restored `set -e`, or any read of `$?` means the
-# author kept a path to a non-zero exit, and this fact does not second-guess
-# it — the shapes below are the ones with no such path left.
-_RERAISES_FAILURE = re.compile(
-    r"""\$\?|\bexit\s+(?:[1-9]|\$|["']\$)|^set\s+-[a-z]*e[a-z]*\b""")
+# `exit 1`, `exit $rc`, or any read of `$?` means the author kept a path to a
+# non-zero exit — a junit report parsed after a tolerated run is the common
+# case — and this fact does not second-guess it.
+_RERAISES_STATUS = re.compile(
+    r"""\$\?|\bexit\s+(?:[1-9]|\$|["']\$)""")
+# Restoring `errexit` is a rescue only where it can still act: `set -e`
+# changes what happens NEXT, so it rescues a suite it PRECEDES and does
+# nothing at all for a failure that already ran and was thrown away.
+_RESTORES_ERREXIT = re.compile(r"^set\s+-[a-z]*e[a-z]*\b")
 
 
 _SEGMENT_SPLIT = re.compile(r"\|\||&&|[;|]")
@@ -640,7 +644,7 @@ def _swallow_reason(run: str) -> str | None:
         return None
 
     def rescued_from(index: int) -> bool:
-        return any(_RERAISES_FAILURE.search(ln) for ln in code[index:])
+        return any(_RERAISES_STATUS.search(ln) for ln in code[index:])
 
     for i in suite_at:
         line = code[i]
@@ -651,7 +655,7 @@ def _swallow_reason(run: str) -> str | None:
                 continue
             # The rest of the SAME line counts too: `… || { echo …; exit 1; }`
             # reports the failure and still fails the job.
-            if _RERAISES_FAILURE.search(line[match.end():]):
+            if _RERAISES_STATUS.search(line[match.end():]):
                 continue
             if rescued_from(i + 1):
                 continue
@@ -667,8 +671,15 @@ def _swallow_reason(run: str) -> str | None:
     for i, line in enumerate(code):
         if not _RELAX_ERREXIT.match(line):
             continue
-        if any(j > i for j in suite_at) and not rescued_from(i + 1):
-            return "set +e"
+        after = [j for j in suite_at if j > i]
+        if not after or rescued_from(i + 1):
+            continue
+        # `set -e` restored BEFORE the suite runs puts the suite back under
+        # `errexit`, so its failure still fails the job. Restored after, it
+        # arrives too late to raise anything.
+        if any(_RESTORES_ERREXIT.match(ln) for ln in code[i + 1:after[0]]):
+            continue
+        return "set +e"
     return None
 
 

--- a/skills/ci-secure/scripts/config_facts.py
+++ b/skills/ci-secure/scripts/config_facts.py
@@ -651,11 +651,16 @@ def _swallow_reason(run: str) -> str | None:
 
     for i in suite_at:
         line = code[i]
-        for pattern, shown in ((_SWALLOW_OR_TRUE, "|| true"),
+        for pattern, shown in ((_SWALLOW_OR_TRUE, None),
                                (_SWALLOW_OR_ECHO, "|| echo")):
             match = pattern.search(line)
             if not match:
                 continue
+            # Quote the shape that is actually in the file: a maintainer told
+            # their workflow says `|| true` will grep for a string it does not
+            # contain.
+            shown = shown or ("|| :" if match.group(0).rstrip().endswith(":")
+                              else "|| true")
             # The rest of the SAME line counts too: `… || { echo …; exit 1; }`
             # reports the failure and still fails the job.
             if _RERAISES_STATUS.search(line[match.end():]):
@@ -664,9 +669,14 @@ def _swallow_reason(run: str) -> str | None:
                 continue
             return shown
 
-    # `exit 0` as the block's last word: everything above it, suite included,
-    # is discarded.
-    if _EXIT_ZERO.search(code[-1]) and suite_at[0] < len(code) - 1:
+    # `exit 0` as the block's last word: everything before it, suite
+    # included, is discarded. "Before" spans the line break AND the semicolon
+    # — `npm test; exit 0` is the same discard as the two-line form, and which
+    # whitespace separates them is no part of the shape.
+    last = code[-1]
+    zero = _EXIT_ZERO.search(last)
+    if zero and (suite_at[0] < len(code) - 1
+                 or _runs_verification_suite(last[:zero.start()])):
         return "exit 0"
 
     # `set +e` before the suite, and nothing afterwards that re-raises the
@@ -699,10 +709,63 @@ def _continue_on_error_is_literally_true(node: dict) -> bool:
                              and value.strip().lower() == "true")
 
 
-def _suite_failure_swallowed(rel: str, doc: dict) -> tuple[list[str], bool]:
-    """(offences, whether this workflow runs any verification suite at all)."""
+_GATE_TRIGGERS = frozenset({"pull_request", "pull_request_target", "push",
+                            "merge_group"})
+
+
+def _can_report_on_a_pull_request(doc: dict) -> bool:
+    """Whether this workflow's jobs can report a check on a pull request.
+
+    F9's claim is about a MERGE GATE that reports green whatever the tests
+    did, so it only holds where a gate exists. A workflow that runs on a
+    schedule, or only when a human dispatches it, reports on no pull request:
+    a deliberately tolerant nightly lint or a manual smoke job is a different
+    — and usually correct — configuration, and failing it would be exactly
+    the false accusation this fact's scope statement rules out.
+
+    An `on:` block this scanner cannot read stays IN scope. Dropping it would
+    turn an unreadable trigger into a silent pass, which is the one direction
+    this engine never trades away.
+    """
+    on = _on_mapping(doc)
+    if on is None:
+        return True
+    return bool({str(k) for k in on} & _GATE_TRIGGERS)
+
+
+_DISCARDS_A_STATUS = re.compile(
+    r"\|\|\s*(?:true\b|:(?=\s*(?:$|[;&|)}]))|echo\b)"
+    r"|(?:^|;)\s*exit\s+0\s*(?:#.*)?$|^set\s+\+[a-z]*e[a-z]*\b",
+    re.MULTILINE)
+
+
+def _discards_a_status(run: str) -> bool:
+    """Any swallow shape at all, whatever the command is.
+
+    Deliberately NOT scoped to the allowlist. It answers a different question
+    from `_swallow_reason`: not "is a suite being swallowed here" but "is
+    something being swallowed here that this scan cannot identify" — which is
+    what separates a coverage gap from a repository with nothing to check.
+    """
+    return any(_DISCARDS_A_STATUS.search(ln) for ln in _code_lines(run))
+
+
+def _suite_failure_swallowed(rel: str,
+                             doc: dict) -> tuple[list[str], bool, list[str]]:
+    """(offences, whether a suite ran at all, unidentifiable discards).
+
+    The third value is the honest-uncertainty channel. A `run:` line the
+    allowlist does not recognise which throws its exit code away — the
+    `bash ci/test.sh || true` shape — has two opposite readings, a swallowed
+    suite and a tolerated cleanup, and the YAML settles neither. What it is
+    NOT is "there is nothing here to check": that verdict asserts no coverage
+    gap exists, on the one shape where one demonstrably does.
+    """
     offences: list[str] = []
+    unidentified: list[str] = []
     saw_suite = False
+    if not _can_report_on_a_pull_request(doc):
+        return offences, saw_suite, unidentified
     for job_name, job in _jobs(doc):
         steps = job.get("steps")
         if not isinstance(steps, list):
@@ -712,11 +775,19 @@ def _suite_failure_swallowed(rel: str, doc: dict) -> tuple[list[str], bool]:
             if not isinstance(step, dict):
                 continue
             run = step.get("run")
-            if not isinstance(run, str) or \
-                    not _block_runs_verification_suite(run):
+            if not isinstance(run, str):
+                continue
+            if not _block_runs_verification_suite(run):
+                if _discards_a_status(run) or \
+                        _continue_on_error_is_literally_true(step):
+                    unidentified.append(
+                        f"{rel}: job `{job_name}` step {position}")
                 continue
             job_runs_suite = saw_suite = True
             where = f"{rel}: job `{job_name}` step {position}"
+            label = step.get("name")
+            if isinstance(label, str) and label.strip():
+                where += f" (`{label.strip()}`)"
             if _continue_on_error_is_literally_true(step):
                 offences.append(f"{where} — `continue-on-error: true`")
                 continue
@@ -726,7 +797,7 @@ def _suite_failure_swallowed(rel: str, doc: dict) -> tuple[list[str], bool]:
         if job_runs_suite and _continue_on_error_is_literally_true(job):
             offences.append(f"{rel}: job `{job_name}` — job-level "
                             "`continue-on-error: true`")
-    return offences, saw_suite
+    return offences, saw_suite, unidentified
 
 
 # --- F7: required checks that a job can skip ---------------------------------
@@ -1715,20 +1786,34 @@ def compute_config_facts(
 
     swallowed: list[str] = []
     any_suite = False
+    unidentified: list[str] = []
     for rel, doc in docs:
-        offences, saw_suite = _suite_failure_swallowed(rel, doc)
+        offences, saw_suite, unknown = _suite_failure_swallowed(rel, doc)
         swallowed += offences
         any_suite = any_suite or saw_suite
+        unidentified += unknown
+    # Three ways this fact ends without a verdict, and they are not the same
+    # claim. A suite ran: pass or fail. No suite ran, but something threw a
+    # status away that this scan could not identify: a COVERAGE GAP, named as
+    # one. Nothing ran and nothing was discarded: genuinely not applicable.
+    gap_outcome = ("unmeasured: no recognised test or lint suite, but %d "
+                   "step(s) discard an exit status this scan could not "
+                   "identify (%s) — one of them may be a suite, and this "
+                   "fact cannot tell; a COVERAGE GAP, not a clean result"
+                   % (len(unidentified), _capped(unidentified, 3, "; ")))
     add("sec.gate.test-failure-fatal",
         "no job that runs the test or lint suite swallows its own exit code "
         "(a suite whose failure cannot fail its job leaves the merge gate "
         "green whatever the tests did)",
         True, not swallowed,
         (_capped(swallowed, 4) if swallowed else
-         ("no test or lint step discards its exit status" if any_suite else
-          "not applicable: no workflow step runs a test, lint, or "
-          "build-verification suite this scan recognises, so there is no "
-          "exit code to swallow")),
+         ("no test or lint step this scan recognises discards its exit "
+          "status" if any_suite else
+          gap_outcome if unidentified else
+          "not applicable: no workflow that can report a check on a pull "
+          "request runs a test, lint, or build-verification suite this scan "
+          "recognises, and no step discards an exit status, so there is no "
+          "merge gate here whose result could be thrown away")),
         # Applicability, following the shape ci-score's test-sharding check
         # uses: a repository whose workflows run no recognised suite has
         # nothing to swallow. That is NOT a pass — a free green for having no
@@ -1736,7 +1821,8 @@ def compute_config_facts(
         # not unmeasured either, which claims a coverage gap where there is
         # none. It leaves the denominator, exactly as an n/a check does in
         # ci-score.
-        outcome=None if any_suite else "not_applicable")
+        outcome=(None if any_suite else
+                 "unmeasured" if unidentified else "not_applicable"))
 
     add("sec.checkout.credentials-scoped",
         "on untrusted-trigger workflows, every checkout sets "

--- a/skills/ci-secure/scripts/report.py
+++ b/skills/ci-secure/scripts/report.py
@@ -1613,7 +1613,11 @@ def _chain_status_block(
     return "\n".join(out)
 
 
-_OUTCOME_MARKS = {"pass": "✅ pass", "fail": "❌ fail", "unmeasured": "⚠️ unmeasured"}
+_OUTCOME_MARKS = {"pass": "✅ pass", "fail": "❌ fail",
+                  "unmeasured": "⚠️ unmeasured",
+                  # A fact with nothing to check in this repository. Rendered,
+                  # never dropped: a row that vanishes reads as a pass.
+                  "not_applicable": "➖ n/a"}
 
 
 def _abbreviate_home(path: str) -> str:

--- a/skills/ci-secure/scripts/report.py
+++ b/skills/ci-secure/scripts/report.py
@@ -1723,6 +1723,10 @@ def _security_score_block(security_score: dict[str, Any] | None) -> str:
     # absent one. `or []` / `or {}` turned both into a silent empty and the
     # report rendered as if the producer had simply said "none".
     damaged: list[str] = []
+    raw_not_applicable = security_score.get("not_applicable")
+    not_applicable = (list(raw_not_applicable or [])
+                      if raw_not_applicable is None
+                      or isinstance(raw_not_applicable, list) else [])
     raw_unmeasured = security_score.get("unmeasured")
     if raw_unmeasured is None or isinstance(raw_unmeasured, list):
         unmeasured = list(raw_unmeasured or [])
@@ -1757,6 +1761,19 @@ def _security_score_block(security_score: dict[str, Any] | None) -> str:
             "",
             f"{len(unmeasured)} check(s) could not be measured ({names}) — a "
             "coverage gap, not a pass.",
+        ]
+    if not_applicable:
+        # The other half of the same disclosure. These checks left the
+        # denominator, so the count line will not add up against the rows
+        # above unless the reader is told why — and the reason is the
+        # opposite of the unmeasured one, which is why it gets its own
+        # sentence rather than being folded into that list.
+        names = ", ".join(str(n) for n in not_applicable)
+        out += [
+            "",
+            f"{len(not_applicable)} check(s) do not apply to this repository "
+            f"({names}) — there was nothing here for them to check, which is "
+            "neither a pass nor a gap, so they are left out of the count.",
         ]
     if damaged:
         out += [

--- a/skills/ci-secure/scripts/scan.py
+++ b/skills/ci-secure/scripts/scan.py
@@ -5590,7 +5590,7 @@ def _compute_security_score(
         # which path produced the block — a `constants` KeyError that fires
         # only on the failure path is the worst place to discover the gap.
         return {"facts": [], "score": None, "passed": 0, "scored_count": 0,
-                "applicable_count": 0, "unmeasured": [],
+                "applicable_count": 0, "unmeasured": [], "not_applicable": [],
                 "constants": {"rule": "100 * passed / scored; pass/fail only, "
                                       "no weights, no partial credit"},
                 # `reason` is READER-VISIBLE: report.py prints it in the

--- a/skills/ci-secure/tests/test_config_facts.py
+++ b/skills/ci-secure/tests/test_config_facts.py
@@ -3509,6 +3509,38 @@ def test_merge_group_is_a_gate_trigger(tmp_path):
     assert f["outcome"] == "fail", f["evidence"]
 
 
+def test_errexit_relaxed_and_restored_before_the_suite_on_one_line_passes(
+        tmp_path):
+    """`set +e; set -e; pytest -q` restores errexit BEFORE the suite runs, so
+    the suite is fatal. Ordering by physical line put all three at one index,
+    leaving the restore search an empty slice — and failing a correctly wired
+    suite, which is the direction this fact must never get wrong."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: |\n          set +e; set -e; pytest -q\n")})
+    assert f["outcome"] == "pass", f["evidence"]
+
+
+def test_merely_printing_the_status_does_not_rescue_a_swallowed_suite(
+        tmp_path):
+    """Echoing `$?` reports the status; it does not re-raise it. Counting a
+    mention as a rescue certifies a job that still exits zero."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: |\n          pytest -q || true\n"
+        '          echo "exit code was $?"\n')})
+    assert f["outcome"] == "fail", f["evidence"]
+    assert "|| true" in f["evidence"], f["evidence"]
+
+
+def test_capturing_the_status_and_exiting_it_still_rescues(tmp_path):
+    """The guard against over-correcting: `rc=$?` captures and `exit $rc`
+    re-raises, across lines, and that is a correctly wired suite."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: |\n          set +e\n          pytest -q\n"
+        "          rc=$?\n"
+        '          echo "suite exited $rc"\n          exit $rc\n')})
+    assert f["outcome"] == "pass", f["evidence"]
+
+
 def test_continue_on_error_on_the_test_step_fails(tmp_path):
     f = _fatal(tmp_path, {"ci.yml": _wf(
         "      - run: pytest -q\n        continue-on-error: true\n")})

--- a/skills/ci-secure/tests/test_config_facts.py
+++ b/skills/ci-secure/tests/test_config_facts.py
@@ -3665,3 +3665,38 @@ def test_a_not_applicable_fact_still_renders_a_row(tmp_path):
     assert row is not None, "the not-applicable fact rendered no row at all"
     assert "n/a" in row, row
     assert "pass" not in row and "unmeasured" not in row, row
+
+
+def test_a_heredoc_body_is_written_text_not_a_run(tmp_path):
+    """A step that WRITES a wrapper script is not a step that runs one. The
+    here-doc body is data on its way to a file; reading `pytest -q || true`
+    there as a swallowed suite fails a job whose own suite is fatal — the
+    false-accusation direction this fact refuses to take."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: |\n"
+        "          cat > run.sh <<'EOF'\n"
+        "          pytest -q || true\n"
+        "          EOF\n"
+        "          pytest -q\n")})
+    assert f["outcome"] == "pass", f["evidence"]
+
+
+def test_a_suite_under_a_shell_keyword_still_counts_as_a_suite(tmp_path):
+    """`if ! pytest -q; then …` runs the suite; `if` is a keyword in front of
+    the command, not the command. Missing it hands a repository that tests on
+    every PR the n/a outcome, which quietly removes it from the denominator."""
+    root, files = _repo(tmp_path, {"ci.yml": _wf(
+        "      - run: |\n"
+        "          if ! pytest -q; then echo 'suite failed'; exit 1; fi\n")})
+    out = cf.compute_config_facts(root, files, [])
+    f = _outcome(out, _FATAL)
+    assert f["outcome"] == "pass", f["evidence"]
+    assert _FATAL not in out["not_applicable"]
+
+
+def test_a_swallow_inside_a_loop_body_is_still_a_swallow(tmp_path):
+    """`for … do pytest || true; done` discards every run's status. The `do`
+    in front of the suite is a keyword; it must not hide the swallow."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: for m in a b; do pytest -q; done || true\n")})
+    assert f["outcome"] == "fail", f["evidence"]

--- a/skills/ci-secure/tests/test_config_facts.py
+++ b/skills/ci-secure/tests/test_config_facts.py
@@ -743,8 +743,18 @@ def test_degraded_block_has_the_same_keys_as_a_real_one(tmp_path, monkeypatch):
     degraded = scan._compute_security_score(root, files, [])
 
     assert set(degraded) - {"reason"} <= set(real) | {"caveat"}
+    # And the direction that catches an OMISSION. The subset above only fires
+    # on a key the degraded path invented; a key the real path grew and the
+    # fallback never learned about slips straight through it, which is how a
+    # consumer ends up with a KeyError that fires on the failure path only.
+    # Enumerating names by hand had the same blind spot — the list is the
+    # thing that goes stale — so compare the key sets themselves.
+    assert set(real) - {"caveat"} <= set(degraded) | {"reason"}, (
+        "degraded block is missing %r"
+        % sorted(set(real) - {"caveat"} - set(degraded)))
     for key in ("facts", "score", "passed", "scored_count",
-                "applicable_count", "unmeasured", "constants", "registered"):
+                "applicable_count", "unmeasured", "not_applicable",
+                "constants", "registered"):
         assert key in degraded, f"degraded block is missing {key!r}"
     assert degraded["score"] is None
     # Same reader-visibility rule as facts_to_score: this string is what the
@@ -3225,6 +3235,95 @@ def test_set_plus_e_that_rechecks_the_exit_code_passes(tmp_path):
     assert f["outcome"] == "pass", f["evidence"]
 
 
+def test_a_one_line_suite_then_exit_zero_fails(tmp_path):
+    """`npm test; exit 0` is the two-line shape with a semicolon instead of a
+    newline. The documented shape is "a trailing `exit 0`"; which whitespace
+    separates it from the suite is not part of the claim."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: npm test; exit 0\n")})
+    assert f["outcome"] == "fail", f["evidence"]
+    assert "exit 0" in f["evidence"], f["evidence"]
+
+
+def test_evidence_names_the_step_not_only_its_position(tmp_path):
+    """A step ordinal alone sends the maintainer counting steps by hand, and
+    the Actions UI labels steps by name. The name is in the YAML already."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - name: Unit tests\n        run: pytest -q || true\n")})
+    assert f["outcome"] == "fail", f["evidence"]
+    assert "Unit tests" in f["evidence"], f["evidence"]
+
+
+def test_or_colon_evidence_quotes_the_shape_that_is_in_the_file(tmp_path):
+    """Reporting `|| :` as `|| true` sends the maintainer grepping for a
+    string their workflow does not contain."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        '      - run: "npm run lint || :"\n')})
+    assert f["outcome"] == "fail", f["evidence"]
+    assert "|| :" in f["evidence"], f["evidence"]
+
+
+def test_a_schedule_only_workflow_is_not_a_merge_gate(tmp_path):
+    """This fact's whole claim is about a MERGE GATE reporting green. A
+    nightly job cannot report on a pull request, so a deliberately tolerant
+    nightly lint is not the configuration being described — failing it is the
+    false accusation the fact's own scope statement rules out."""
+    f = _fatal(tmp_path, {"nightly.yml": (
+        "name: nightly\non:\n  schedule:\n    - cron: '0 3 * * *'\n"
+        "permissions:\n  contents: read\njobs:\n  lint:\n"
+        "    runs-on: ubuntu-latest\n    steps:\n"
+        "      - run: npx eslint . --fix || true\n")})
+    assert f["outcome"] == "not_applicable", f["evidence"]
+
+
+def test_a_manual_dispatch_only_workflow_is_not_a_merge_gate(tmp_path):
+    """Same reason: a `workflow_dispatch`-only workflow runs when a human asks
+    it to, and reports on no pull request."""
+    f = _fatal(tmp_path, {"manual.yml": (
+        "name: manual\non:\n  workflow_dispatch:\n"
+        "permissions:\n  contents: read\njobs:\n  smoke:\n"
+        "    runs-on: ubuntu-latest\n    steps:\n"
+        "      - run: pytest tests/smoke.py || true\n")})
+    assert f["outcome"] == "not_applicable", f["evidence"]
+
+
+def test_a_gate_shaped_workflow_beside_a_nightly_one_is_still_judged(tmp_path):
+    """The scope narrowing must not become a way out: a repo whose PR workflow
+    swallows its suite still fails, whatever its nightly workflow does."""
+    f = _fatal(tmp_path, {
+        "nightly.yml": ("name: nightly\non:\n  schedule:\n"
+                        "    - cron: '0 3 * * *'\npermissions:\n"
+                        "  contents: read\njobs:\n  lint:\n"
+                        "    runs-on: ubuntu-latest\n    steps:\n"
+                        "      - run: npx eslint . || true\n"),
+        "ci.yml": _wf("      - run: pytest -q || true\n")})
+    assert f["outcome"] == "fail", f["evidence"]
+    assert "ci.yml" in f["evidence"], f["evidence"]
+    assert "nightly.yml" not in f["evidence"], f["evidence"]
+
+
+def test_an_unrecognised_command_that_swallows_is_a_gap_not_not_applicable(
+        tmp_path):
+    """`bash ci/test.sh || true` is the ambiguous case, and the two honest
+    readings are opposite: a swallowed suite, or a tolerated cleanup. What it
+    is NOT is "there is nothing here to check" — that claims no coverage gap
+    exists, on the one shape where one demonstrably does. It is unmeasured."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: bash ci/test.sh || true\n")})
+    assert f["outcome"] == "unmeasured", f["evidence"]
+    assert "ci.yml" in f["evidence"], f["evidence"]
+
+
+def test_an_unrecognised_command_that_swallows_nothing_stays_not_applicable(
+        tmp_path):
+    """The other side: nothing recognised AND nothing discarded means there
+    genuinely is nothing to check, and calling that a coverage gap would
+    invent one."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: bash ci/deploy.sh\n")})
+    assert f["outcome"] == "not_applicable", f["evidence"]
+
+
 def test_continue_on_error_on_the_test_step_fails(tmp_path):
     f = _fatal(tmp_path, {"ci.yml": _wf(
         "      - run: pytest -q\n        continue-on-error: true\n")})
@@ -3305,7 +3404,8 @@ def test_a_repo_with_no_suite_at_all_is_not_applicable_not_a_pass(tmp_path):
     # The evidence says WHY it does not apply. "no step discards its exit
     # status" would be true and would read as a clean bill for a suite that
     # does not exist.
-    assert "no workflow step runs a test" in f["evidence"], f["evidence"]
+    assert "runs a test" in f["evidence"], f["evidence"]
+    assert "merge gate" in f["evidence"], f["evidence"]
     assert _FATAL in out["not_applicable"]
     assert _FATAL not in out["unmeasured"]
 
@@ -3338,8 +3438,13 @@ def test_a_not_applicable_fact_still_renders_a_row(tmp_path):
         "findings": [], "repo": "x/y", "scanned_workflows": 1,
         "security_score": cf.compute_config_facts(root, files, []),
     })
-    row = next((ln for ln in md.splitlines() if _FATAL in ln
-                or "swallows its own exit code" in ln), None)
+    # The TABLE row specifically. The fact id also appears in the prose line
+    # that discloses the count, and matching that instead would let the row
+    # itself vanish while this test stayed green.
+    row = next((ln for ln in md.splitlines()
+                if ln.startswith("|") and (_FATAL in ln
+                                           or "swallows its own exit code"
+                                           in ln)), None)
     assert row is not None, "the not-applicable fact rendered no row at all"
     assert "n/a" in row, row
     assert "pass" not in row and "unmeasured" not in row, row

--- a/skills/ci-secure/tests/test_config_facts.py
+++ b/skills/ci-secure/tests/test_config_facts.py
@@ -3167,6 +3167,16 @@ def test_or_echo_that_still_exits_nonzero_passes(tmp_path):
     assert f["outcome"] == "pass", f["evidence"]
 
 
+def test_or_echo_then_a_same_line_exit_one_passes(tmp_path):
+    """The same-line rescue, on a shape that actually reaches it. The sibling
+    test above uses `|| { echo …; exit 1; }`, which no swallow pattern matches
+    at all, so it never exercises this branch. `|| echo "failed"; exit 1`
+    does: the swallow fires, and the rest of the same line re-raises."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        '      - run: pytest -q || echo "failed"; exit 1\n')})
+    assert f["outcome"] == "pass", f["evidence"]
+
+
 def test_trailing_exit_zero_after_the_suite_fails_where_no_errexit(tmp_path):
     """On a step whose shell has no errexit — `pwsh`, `powershell`, `cmd` —
     a trailing `exit 0` really does run after a failed suite and discards
@@ -3407,6 +3417,96 @@ def test_an_unrecognised_command_that_swallows_nothing_stays_not_applicable(
     f = _fatal(tmp_path, {"ci.yml": _wf(
         "      - run: bash ci/deploy.sh\n")})
     assert f["outcome"] == "not_applicable", f["evidence"]
+
+
+# The false-accusation battery. Every line below is ordinary GitHub Actions
+# YAML that names a suite tool WITHOUT running one — in a path, an image tag,
+# a message body, a filename, a process pattern, or an install argument. The
+# fact's own scope statement says a false accusation against a stranger's
+# repository costs more than a miss, so each of these must stay green.
+_NOT_A_SUITE = {
+    "browser deps install": "npx playwright install --with-deps || true",
+    "chat notification naming the suite":
+        'curl -X POST -d \'{"text":"pytest failed"}\' "$SLACK" || true',
+    "npm i shorthand": "npm i -D jest || true",
+    "image tag containing a tool name":
+        "docker pull ghcr.io/org/mypy:latest || true",
+    "a message body quoting a tool":
+        'gh pr comment 1 --body "eslint found 3 issues" || true',
+    "a directory named after a tool": "tar czf out.tgz .tox || true",
+    "a process pattern naming a tool": "pkill -f karma || true",
+    "making a tool's cache directory": "mkdir -p .tox || true",
+    "restoring a config file": "git checkout -- jest.config.js || true",
+}
+
+
+@pytest.mark.parametrize("label", sorted(_NOT_A_SUITE))
+def test_naming_a_suite_tool_is_not_running_one(tmp_path, label):
+    """A tool name in an argument is not a suite. Reading it as one fails the
+    check on a repository whose tests are perfectly fatal — the exact false
+    accusation this fact is built to avoid."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        f"      - run: {_NOT_A_SUITE[label]}\n"
+        "      - run: pytest -q\n")})
+    assert f["outcome"] == "pass", f"{label}: {f['evidence']}"
+
+
+def test_or_exit_zero_after_the_suite_fails(tmp_path):
+    """`|| exit 0` is the discard stated outright — more explicit than
+    `|| true`, and it was the one shape reported as a clean bill."""
+    f = _fatal(tmp_path, {"ci.yml": _wf("      - run: pytest -q || exit 0\n")})
+    assert f["outcome"] == "fail", f["evidence"]
+
+
+def test_or_bin_true_after_the_suite_fails(tmp_path):
+    """`/bin/true` is `true` by absolute path."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: pytest -q || /bin/true\n")})
+    assert f["outcome"] == "fail", f["evidence"]
+
+
+def test_a_reusable_workflow_holding_the_suite_is_in_scope(tmp_path):
+    """`workflow_call` is where a large repository usually keeps its suite,
+    and the caller reports the called job's status into the pull request. Out
+    of scope it was not merely missed — it left the denominator, certifying a
+    repository whose gate is exactly the one this fact describes."""
+    f = _fatal(tmp_path, {"reusable.yml": (
+        "name: tests\non:\n  workflow_call:\npermissions:\n"
+        "  contents: read\njobs:\n  test:\n    runs-on: ubuntu-latest\n"
+        "    steps:\n      - run: pytest -q || true\n")})
+    assert f["outcome"] == "fail", f["evidence"]
+
+
+def test_a_commented_out_suite_is_not_a_suite(tmp_path):
+    """A commented `# pytest -q` line runs nothing, so the `exit 0` under it
+    discards no suite. Reading comments as code would invent a suite — and
+    then a swallowed one — out of a note, and fail a repository whose real
+    tests are fatal."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: |\n          echo hi\n          # pytest -q\n"
+        "          exit 0\n"
+        "      - run: pytest -q\n")})
+    assert f["outcome"] == "pass", f["evidence"]
+
+
+def test_an_unreadable_trigger_block_stays_in_scope(tmp_path):
+    """The stated never-silent-pass direction: a workflow whose `on:` cannot
+    be read is judged, because dropping it would let an unreadable trigger
+    certify a swallowed suite."""
+    f = _fatal(tmp_path, {"ci.yml": (
+        "name: ci\npermissions:\n  contents: read\njobs:\n  test:\n"
+        "    runs-on: ubuntu-latest\n    steps:\n"
+        "      - run: pytest -q || true\n")})
+    assert f["outcome"] == "fail", f["evidence"]
+
+
+def test_merge_group_is_a_gate_trigger(tmp_path):
+    """A merge queue is a merge gate by definition."""
+    f = _fatal(tmp_path, {"ci.yml": (
+        "name: ci\non:\n  merge_group:\npermissions:\n  contents: read\n"
+        "jobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n"
+        "      - run: pytest -q || true\n")})
+    assert f["outcome"] == "fail", f["evidence"]
 
 
 def test_continue_on_error_on_the_test_step_fails(tmp_path):

--- a/skills/ci-secure/tests/test_config_facts.py
+++ b/skills/ci-secure/tests/test_config_facts.py
@@ -3167,9 +3167,13 @@ def test_or_echo_that_still_exits_nonzero_passes(tmp_path):
     assert f["outcome"] == "pass", f["evidence"]
 
 
-def test_trailing_exit_zero_after_the_suite_fails(tmp_path):
+def test_trailing_exit_zero_after_the_suite_fails_where_no_errexit(tmp_path):
+    """On a step whose shell has no errexit — `pwsh`, `powershell`, `cmd` —
+    a trailing `exit 0` really does run after a failed suite and discards
+    it."""
     f = _fatal(tmp_path, {"ci.yml": _wf(
-        "      - run: |\n          cargo test --all\n          exit 0\n")})
+        "      - shell: pwsh\n"
+        "        run: |\n          cargo test --all\n          exit 0\n")})
     assert f["outcome"] == "fail", f["evidence"]
     assert "exit 0" in f["evidence"], f["evidence"]
 
@@ -3179,10 +3183,68 @@ def test_trailing_exit_zero_with_an_inline_comment_fails(tmp_path):
     Requiring the `0` to end the line would read a self-documented swallow as
     a pass."""
     f = _fatal(tmp_path, {"ci.yml": _wf(
-        "      - run: |\n          cargo test --all\n"
+        "      - shell: cmd\n"
+        "        run: |\n          cargo test --all\n"
         "          exit 0 # always succeed\n")})
     assert f["outcome"] == "fail", f["evidence"]
     assert "exit 0" in f["evidence"], f["evidence"]
+
+
+def test_trailing_exit_zero_under_default_errexit_shell_passes(tmp_path):
+    """GitHub's default `run` shell on Linux and macOS is `bash -e {0}`
+    (and an explicit `shell: bash` gets `-eo pipefail`): a failing suite
+    aborts the step before a trailing `exit 0` is ever reached, so the step
+    already fails and nothing is swallowed. Flagging it is a false accusation
+    on a fatally wired job — exactly what this fact promises never to make."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: |\n          pytest -q\n          exit 0\n")})
+    assert f["outcome"] == "pass", f["evidence"]
+
+
+def test_trailing_exit_zero_on_a_windows_default_shell_fails(tmp_path):
+    """With no `shell:` anywhere, a `windows-*` runner defaults to `pwsh`,
+    which carries no errexit — the discard is real there."""
+    f = _fatal(tmp_path, {"ci.yml": (
+        "name: ci\non: [pull_request]\npermissions:\n  contents: read\n"
+        "jobs:\n  test:\n    runs-on: windows-latest\n    steps:\n"
+        "      - run: |\n          dotnet test\n          exit 0\n")})
+    assert f["outcome"] == "fail", f["evidence"]
+
+
+def test_trailing_exit_zero_under_a_job_default_pwsh_fails(tmp_path):
+    """`defaults.run.shell` on the job (or the workflow) sets the step's
+    effective shell, so a job-wide `pwsh` makes the discard real on every
+    step that does not override it."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: |\n          pytest -q\n          exit 0\n",
+        job_extra="    defaults:\n      run:\n        shell: pwsh\n")})
+    assert f["outcome"] == "fail", f["evidence"]
+
+
+_ALLOWLIST_SAMPLES = (
+    "pytest -q", "py.test", "tox", "nox", "pre-commit run --all-files",
+    "npm test", "pnpm run lint", "yarn typecheck", "bun run check",
+    "npx jest", "npx playwright", "jest", "vitest run", "mocha", "karma",
+    "playwright test", "cypress run", "go test ./...", "go vet ./...",
+    "golangci-lint run", "cargo test", "cargo clippy",
+    "mvn -B verify", "./gradlew build check", "dotnet test", "swift test",
+    "ctest", "bazel test //...", "bundle exec rspec", "rubocop",
+    "rake test", "phpunit", "composer test", "make test", "make lint",
+    "ruff check .", "flake8", "pylint src", "mypy src", "pyright",
+    "eslint .", "stylelint styles.css", "shellcheck run.sh",
+    "hadolint Dockerfile", "actionlint", "tflint", "black --check .",
+)
+
+
+@pytest.mark.parametrize("cmd", _ALLOWLIST_SAMPLES)
+def test_every_allowlisted_suite_command_is_guarded(tmp_path, cmd):
+    """One representative spelling per arm of the suite-command allowlist,
+    each swallowed with `|| true`, each of which must fail the fact.
+    Deleting any arm silently flips a repository whose only suite uses it
+    from *fail* to *not_applicable* — this pins every arm to a red."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        f'      - run: "{cmd} || true"\n')})
+    assert f["outcome"] == "fail", (cmd, f["evidence"])
 
 
 def test_a_later_set_dash_e_does_not_rescue_an_already_discarded_suite(
@@ -3257,9 +3319,13 @@ def test_set_plus_e_that_rechecks_the_exit_code_passes(tmp_path):
 def test_a_one_line_suite_then_exit_zero_fails(tmp_path):
     """`npm test; exit 0` is the two-line shape with a semicolon instead of a
     newline. The documented shape is "a trailing `exit 0`"; which whitespace
-    separates it from the suite is not part of the claim."""
+    separates it from the suite is not part of the claim. On an errexit
+    shell the semicolon form aborts at the failing suite exactly like the
+    newline form, so the discard is only real where the shell has no
+    errexit."""
     f = _fatal(tmp_path, {"ci.yml": _wf(
-        "      - run: npm test; exit 0\n")})
+        "      - shell: powershell\n"
+        "        run: npm test; exit 0\n")})
     assert f["outcome"] == "fail", f["evidence"]
     assert "exit 0" in f["evidence"], f["evidence"]
 

--- a/skills/ci-secure/tests/test_config_facts.py
+++ b/skills/ci-secure/tests/test_config_facts.py
@@ -3150,6 +3150,50 @@ def test_trailing_exit_zero_after_the_suite_fails(tmp_path):
     assert "exit 0" in f["evidence"], f["evidence"]
 
 
+def test_trailing_exit_zero_with_an_inline_comment_fails(tmp_path):
+    """`exit 0 # always succeed` is the same discard with a comment after it.
+    Requiring the `0` to end the line would read a self-documented swallow as
+    a pass."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: |\n          cargo test --all\n"
+        "          exit 0 # always succeed\n")})
+    assert f["outcome"] == "fail", f["evidence"]
+    assert "exit 0" in f["evidence"], f["evidence"]
+
+
+def test_a_later_set_dash_e_does_not_rescue_an_already_discarded_suite(
+        tmp_path):
+    """`set -e` changes what happens NEXT. It cannot restore the status of a
+    command that already ran and had its failure thrown away, so a `set -e`
+    after `pytest || true` leaves the suite exactly as swallowed as before."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: |\n          pytest -q || true\n          set -e\n"
+        "          echo done\n")})
+    assert f["outcome"] == "fail", f["evidence"]
+    assert "|| true" in f["evidence"], f["evidence"]
+
+
+def test_errexit_restored_only_after_the_suite_ran_fails(tmp_path):
+    """`set +e` / suite / `set -e` with no read of the status in between: the
+    suite ran with `errexit` off, its failure was never raised, and restoring
+    `errexit` afterwards raises nothing retroactively."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: |\n          set +e\n          pytest -q\n"
+        "          set -e\n")})
+    assert f["outcome"] == "fail", f["evidence"]
+    assert "set +e" in f["evidence"], f["evidence"]
+
+
+def test_errexit_relaxed_and_restored_before_the_suite_passes(tmp_path):
+    """The other side of the same line: `errexit` was off for a cleanup and
+    back on before the suite ran, so the suite's failure still fails the job.
+    Failing this would punish a job whose tests ARE fatal."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: |\n          set +e\n          rm -rf .cache\n"
+        "          set -e\n          pytest -q\n")})
+    assert f["outcome"] == "pass", f["evidence"]
+
+
 def test_set_plus_e_without_an_exit_code_recheck_fails(tmp_path):
     f = _fatal(tmp_path, {"ci.yml": _wf(
         "      - run: |\n          set +e\n          pytest -q\n"

--- a/skills/ci-secure/tests/test_config_facts.py
+++ b/skills/ci-secure/tests/test_config_facts.py
@@ -3226,6 +3226,25 @@ def test_set_plus_e_without_an_exit_code_recheck_fails(tmp_path):
     assert "set +e" in f["evidence"], f["evidence"]
 
 
+def test_errexit_relaxed_on_the_same_line_as_the_suite_fails(tmp_path):
+    """`set +e; pytest -q` is the two-line shape with a semicolon instead of a
+    newline: errexit is off, the suite runs under it, and nothing raises the
+    status afterwards. Ordering the two by LINE alone put them at the same
+    index and read the swallow as a pass."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: |\n          set +e; pytest -q\n          echo done\n")})
+    assert f["outcome"] == "fail", f["evidence"]
+    assert "set +e" in f["evidence"], f["evidence"]
+
+
+def test_errexit_relaxed_and_rechecked_on_one_line_passes(tmp_path):
+    """The guard against over-correcting it: the same line that relaxes
+    errexit also captures and re-raises the status, so the suite is fatal."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: |\n          set +e; pytest -q; rc=$?; exit $rc\n")})
+    assert f["outcome"] == "pass", f["evidence"]
+
+
 def test_set_plus_e_that_rechecks_the_exit_code_passes(tmp_path):
     """The legitimate shape: relax `errexit` to capture the status, then
     re-raise it. Failing this would punish a job that DOES fail."""

--- a/skills/ci-secure/tests/test_config_facts.py
+++ b/skills/ci-secure/tests/test_config_facts.py
@@ -115,7 +115,7 @@ def test_a_well_configured_repo_passes_every_fact(tmp_path):
         required_contexts_fetcher=lambda repo: ([], "branch `main`"),
         fork_approval_fetcher=lambda repo: ("all_external_contributors", "x"))
     assert out["score"] == 100.0
-    assert out["passed"] == out["scored_count"] == 8
+    assert out["passed"] == out["scored_count"] == 9
     for f in out["facts"]:
         assert f["outcome"] == "pass", f"{f['fact_id']} failed: {f['evidence']}"
 
@@ -128,7 +128,7 @@ def test_the_api_gated_facts_are_the_only_unmeasured_ones_offline(tmp_path):
     out = cf.compute_config_facts(root, files, [])
     assert sorted(out["unmeasured"]) == ["sec.fork-approval.effective",
                                          "sec.required-checks.skippable"]
-    assert out["scored_count"] == 6 and out["applicable_count"] == 8
+    assert out["scored_count"] == 7 and out["applicable_count"] == 9
     assert "COVERAGE GAP" in out["caveat"]
 
 
@@ -533,9 +533,9 @@ def test_codeowners_undecodable_file_is_unmeasured_not_a_fail(tmp_path):
     assert "unmeasured" in f["evidence"], f
     assert "sec.codeowners.workflows" in out["unmeasured"]
     # ...and it is a coverage gap, not a silent pass. `applicable_count` stays
-    # 8 — every fact is still applicable — while only 5 score: this one plus
+    # 9 — every fact is still applicable — while only 6 score: this one plus
     # both API-gated facts, which are unmeasured offline too.
-    assert out["scored_count"] == 5 and out["applicable_count"] == 8
+    assert out["scored_count"] == 6 and out["applicable_count"] == 9
     assert "COVERAGE GAP" in out["caveat"]
 
 
@@ -562,7 +562,7 @@ def test_codeowners_unreadable_directory_is_one_unmeasured_row(tmp_path):
     f = _outcome(out, "sec.codeowners.workflows")
     assert f["outcome"] == "unmeasured", f
     # The OTHER facts still resolved — the failure is contained to this row.
-    assert out["scored_count"] == 5, out
+    assert out["scored_count"] == 6, out
 
 
 # --- F4: the sharpened trigger fact -----------------------------------
@@ -685,7 +685,7 @@ def test_unscannable_workflow_forces_workflow_facts_to_unmeasured(tmp_path):
             )
             assert "broken.yml" in f["evidence"]
     assert out["scored_count"] == 1
-    assert out["applicable_count"] == 8
+    assert out["applicable_count"] == 9
     assert "COVERAGE GAP" in out["caveat"]
     # The ratio must be over RESOLVED facts only. If unmeasured facts leaked
     # into the numerator, 5 unmeasured + 1 pass over scored=1 would read 600 —
@@ -716,9 +716,9 @@ def test_score_is_the_registered_ratio_with_no_weights(tmp_path):
         root, files, [], repo="owner/repo",
         required_contexts_fetcher=lambda repo: ([], "branch `main`"),
         fork_approval_fetcher=lambda repo: ("first_time_contributors", "x"))
-    # bad.yml fails exactly one fact (permissions-declares); 7/8 pass.
-    assert out["passed"] == 7 and out["scored_count"] == 8
-    assert out["score"] == pytest.approx(round(100 * 7 / 8, 1))
+    # bad.yml fails exactly one fact (permissions-declares); 8/9 pass.
+    assert out["passed"] == 8 and out["scored_count"] == 9
+    assert out["score"] == pytest.approx(round(100 * 8 / 9, 1))
     assert out["registered"]
     assert "no weights" in out["constants"]["rule"]
 
@@ -1124,8 +1124,8 @@ def test_a_scan_gap_forces_the_fact_unmeasured(tmp_path):
 
 def test_the_fact_table_carries_both_api_gated_facts(tmp_path):
     out = _facts_with(tmp_path, {"ci.yml": _VERDICT_PATTERN}, ["test"])
-    assert out["applicable_count"] == 8
-    assert out["scored_count"] == 8
+    assert out["applicable_count"] == 9
+    assert out["scored_count"] == 9
 
 
 # --- F8: sec.fork-approval.effective -----------------------------------------
@@ -1207,10 +1207,10 @@ def test_a_scan_gap_does_not_unmeasure_the_fork_approval_fact(tmp_path):
     assert _outcome(out, _FORK_FACT)["outcome"] == "pass"
 
 
-def test_the_fact_table_carries_eight_facts(tmp_path):
+def test_the_fact_table_carries_nine_facts(tmp_path):
     out = _fork_facts(tmp_path, "all_external_contributors")
-    assert out["applicable_count"] == 8
-    assert out["scored_count"] == 8
+    assert out["applicable_count"] == 9
+    assert out["scored_count"] == 9
 
 
 # ---------------------------------------------------------------------------
@@ -2013,7 +2013,7 @@ def test_a_branch_protection_fetcher_that_raises_becomes_one_unmeasured_row(
     assert "gh subprocess died" in f["evidence"], f["evidence"]
     assert _FACT in out["unmeasured"]
     # The rest of the table still resolved — the failure is contained.
-    assert out["scored_count"] == 7 and out["applicable_count"] == 8
+    assert out["scored_count"] == 8 and out["applicable_count"] == 9
 
 
 def test_a_fork_approval_fetcher_that_raises_becomes_one_unmeasured_row(
@@ -2031,7 +2031,7 @@ def test_a_fork_approval_fetcher_that_raises_becomes_one_unmeasured_row(
     assert f["outcome"] == "unmeasured", f
     assert "gh subprocess died" in f["evidence"], f["evidence"]
     assert _FORK_FACT in out["unmeasured"]
-    assert out["scored_count"] == 7 and out["applicable_count"] == 8
+    assert out["scored_count"] == 8 and out["applicable_count"] == 9
 
 
 # ---------------------------------------------------------------------------
@@ -3082,3 +3082,206 @@ def test_a_bypass_found_on_a_partially_read_protection_discloses_the_gap(
         _FACT)
     assert f["outcome"] == "fail", f["evidence"]
     assert "read from rulesets only" in f["evidence"], f["evidence"]
+
+
+# ---------------------------------------------------------------------------
+# F9 — a test/lint suite whose failure cannot fail its job.
+#
+# Sibling of `sec.required-checks.skippable`: that fact is "a SKIPPED required
+# check reports green"; this one is "a check that RAN reports green whatever
+# the suite did". Same consequence — the merge gate is decorative — so the
+# tests below pin both directions: every swallow shape fails, and everything
+# the fact deliberately does not claim (uploads, unrecognized commands,
+# expression-valued continue-on-error) stays green.
+# ---------------------------------------------------------------------------
+
+_FATAL = "sec.gate.test-failure-fatal"
+
+
+def _wf(steps: str, job_extra: str = "") -> str:
+    return ("name: ci\non: [pull_request]\npermissions:\n  contents: read\n"
+            "jobs:\n  test:\n    runs-on: ubuntu-latest\n"
+            + job_extra + "    steps:\n" + steps)
+
+
+def _fatal(tmp_path, workflows, **kw):
+    root, files = _repo(tmp_path, workflows)
+    return _outcome(cf.compute_config_facts(
+        root, files, kw.pop("scan_incomplete", []), **kw), _FATAL)
+
+
+def test_a_suite_that_can_fail_its_job_passes(tmp_path):
+    f = _fatal(tmp_path, {"ci.yml": _SAFE_WF})
+    assert f["outcome"] == "pass", f["evidence"]
+
+
+def test_or_true_after_the_suite_fails_and_names_file_and_job(tmp_path):
+    f = _fatal(tmp_path, {"ci.yml": _wf("      - run: pytest -q || true\n")})
+    assert f["outcome"] == "fail", f["evidence"]
+    assert "ci.yml" in f["evidence"], f["evidence"]
+    assert "`test`" in f["evidence"], f["evidence"]
+    assert "|| true" in f["evidence"], f["evidence"]
+
+
+def test_or_colon_after_the_suite_fails(tmp_path):
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        '      - run: "npm run lint || :"\n')})
+    assert f["outcome"] == "fail", f["evidence"]
+
+
+def test_or_echo_after_the_suite_fails(tmp_path):
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        '      - run: go test ./... || echo "tests failed"\n')})
+    assert f["outcome"] == "fail", f["evidence"]
+
+
+def test_or_echo_that_still_exits_nonzero_passes(tmp_path):
+    """`|| { echo …; exit 1; }` reports the failure AND fails the job. Reading
+    the `|| echo` prefix alone would red a correct guard."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        '      - run: go test ./... || { echo "tests failed"; exit 1; }\n')})
+    assert f["outcome"] == "pass", f["evidence"]
+
+
+def test_trailing_exit_zero_after_the_suite_fails(tmp_path):
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: |\n          cargo test --all\n          exit 0\n")})
+    assert f["outcome"] == "fail", f["evidence"]
+    assert "exit 0" in f["evidence"], f["evidence"]
+
+
+def test_set_plus_e_without_an_exit_code_recheck_fails(tmp_path):
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: |\n          set +e\n          pytest -q\n"
+        "          echo done\n")})
+    assert f["outcome"] == "fail", f["evidence"]
+    assert "set +e" in f["evidence"], f["evidence"]
+
+
+def test_set_plus_e_that_rechecks_the_exit_code_passes(tmp_path):
+    """The legitimate shape: relax `errexit` to capture the status, then
+    re-raise it. Failing this would punish a job that DOES fail."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: |\n          set +e\n          pytest -q\n"
+        "          rc=$?\n          echo done\n          exit $rc\n")})
+    assert f["outcome"] == "pass", f["evidence"]
+
+
+def test_continue_on_error_on_the_test_step_fails(tmp_path):
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: pytest -q\n        continue-on-error: true\n")})
+    assert f["outcome"] == "fail", f["evidence"]
+    assert "continue-on-error" in f["evidence"], f["evidence"]
+
+
+def test_continue_on_error_on_the_job_running_the_suite_fails(tmp_path):
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: pytest -q\n", job_extra="    continue-on-error: true\n")})
+    assert f["outcome"] == "fail", f["evidence"]
+
+
+def test_continue_on_error_from_an_expression_is_not_judged(tmp_path):
+    """`continue-on-error: ${{ matrix.experimental }}` is true for some matrix
+    legs and false for others; the YAML cannot say which. Not a literal true,
+    so not a fail — a miss beats a false accusation here."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: pytest -q\n"
+        "        continue-on-error: ${{ matrix.experimental }}\n")})
+    assert f["outcome"] == "pass", f["evidence"]
+
+
+def test_continue_on_error_on_an_upload_step_is_not_this_facts_business(
+        tmp_path):
+    """Deliberately EXEMPT: a non-fatal coverage upload, artifact upload, SARIF
+    upload or chat notification is another engine's business, not a swallowed
+    test result. Double-reporting it here would be a defect."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: pytest -q\n"
+        "      - uses: codecov/codecov-action@v4\n"
+        "        continue-on-error: true\n"
+        "      - uses: actions/upload-artifact@v4\n"
+        "        continue-on-error: true\n"
+        "      - uses: github/codeql-action/upload-sarif@v3\n"
+        "        continue-on-error: true\n"
+        "      - run: curl -sf -X POST $SLACK_WEBHOOK || true\n")})
+    assert f["outcome"] == "pass", f["evidence"]
+
+
+def test_an_unrecognized_command_is_never_failed(tmp_path):
+    """When the scan cannot tell what a `run:` block does, it does not fail the
+    fact. `./scripts/ci.sh || true` may be swallowing a suite or a cleanup —
+    accusing a repo on a guess is worse than missing one."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: pytest -q\n      - run: ./scripts/ci.sh || true\n")})
+    assert f["outcome"] == "pass", f["evidence"]
+
+
+def test_a_swallowed_utility_line_beside_the_suite_is_not_a_fail(tmp_path):
+    """`grep … || true` in the same block as the suite swallows the grep, not
+    the tests. Only a line that RUNS the suite counts."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: |\n          grep -c TODO src/*.py || true\n"
+        "          pytest -q\n")})
+    assert f["outcome"] == "pass", f["evidence"]
+
+
+def test_installing_a_test_runner_is_not_running_one(tmp_path):
+    """`pip install pytest || true` tolerates a failed install; it swallows no
+    test result. Reading the runner's NAME as a run would fail the fact on a
+    repository whose tests are perfectly fatal."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        "      - run: |\n          pip install pytest || true\n"
+        "          cat tox.ini || true\n          pytest -q\n")})
+    assert f["outcome"] == "pass", f["evidence"]
+
+
+def test_a_repo_with_no_suite_at_all_is_not_applicable_not_a_pass(tmp_path):
+    """The applicability gate, following the shape ci-score's test-sharding
+    check uses: a repo whose workflows run no test, lint or build-verification
+    suite has nothing to swallow, so the fact leaves the denominator rather
+    than handing out a free green."""
+    root, files = _repo(tmp_path, {"ci.yml": _wf("      - run: echo hello\n")})
+    out = cf.compute_config_facts(root, files, [])
+    f = _outcome(out, _FATAL)
+    assert f["outcome"] == "not_applicable", f["evidence"]
+    # The evidence says WHY it does not apply. "no step discards its exit
+    # status" would be true and would read as a clean bill for a suite that
+    # does not exist.
+    assert "no workflow step runs a test" in f["evidence"], f["evidence"]
+    assert _FATAL in out["not_applicable"]
+    assert _FATAL not in out["unmeasured"]
+
+
+def test_not_applicable_leaves_the_applicable_count(tmp_path):
+    """`not_applicable` is OUT of the denominator — the same treatment
+    ci-score gives an n/a check, and the opposite of `unmeasured`, which stays
+    in as a named coverage gap."""
+    root, files = _repo(tmp_path, {"ci.yml": _wf("      - run: echo hello\n")})
+    out = cf.compute_config_facts(root, files, [])
+    # Eight other facts: six measurable offline, two API-gated and unmeasured.
+    assert out["applicable_count"] == 8
+    assert out["scored_count"] == 6
+
+
+def test_a_scan_gap_unmeasures_the_fatal_fact(tmp_path):
+    """A universal claim over every workflow: an unreadable file could be the
+    one holding the swallow, so the fact is unmeasured, never a pass."""
+    f = _fatal(tmp_path, {"ci.yml": _SAFE_WF},
+               scan_incomplete=[{"workflow_file": "broken.yml"}])
+    assert f["outcome"] == "unmeasured", f["evidence"]
+
+
+def test_a_not_applicable_fact_still_renders_a_row(tmp_path):
+    """ARTIFACT-LEVEL: a row that quietly vanishes reads as a pass. The n/a
+    outcome must reach the page with a mark of its own, distinguishable from
+    both a green and a coverage gap."""
+    root, files = _repo(tmp_path, {"ci.yml": _wf("      - run: echo hello\n")})
+    md = _load_report().render({
+        "findings": [], "repo": "x/y", "scanned_workflows": 1,
+        "security_score": cf.compute_config_facts(root, files, []),
+    })
+    row = next((ln for ln in md.splitlines() if _FATAL in ln
+                or "swallows its own exit code" in ln), None)
+    assert row is not None, "the not-applicable fact rendered no row at all"
+    assert "n/a" in row, row
+    assert "pass" not in row and "unmeasured" not in row, row

--- a/skills/ci-secure/tests/test_config_facts.py
+++ b/skills/ci-secure/tests/test_config_facts.py
@@ -3129,6 +3129,20 @@ def test_or_colon_after_the_suite_fails(tmp_path):
     assert f["outcome"] == "fail", f["evidence"]
 
 
+def test_or_colon_with_a_trailing_comment_still_fails(tmp_path):
+    """A comment after `|| :` does not un-swallow the suite.
+
+    `|| :` is recognised by what FOLLOWS the colon, since a bare `:` is also
+    the start of `:=`-style expansions and of a `::` group. The shape it is
+    most often written in carries the author's reason on the same line —
+    `pytest || :  # tolerate flakes` — and a comment is exactly as much a
+    terminator as the `;` and `&&` already accepted. Left out, the one form
+    of this shape a repository actually writes reads as a pass."""
+    f = _fatal(tmp_path, {"ci.yml": _wf(
+        '      - run: "pytest -q || :  # tolerate flakes"\n')})
+    assert f["outcome"] == "fail", f["evidence"]
+
+
 def test_or_echo_after_the_suite_fails(tmp_path):
     f = _fatal(tmp_path, {"ci.yml": _wf(
         '      - run: go test ./... || echo "tests failed"\n')})

--- a/skills/ci-secure/tests/test_facts_census.py
+++ b/skills/ci-secure/tests/test_facts_census.py
@@ -53,6 +53,7 @@ _EXPECTED_FACTS = frozenset({
     "sec.checkout.credentials-scoped",
     "sec.required-checks.skippable",
     "sec.fork-approval.effective",
+    "sec.gate.test-failure-fatal",
 })
 
 

--- a/skills/ci-secure/tests/test_report.py
+++ b/skills/ci-secure/tests/test_report.py
@@ -1691,6 +1691,37 @@ def test_the_config_facts_render_as_a_pass_fail_table_with_NO_aggregate(
     assert md.index("## 🔗 Vector map") < md.index("## 🧰 Config hygiene checks")
 
 
+def test_a_not_applicable_check_is_disclosed_in_prose_not_only_as_a_mark(
+) -> None:
+    """`unmeasured` gets a sentence telling the reader it is a coverage gap.
+    A check that does not apply leaves the denominator instead, and the reader
+    is owed the same disclosure in the other direction — otherwise the only
+    trace of it is an unexplained mark in a table whose count line does not
+    add up against the rows above it."""
+    score = dict(_SCORE_JSON)
+    score["facts"] = list(_SCORE_JSON["facts"]) + [
+        {"fact_id": "sec.gate.test-failure-fatal",
+         "fact": "no job that runs the test or lint suite swallows its own "
+                 "exit code",
+         "outcome": "not_applicable",
+         "evidence": "not applicable: no workflow that can report a check on "
+                     "a pull request runs a suite this scan recognises"},
+    ]
+    score["not_applicable"] = ["sec.gate.test-failure-fatal"]
+    md = report.render({
+        "findings": [], "repo": "x/y", "scanned_workflows": 3,
+        "security_score": score,
+    })
+    assert "sec.gate.test-failure-fatal" in md
+    assert "do not apply" in md or "does not apply" in md, md
+    # And it must not borrow the coverage-gap wording: the whole point of the
+    # separate outcome is that this is NOT a gap.
+    na_line = [ln for ln in md.splitlines()
+               if "apply" in ln and "check" in ln]
+    assert na_line, md
+    assert "coverage gap" not in na_line[0], na_line[0]
+
+
 def test_security_score_evidence_pipes_do_not_break_the_table() -> None:
     """Evidence carrying a `|` would otherwise split the row into phantom
     columns."""

--- a/skills/ci-secure/tests/test_skill_body_budget.py
+++ b/skills/ci-secure/tests/test_skill_body_budget.py
@@ -47,3 +47,21 @@ def test_skill_body_line_budget_guard_actually_fires_when_over():
     body = _skill_body_line_count(over)
     assert body == _SKILL_BODY_LINE_BUDGET          # frontmatter stripped, body isolated
     assert not (body < _SKILL_BODY_LINE_BUDGET)     # exactly at budget → the guard trips
+
+
+def test_the_spoken_close_has_a_rule_for_every_outcome_the_engine_emits():
+    """The hygiene close-out contract must name every outcome the fact table
+    can render. It enumerated pass, fail and unmeasured; the engine also emits
+    `not_applicable`, and a contract silent about it pushes the agent to the
+    one sentence the outcome exists to prevent — "All config hygiene checks
+    pass." said over a row that did not apply. The terminal close is the
+    surface most runs actually show, so a gap here outranks the table's mark.
+    """
+    body = _SKILL_MD
+    close = body[body.index("Contract lines, all mandatory:"):]
+    close = close[:close.index("**Then the vector map**")]
+    close = close.lower()
+    assert "unmeasured" in close, "close contract lost its unmeasured rule"
+    assert "n/a" in close or "not applicable" in close, (
+        "close contract has no rule for a not-applicable row, so an n/a row "
+        "gets folded into 'All config hygiene checks pass.'")


### PR DESCRIPTION
## TL;DR

A repository can have a full test suite, a required check, and a green merge button while the tests are wired so that failing changes nothing — one stray fragment at the end of the command line throws the result away, and every pull request after it merges on a check that can never go red. The security audit already reports the case where a required check is green because it never ran; it now also reports the case where the check ran and came back green no matter what the tests did. Without it, a repository whose merge gate is decorative is told its gate is sound.

```
already covered:  suite SKIPPED   ->  required check reports green  ->  merges
now covered:      suite RAN, FAILED, exit code discarded
                                  ->  required check reports green  ->  merges
```

## What the check asks

No job that runs the test or lint suite swallows its own exit code. The failing shapes are `|| true`, `|| :`, `|| echo …`, a trailing `exit 0` (on its own line, after a semicolon, or followed by a comment), `set +e` with nothing afterwards that re-checks the status it stopped enforcing, and a step (or its job) marked non-fatal. A quoted `'true'` counts. An expression such as `${{ matrix.experimental }}` does not: it is true on some matrix legs and false on others, and the workflow file cannot say which. Restoring `set -e` after the suite already ran does not rescue it either — that changes what happens next, and the failure has already been discarded.

This is a pass/fail configuration fact, not an attack vector. Nothing here is an exploit chain, no finding is raised, and the ten critical vectors are untouched.

## Scope, deliberately narrow

Only a workflow that can report a check on a pull request is judged at all. A nightly scheduled job or a manually dispatched smoke run reports on no pull request, so a deliberately tolerant `|| true` there is not the decorative merge gate this check describes. A trigger the scanner cannot read stays in scope, because dropping it would turn an unreadable workflow into a silent pass.

Within those workflows, only a command a shipped allowlist recognises as a test, lint, or build-verification suite can fail the check. What is read is the command itself, past anything standing in front of it that does not change what runs — an environment assignment, a privilege or timing wrapper, an interpreter runner, a leading path, and a shell keyword, since a suite written inside a conditional or a loop runs exactly as one written on a bare line does. Two things follow, both intended:

- **A command whose purpose the workflow file cannot establish is never failed.** `./scripts/ci.sh || true` might be swallowing a suite or tolerating a cleanup. A false accusation against a stranger's repository costs more than a miss, particularly for a check that feeds a published score.
- **Non-fatal upload, report, and notification steps do not reach this check** — coverage uploads, artifact uploads, SARIF uploads, a chat webhook. A step is judged only by its own command line: an uploader invoked as an action has no command line at all, and a webhook call matches nothing on the allowlist. Making a reporting step non-fatal is usually the right call about speed and reliability, and the speed engine already reports it; billing one configuration to two engines would be a defect, not thoroughness. The residual is disclosed rather than papered over: the exemption is a property of the command, so a reporting step whose command *does* match the allowlist is in scope here and can be billed by both. A `|| true` on a utility line beside the suite (`grep … || true`) swallows the grep, not the tests, and is likewise out of scope, as is text a step is merely writing to a file: the body of a here-document is not shell the step runs, so writing out a tolerant wrapper script is never read as throwing a test result away.

## Three ways to end without a verdict, and they are not the same claim

Nothing to swallow means nothing to certify: a green would read as "these tests are wired to fail the build" about a repository that has no tests. So a repository with nothing to check leaves the denominator entirely, which is the shape the best-practices engine already settled on for the same question, while its row still renders with its own mark, because a row that quietly disappears reads as a pass.

But "nothing to check" is a stronger claim than "nothing this scan recognises", and the two are kept apart. Not-applicable requires both that no recognised suite ran and that no step threw an exit status away. Where the allowlist recognised nothing but something did discard a status — `bash ci/test.sh || true` — the two readings are opposite and the workflow file settles neither. That is reported as a coverage gap with the steps named, and it stays in the denominator, because "there is nothing here to check" would assert no gap exists on the one shape where one demonstrably does.

That distinction is now explicit in the data the engines exchange: "could not be checked" and "there is nothing here to check" are separate lists, and the applicable count excludes only the second. Both reader surfaces say so in words — a sentence in the report and a note in the gate headline — so the count line can be reconciled against the rows above it.

## Blast radius

The security engine's configuration-fact aggregate is one of the three inputs the blended CI Score is built from. **This adds a ninth fact to that aggregate, so the security third of the blended score moves for any repository that has at least one failing configuration fact** — a repository already passing everything scores the same, since nine of nine and eight of eight are both 100. The aggregate stays machine-only and is still rendered nowhere a reader looks; the blend consumes the counts verbatim, so no consumer needs a change. The crash-path fallback block was extended to carry the new list too, so its key set still matches the real one on both paths.

The committed worked examples were checked and do not need regenerating: they are stamped to the engine commit that produced them, guarded on that stamp and on report-versus-findings agreement, and no committed artifact or fixture pins the fact set. Regenerating them against this branch would replace a reproducible historical pair with output from a commit that is not on the default branch. They do now describe an eight-fact engine, so a follow-up should re-render them from an on-main commit.

## Red proof

Every behavioural change here was written test-first and watched fail against the unchanged engine. The fact's own arrival:

```
$ pytest skills/ci-secure/tests/test_config_facts.py \
    -k "or_true_after_the_suite or no_suite_at_all"
>       raise AssertionError(f"{fact_id} missing from the fact table")
E       AssertionError: sec.gate.test-failure-fatal missing from the fact table
FAILED test_or_true_after_the_suite_fails_and_names_file_and_job
FAILED test_a_repo_with_no_suite_at_all_is_not_applicable_not_a_pass
```

and each later correction the same way — the swallow shapes that were reading as a pass, the scheduled and manually dispatched workflows that were being failed for a gate they do not have, the unidentifiable discard that was being called "nothing to check", the count line no reader surface explained, and the close-out contract that had no rule for the new mark:

```
E   AssertionError: no test or lint step discards its exit status
E   assert 'pass' == 'fail'
E   AssertionError: assert 'not_applicable' == 'unmeasured'
E   AssertionError: close contract has no rule for a not-applicable row, so an
    n/a row gets folded into 'All config hygiene checks pass.'
E   AssertionError: degraded block is missing ['not_applicable']
```

Both directions are pinned: every swallow shape fails the check, and every shape the check deliberately does not claim — uploads, unrecognised commands, an expression-valued non-fatal marker, a re-raised failure after the echo, a `set +e` that re-checks the status, errexit relaxed and restored before the suite runs, installing a test runner rather than running one — stays green. Two guards pin the narrowings against over-correction: a gate-shaped workflow beside a nightly one is still judged, and an unrecognised command that discards nothing is still not-applicable. The not-applicable row carries its own mutation proof: rename its display mark and the rendering test fails on the raw outcome string, so the row cannot regress into looking like a pass. The disjointness census and the gate's outcome vocabulary both go red until they are updated deliberately, which is what they exist for. Full suite green from the repository root.



