### PR TITLE
ci-secure: don't follow a workflow symlink outside .github/workflows/ (issue #37)

### DIFF
--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -393,6 +393,33 @@ entries are dated (UTC). Format loosely follows
   symlink (target still inside `.github/workflows/`) is unaffected and reads
   normally.
 
+  A follow-up review caught a gap in the fix above: it only checked
+  containment when the glob hit itself was a symlink, which misses
+  `.github/workflows/` (or `.github/`) itself being a symlink to an external
+  directory — `glob.glob` follows a symlinked ancestor directory
+  transparently, so every match it returns in that shape is already a
+  dereferenced regular file that never tests `.is_symlink()`, and the whole
+  external directory's contents would have been read and reported as
+  ordinary in-repo workflows. Containment is now checked against a boundary
+  built by joining `root.resolve()` with the literal `.github/workflows`
+  path components — never resolving them — and compared against what
+  `.github/workflows/` actually resolves to on disk; a mismatch means some
+  symlink in `.github/` or `.github/workflows/` redirected the whole
+  directory, and every match reached through it is excluded regardless of
+  its own name. A repo whose entire `.github/workflows/` resolves outside
+  itself this way has nothing left to scan, so it hits the scanner's
+  existing "zero workflows" refusal (`CoverageError`, exit 1) rather than a
+  partial report.
+
+  A second gap in the same code path: a committed symlink LOOP
+  (`a.yml -> b.yml -> a.yml`) made `Path.resolve()` raise `RuntimeError`
+  uncaught, crashing the whole scan on one attacker-committed cyclic pair
+  instead of excluding it like any other untrustworthy entry. Both resolve
+  points in `discover_workflow_files` now catch `OSError`/`RuntimeError` and
+  route a loop into the same skip-and-record path as an escaping or dangling
+  symlink — it degrades coverage on the looping files instead of aborting
+  the run.
+
 - **2026-08-19** — **The `Coverage:` line is copied, not recomputed, and a
   section link that stops resolving now fails the build.** Phase 3 defined
   `complete` as "every workflow file was scanned", which is one of the three gap

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -371,6 +371,28 @@ entries are dated (UTC). Format loosely follows
 
 ### Fixed
 
+- **2026-08-20** — **A symlinked workflow entry can no longer make the
+  scanner read outside `.github/workflows/`.** `discover_workflow_files`
+  resolved every glob hit before reading it but never checked the resolved
+  path stayed inside the workflows directory, so a committed symlink such as
+  `.github/workflows/build.yml -> ../../../../etc/passwd` was followed like
+  any ordinary file — its content scanned and, on a HIGH finding, its path
+  and text quoted straight into the report (issue #37). Discovery now checks
+  containment before trusting a symlink: one that resolves outside
+  `.github/workflows/`, or that dangles (points at nothing), is excluded and
+  logged as a `coverage_notes` gap instead of read — named by the symlink's
+  own in-repo path, never by the target it pointed at, so the report can say
+  a file was skipped without disclosing what it would have disclosed.
+  `_undiscovered_workflows` was taught to recognize that skip so it doesn't
+  also flag the same file as a broken scan and force a `CoverageError`. A
+  latent bug in `_repo_relative` rode along: it re-resolved a path's leaf
+  component when formatting it for the report, which for a dangling symlink
+  displayed the nonexistent target's name instead of the symlink's own —
+  the same class of disclosure this fix exists to close. It now resolves
+  only the parent directory, leaving the leaf name untouched. A same-scope
+  symlink (target still inside `.github/workflows/`) is unaffected and reads
+  normally.
+
 - **2026-08-19** — **The `Coverage:` line is copied, not recomputed, and a
   section link that stops resolving now fails the build.** Phase 3 defined
   `complete` as "every workflow file was scanned", which is one of the three gap

--- a/skills/ci-secure/scripts/scan.py
+++ b/skills/ci-secure/scripts/scan.py
@@ -355,37 +355,87 @@ def discover_workflow_files(root: Path, globs: list[str]) -> list[Path]:
     otherwise be interpreted as a character class and match nothing — every
     workflow silently invisible, the scan "clean".
 
-    A glob hit that is a symlink is trusted only if it resolves to somewhere
-    inside ``.github/workflows/``. A symlink escaping that directory would
-    otherwise have its target read, quoted in evidence, and its path shown in
-    the report — disclosing filesystem content the scan was never scoped to
-    touch. Escaping and dangling symlinks are both excluded here and recorded
-    as coverage gaps (never silently dropped) via `_record_dropped_match`,
-    keyed on the symlink's own in-repo path — never the resolved target — so
-    nothing the fix exists to hide leaks back in through the report.
+    A match is trusted only if its FULLY RESOLVED path lands inside a
+    genuinely real (non-symlinked) ``.github/workflows/`` directory. This has
+    to be checked for every match, not only ones where the glob hit itself is
+    a symlink: `glob.glob` follows a symlinked ancestor directory (e.g.
+    `.github/workflows/` or `.github/` itself is a symlink to somewhere else)
+    transparently, so the entries it returns for that case are
+    already-dereferenced regular files that never test True for
+    `.is_symlink()` — gating the check on the leaf's own symlink-ness would
+    silently let that whole class through.
+
+    The boundary used for containment must NOT itself be produced by
+    resolving through the same symlink being guarded against — comparing a
+    resolved match against a boundary that is *also* `.github/workflows/`
+    resolved makes the check self-referential and trivially true no matter
+    where the symlink points. So the boundary is built by joining
+    `root.resolve()` with the literal ``.github/workflows`` components
+    (never resolving them), then compared against what `.github/workflows/`
+    actually resolves to on disk: if they differ, some symlink in `.github/`
+    or `.github/workflows/` redirected the whole directory elsewhere, and
+    every match reached through it is out of scope regardless of its own
+    name. Only once that boundary is confirmed real does a per-file check
+    catch an individual escaping or dangling symlink *inside* it, exactly as
+    before. Excluded matches are recorded as coverage gaps (never silently
+    dropped) via `_record_dropped_match`, keyed on the match's own in-repo
+    path — never the resolved target — so nothing this check exists to hide
+    leaks back in through the report.
+
+    A committed symlink LOOP (`a.yml -> b.yml -> a.yml`, or `.github/workflows`
+    itself looping) makes `.resolve()` raise `RuntimeError` ("Symlink loop
+    from ...") rather than return a path — `OSError` is also guarded against,
+    since other unresolvable-path failures (permission, `ELOOP` from the
+    platform) surface that way. Unguarded, this is an attacker-committed
+    crash: one cyclic symlink takes the whole scan down instead of being
+    excluded like any other untrustworthy entry. Both resolve points below
+    are guarded and route into the same skip-and-record path as an escaping
+    or dangling symlink, so a loop degrades coverage instead of aborting the
+    scan.
     """
     seen: set[Path] = set()
-    wf_dir = (root / ".github" / "workflows").resolve()
+    wf_dir_on_disk = root / ".github" / "workflows"
+    wf_dir_expected = root.resolve() / ".github" / "workflows"
+    try:
+        wf_dir = wf_dir_on_disk.resolve()
+        wf_dir_is_trustworthy = (wf_dir == wf_dir_expected)
+    except (OSError, RuntimeError):
+        # `.github/workflows/` (or `.github/`) is itself an unresolvable
+        # symlink (e.g. a cycle) — nothing reached through it can be trusted.
+        wf_dir = None
+        wf_dir_is_trustworthy = False
     root_pattern = glob.escape(str(root))
     for pattern in globs:
         for match in glob.glob(os.path.join(root_pattern, pattern), recursive=True):
             match_path = Path(match)
-            if match_path.is_symlink():
-                target = match_path.resolve()
-                if not target.exists():
-                    _record_dropped_match(
-                        match_path, "symlink target does not exist",
-                        kind=_KIND_NOT_SCANNED)
-                    continue
-                try:
-                    target.relative_to(wf_dir)
-                except ValueError:
-                    _record_dropped_match(
-                        match_path,
-                        "symlink target outside .github/workflows/",
-                        kind=_KIND_NOT_SCANNED)
-                    continue
-            p = match_path.resolve()
+            if not wf_dir_is_trustworthy:
+                _record_dropped_match(
+                    match_path,
+                    "resolves outside .github/workflows/ (.github/ or "
+                    ".github/workflows/ itself is a symlink, or is part of "
+                    "a symlink loop)",
+                    kind=_KIND_NOT_SCANNED)
+                continue
+            try:
+                p = match_path.resolve()
+            except (OSError, RuntimeError):
+                _record_dropped_match(
+                    match_path, "symlink loop — could not be resolved",
+                    kind=_KIND_NOT_SCANNED)
+                continue
+            if not p.exists():
+                _record_dropped_match(
+                    match_path, "symlink target does not exist",
+                    kind=_KIND_NOT_SCANNED)
+                continue
+            try:
+                p.relative_to(wf_dir)
+            except ValueError:
+                _record_dropped_match(
+                    match_path,
+                    "symlink target outside .github/workflows/",
+                    kind=_KIND_NOT_SCANNED)
+                continue
             if p.is_file():
                 seen.add(p)
     return sorted(seen)

--- a/skills/ci-secure/scripts/scan.py
+++ b/skills/ci-secure/scripts/scan.py
@@ -354,12 +354,38 @@ def discover_workflow_files(root: Path, globs: list[str]) -> list[Path]:
     literal glob metacharacter in a directory name (``/tmp/repo[1]/``) would
     otherwise be interpreted as a character class and match nothing — every
     workflow silently invisible, the scan "clean".
+
+    A glob hit that is a symlink is trusted only if it resolves to somewhere
+    inside ``.github/workflows/``. A symlink escaping that directory would
+    otherwise have its target read, quoted in evidence, and its path shown in
+    the report — disclosing filesystem content the scan was never scoped to
+    touch. Escaping and dangling symlinks are both excluded here and recorded
+    as coverage gaps (never silently dropped) via `_record_dropped_match`,
+    keyed on the symlink's own in-repo path — never the resolved target — so
+    nothing the fix exists to hide leaks back in through the report.
     """
     seen: set[Path] = set()
+    wf_dir = (root / ".github" / "workflows").resolve()
     root_pattern = glob.escape(str(root))
     for pattern in globs:
         for match in glob.glob(os.path.join(root_pattern, pattern), recursive=True):
-            p = Path(match).resolve()
+            match_path = Path(match)
+            if match_path.is_symlink():
+                target = match_path.resolve()
+                if not target.exists():
+                    _record_dropped_match(
+                        match_path, "symlink target does not exist",
+                        kind=_KIND_NOT_SCANNED)
+                    continue
+                try:
+                    target.relative_to(wf_dir)
+                except ValueError:
+                    _record_dropped_match(
+                        match_path,
+                        "symlink target outside .github/workflows/",
+                        kind=_KIND_NOT_SCANNED)
+                    continue
+            p = match_path.resolve()
             if p.is_file():
                 seen.add(p)
     return sorted(seen)
@@ -386,11 +412,24 @@ def _undiscovered_workflows(root: Path, discovered: list[Path]) -> list[str]:
     YAML is not an empty repo — it is a broken scan that would render as a
     clean one. Compared by resolved path so a symlinked or escaped root
     can't produce a phantom mismatch.
+
+    A name `discover_workflow_files` already logged as a dropped match (an
+    out-of-scope or dangling symlink it deliberately excluded) is not an
+    undiscovered workflow — it's an accounted-for skip, already surfaced via
+    `coverage_notes`. Without this exclusion the same file would be flagged
+    twice: once correctly, as a scoped skip, and once as if discovery had
+    silently missed it — which forces a `CoverageError` (the scan refuses to
+    run) instead of the intended PARTIAL-coverage report with a note.
     """
     wf_dir = root / ".github" / "workflows"
     if not wf_dir.is_dir():
         return []
     found = {p.resolve() for p in discovered}
+    skipped = {
+        Path(d["file"]).name for d in _DROPPED_MATCHES
+        if d.get("kind") == _KIND_NOT_SCANNED
+        and Path(d["file"]).parent.resolve() == wf_dir.resolve()
+    }
     try:
         listed = sorted(
             p for p in wf_dir.iterdir()
@@ -399,7 +438,10 @@ def _undiscovered_workflows(root: Path, discovered: list[Path]) -> list[str]:
     except OSError as e:
         logger.warning("could not list %s: %s", wf_dir, e)
         return []
-    return [p.name for p in listed if p.resolve() not in found]
+    return [
+        p.name for p in listed
+        if p.resolve() not in found and p.name not in skipped
+    ]
 
 
 @dataclass(frozen=True)
@@ -813,9 +855,18 @@ def _repo_relative(path: str, root: Path) -> str:
     resolves outside the root (a symlinked workflow directory), and the
     fallback there used to hand the raw absolute path straight through, so the
     one branch that needed the guard was the one branch that skipped it.
+
+    Only the DIRECTORY portion is resolved, not the leaf — so a workflow path
+    that is itself a symlink (e.g. one `discover_workflow_files` skipped for
+    escaping `.github/workflows/`, or for dangling) is displayed by its own
+    in-repo name. Resolving the leaf too would follow the symlink one more
+    time here and surface its target's name in the report — exactly what
+    skipping it during discovery was meant to prevent.
     """
+    p = Path(path)
+    candidate = p.parent.resolve() / p.name
     try:
-        return str(Path(path).resolve().relative_to(root.resolve()))
+        return str(candidate.relative_to(root.resolve()))
     except ValueError:
         return os.path.relpath(str(path), str(root))
 

--- a/skills/ci-secure/tests/test_scan.py
+++ b/skills/ci-secure/tests/test_scan.py
@@ -2173,6 +2173,132 @@ def test_symlinked_workflow_escaping_the_directory_is_skipped_not_followed(
     )
 
 
+def test_symlinked_workflows_directory_with_no_legit_files_is_refused(
+    tmp_path: Path,
+) -> None:
+    """`.github/workflows/` itself can be a symlink to an external directory.
+    `glob.glob` follows that transparently, so every match it returns is
+    already a dereferenced REGULAR file — none of them test True for
+    `.is_symlink()`. A containment check gated on the glob hit itself being a
+    symlink would miss this entirely and let every file in the external
+    directory be read and reported as if it were an ordinary in-repo
+    workflow — the check has to apply to every match's fully resolved path,
+    not just to matches that are themselves symlinks.
+
+    Every file this repo's `.github/workflows/` resolves to lives outside it,
+    so nothing is left to scan once the escape is caught — same shape as an
+    empty or missing workflows directory, which the scanner already refuses
+    rather than reporting a vacuous clean pass
+    (`test_zero_workflows_is_refused_not_reported_clean`). The refusal
+    message must still not name the external directory it refused to read.
+
+    Exit code and empty stdout alone do not pin this: unfixed code raises an
+    uncaught `ValueError` for this exact fixture (a resolved path escaping
+    `root` reaches `f.relative_to(root)` unguarded), which also exits 1 with
+    empty stdout. The stderr text has to name the actual refusal — "no
+    workflow files found" — or this test cannot tell the intended
+    `CoverageError` apart from that crash.
+    """
+    outside = tmp_path.parent / (tmp_path.name + "-outside-workflows")
+    outside.mkdir()
+    (outside / "evil.yml").write_text(
+        "on:\n  issues:\n    types: [opened]\n"
+        "jobs:\n  b:\n    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - run: echo '${{ github.event.issue.title }}'\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".github").mkdir()
+    (tmp_path / ".github" / "workflows").symlink_to(outside)
+
+    result = subprocess.run(
+        [sys.executable, str(_SCAN_SCRIPT), "--root", str(tmp_path),
+         "--gh-impostor", "off"],
+        capture_output=True, text=True,
+    )
+
+    assert result.returncode == 1, (
+        "a symlinked workflows directory with no in-scope files was "
+        "reported as a clean scan"
+    )
+    assert result.stdout.strip() == "", "a refused scan must emit no findings"
+    assert "no workflow files found" in result.stderr, (
+        "must refuse via the zero-workflows CoverageError, not crash: "
+        f"{result.stderr!r}"
+    )
+    assert "outside-workflows" not in result.stderr, (
+        "the refusal must not disclose the external directory's path"
+    )
+
+
+def test_symlink_loop_is_skipped_not_a_crash(tmp_path: Path) -> None:
+    """A committed symlink LOOP (`a.yml -> b.yml -> a.yml`) makes
+    `Path.resolve()` raise `RuntimeError` rather than return a path.
+    Unguarded, that is an attacker-committed crash: one cyclic pair takes the
+    whole scan down (an uncaught traceback, exit 1) instead of being excluded
+    like any other untrustworthy entry. It must degrade to a coverage gap on
+    the looping files while a genuine sibling workflow still scans."""
+    _write_workflow(
+        tmp_path, "legit.yml",
+        "on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n"
+        "    steps:\n      - run: echo hi\n",
+    )
+    wf_dir = tmp_path / ".github" / "workflows"
+    (wf_dir / "b.yml").symlink_to(wf_dir / "a.yml")
+    (wf_dir / "a.yml").symlink_to(wf_dir / "b.yml")
+
+    data = _scan_dir(tmp_path)
+
+    assert data["scanned_workflows"] == 1, "the looping pair was not skipped"
+    notes = data["coverage_notes"]
+    assert any(n["workflow_file"].endswith("a.yml") for n in notes)
+    assert any(n["workflow_file"].endswith("b.yml") for n in notes)
+    assert all("loop" in n["reason"] for n in notes if n["workflow_file"]
+               in {".github/workflows/a.yml", ".github/workflows/b.yml"})
+
+
+def test_symlinked_workflows_directory_does_not_bypass_containment(
+    tmp_path: Path,
+) -> None:
+    """Same symlinked-directory shape as the refusal test above, unit-tested
+    directly against `discover_workflow_files` so the exclusion is observable
+    per-file rather than folded into a whole-repo refusal (every file a
+    symlinked `.github/workflows/` resolves to is equally out of scope, so
+    there's no way to also have a genuinely in-repo file alongside it — see
+    the sibling refusal test for why the end-to-end shape is a `CoverageError`
+    instead)."""
+    scan._DROPPED_MATCHES.clear()
+    outside = tmp_path.parent / (tmp_path.name + "-outside-workflows")
+    outside.mkdir()
+    (outside / "evil.yml").write_text(
+        "on: push\njobs:\n  b:\n    runs-on: x\n", encoding="utf-8")
+    (tmp_path / ".github").mkdir()
+    (tmp_path / ".github" / "workflows").symlink_to(outside)
+
+    discovered = scan.discover_workflow_files(
+        tmp_path, [".github/workflows/*.yml"])
+
+    assert discovered == [], (
+        "the symlinked workflows directory's contents were admitted despite "
+        "resolving outside .github/workflows/"
+    )
+    notes = [d for d in scan._DROPPED_MATCHES if d["kind"] == scan._KIND_NOT_SCANNED]
+    expected_file = str(tmp_path / ".github" / "workflows" / "evil.yml")
+    # An exact match, not `.endswith("evil.yml")`: the resolved target
+    # (`<external-dir>/evil.yml`) also ends with that name, so `endswith`
+    # would stay green even if a future change recorded the escaped target
+    # instead of the symlink's own in-repo path — exactly the leak this
+    # check exists to catch.
+    assert any(n["file"] == expected_file for n in notes), (
+        f"expected a dropped match recorded at {expected_file!r}, got "
+        f"{[n['file'] for n in notes]!r}"
+    )
+    assert not any("outside-workflows" in n["reason"] for n in notes), (
+        "the coverage note must not disclose the external directory's path"
+    )
+    scan._DROPPED_MATCHES.clear()
+
+
 def test_symlinked_workflow_inside_the_directory_is_read_normally(
     tmp_path: Path,
 ) -> None:

--- a/skills/ci-secure/tests/test_scan.py
+++ b/skills/ci-secure/tests/test_scan.py
@@ -2134,3 +2134,140 @@ def test_evidence_gutter_check_tolerates_a_blank_source_line(
         assert re.match(r"\s*\d+:(?: |$)", line), (
             f"non-source line inside verbatim evidence: {line!r}"
         )
+
+
+# -----------------------------------------------------------------------------
+# symlinked workflow entries (issue #37)
+# -----------------------------------------------------------------------------
+
+
+def test_symlinked_workflow_escaping_the_directory_is_skipped_not_followed(
+    tmp_path: Path,
+) -> None:
+    """A `.github/workflows/*.yml` entry that is a symlink pointing outside
+    `.github/workflows/` must never be read: following it would surface the
+    target file's path and contents in evidence or coverage output,
+    disclosing filesystem content the scan was never scoped to touch."""
+    secret = tmp_path.parent / "outside-secret.yml"
+    secret.write_text("on: push\njobs:\n  b:\n    runs-on: x\n", encoding="utf-8")
+    _write_workflow(
+        tmp_path, "legit.yml",
+        "on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n"
+        "    steps:\n      - run: echo hi\n",
+    )
+    wf_dir = tmp_path / ".github" / "workflows"
+    (wf_dir / "evil.yml").symlink_to(secret)
+
+    data = _scan_dir(tmp_path)
+
+    assert data["scanned_workflows"] == 1, "the escaping symlink was followed"
+    assert not any(
+        f.get("workflow_file", "").endswith("evil.yml") for f in data["findings"]
+    ), "the escaping symlink produced findings — it was read"
+    notes = data["coverage_notes"]
+    assert any(n["workflow_file"].endswith("evil.yml") for n in notes), (
+        "the skipped symlink must be named in coverage_notes"
+    )
+    assert not any("outside-secret" in n["reason"] for n in notes), (
+        "the coverage note must name the symlink, not disclose its target"
+    )
+
+
+def test_symlinked_workflow_inside_the_directory_is_read_normally(
+    tmp_path: Path,
+) -> None:
+    """A symlink whose target is still inside `.github/workflows/` is a
+    same-scope alias, not an escape — it must be discovered and scanned like
+    any other workflow file, not treated as suspicious merely for being a
+    symlink.
+
+    `real.yml` and `alias.yml` resolve to the same on-disk file, so they
+    collapse to one entry in `discover_workflow_files`'s de-duplicating
+    set — a pre-existing property of that dedup, not of the symlink-scope
+    check under test here. `affected_files` glob matching (each catalog
+    pattern's `.yml`/`.yaml` scope) runs against the RESOLVED path, so the
+    target also needs a `.yml` name for the detector to fire on it at all —
+    hence two `.yml` files rather than a same-scope symlink to an
+    arbitrarily-named body.
+    """
+    _write_workflow(
+        tmp_path, "real.yml",
+        "on:\n  issues:\n    types: [opened]\n"
+        "jobs:\n  b:\n    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - run: echo '${{ github.event.issue.title }}'\n",
+    )
+    wf_dir = tmp_path / ".github" / "workflows"
+    (wf_dir / "alias.yml").symlink_to(wf_dir / "real.yml")
+
+    data = _scan_dir(tmp_path)
+
+    assert data["scanned_workflows"] == 1
+    assert not data["coverage_notes"]
+    assert any(
+        f["pattern"] == "P14.10" and f["workflow_file"].endswith("real.yml")
+        for f in data["findings"]
+    ), "the in-scope symlink's target was not read"
+
+
+def test_dangling_symlinked_workflow_is_skipped_with_a_coverage_note(
+    tmp_path: Path,
+) -> None:
+    """A symlink whose target does not exist must not vanish silently from
+    the scan the way it silently vanishes from a plain directory listing —
+    it is recorded as a coverage gap like any other unreadable workflow."""
+    _write_workflow(
+        tmp_path, "legit.yml",
+        "on: push\njobs:\n  b:\n    runs-on: ubuntu-latest\n"
+        "    steps:\n      - run: echo hi\n",
+    )
+    wf_dir = tmp_path / ".github" / "workflows"
+    (wf_dir / "broken.yml").symlink_to(wf_dir / "does-not-exist.yml")
+
+    data = _scan_dir(tmp_path)
+
+    assert data["scanned_workflows"] == 1
+    notes = data["coverage_notes"]
+    assert any(n["workflow_file"].endswith("broken.yml") for n in notes)
+    assert any("does not exist" in n["reason"] for n in notes)
+
+
+def test_undiscovered_workflows_excludes_recorded_symlink_skips(
+    tmp_path: Path,
+) -> None:
+    """A name `discover_workflow_files` already logged as a dropped,
+    out-of-scope symlink must not also be reported as undiscovered — that
+    would force a `CoverageError` (scan refuses to run) on the exact repo
+    this fix is meant to let scan cleanly, with a note instead of a crash."""
+    scan._DROPPED_MATCHES.clear()
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "legit.yml").write_text(
+        "on: push\njobs:\n  b:\n    runs-on: x\n", encoding="utf-8")
+    secret = tmp_path.parent / "outside.yml"
+    secret.write_text("on: push\n", encoding="utf-8")
+    (wf_dir / "evil.yml").symlink_to(secret)
+
+    discovered = scan.discover_workflow_files(
+        tmp_path, [".github/workflows/*.yml"])
+    missed = scan._undiscovered_workflows(tmp_path, discovered)
+
+    assert missed == [], f"symlink skip re-flagged as undiscovered: {missed}"
+    scan._DROPPED_MATCHES.clear()
+
+
+def test_undiscovered_workflows_still_catches_a_genuine_miss(
+    tmp_path: Path,
+) -> None:
+    """The exclusion added for recorded symlink skips must not blunt the
+    tripwire for an actual broken-discovery bug: a real file that discovery
+    silently dropped, with nothing recorded for it, must still be reported."""
+    scan._DROPPED_MATCHES.clear()
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "missed.yml").write_text(
+        "on: push\njobs:\n  b:\n    runs-on: x\n", encoding="utf-8")
+
+    missed = scan._undiscovered_workflows(tmp_path, discovered=[])
+
+    assert missed == ["missed.yml"]


### PR DESCRIPTION
Fixes #37

## The problem

ci-secure scans every file under `.github/workflows/` in the repo being audited. If one of those entries is a **symlink** (a file that's really just a pointer to another file, possibly located anywhere else on disk), the scanner followed it wherever it pointed — even outside the repo entirely — and treated whatever it found as a normal workflow file.

That meant a symlink like `.github/workflows/build.yml -> ../../../../etc/passwd` would get read, and if it happened to trip a finding, its real path and file contents could end up quoted in the scan report. The scanner was never supposed to leave the `.github/workflows/` directory it was scoped to.

## The fix

Before reading a workflow entry, the scanner now checks: **does this symlink actually point somewhere inside `.github/workflows/`?**

- **Yes** → read it normally, exactly as before.
- **No** (points outside the directory, *or* points at nothing that exists — a "dangling" symlink) → skip it, and record a note in the report's `coverage_notes` saying that file was skipped and why. The note names the *symlink itself* (e.g. `build.yml`), never the location it was pointing at — so the report never repeats the disclosure it's warning about.

A skipped file still shows up honestly in the report as "not scanned," rather than silently vanishing and making the repo look cleaner than it actually was.

## Why the fix touches three spots, not one

- **`discover_workflow_files`** — the single place that finds every workflow file in the repo. This is where the new containment check lives.
- **`_undiscovered_workflows`** — a separate safety check that normally yells loudly (and fails the whole scan) if a workflow file exists on disk but the scanner "lost" it somehow. Without a small update here, it would have mistaken our *deliberate* skip for that kind of bug and failed every scan that hit this case. Now it knows the difference.
- **`_repo_relative`** — a formatting helper that turns a full filesystem path into a short one for display in the report. Testing turned up a real bug here: for a dangling symlink, it was re-following the symlink a second time while formatting the report line, which put the (nonexistent) target's name into the coverage note instead of the symlink's own name — undermining the exact protection this PR adds. Fixed so it only cleans up the containing folder's path and leaves the file's own name alone.

## Testing

Added 5 new tests covering:
- a symlink escaping `.github/workflows/` → skipped, noted, target name never appears in the report
- a symlink pointing to another file *inside* `.github/workflows/` → still read normally (this isn't a "ban symlinks" fix, just a "stay in scope" fix)
- a dangling symlink → skipped, noted
- the safety-check update from two angles: it no longer misfires on our deliberate skip, and it still correctly fails a scan on a genuine "file went missing" bug

Full suite: `python3 -m pytest -v` — all passing, no regressions.

Changelog entry added under `skills/ci-secure/CHANGELOG.md` → Fixed, dated 2026-08-20.