### PR TITLE
ci-secure: record the three pattern ids the rejection record silently dropped

### DIFF
--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -109,6 +109,23 @@ entries are dated (UTC). Format loosely follows
 
 ### Changed
 
+- **2026-08-25** — **The rejection record now accounts for every pattern id
+  the old catalog carried, and states the catalog's size correctly.**
+  `references/why-these-ten.md` is the one document that explains why each
+  pattern the scanner no longer ships was dropped, and three ids were missing
+  from it — untrusted-event trigger presence (P14.1), secret passed on the
+  command line (P14.21), and secrets accessible to jobs without environment
+  scoping (P14.4) — so a reader who met one of them in an older finding or
+  catalog reference had nothing defining it. Each now carries its rejection in
+  the document's own idiom. The opening line's arithmetic is corrected with
+  them: the pre-descope catalog held 27 patterns, of which nine of today's ten
+  survived and 18 were removed. It had been stated as 25 and then would have
+  been 28, both of which counted the tenth vector (P14.25) into a catalog it
+  was admitted a week after. The census guard now subtracts post-descope
+  admissions instead of deriving the historical size from every id the
+  document names, so it can fail on that error rather than restate it. No
+  detector, catalog entry or severity changes; the scanner is untouched.
+
 - **2026-08-20** — **Build provenance and artifact attestation now have a
   recorded verdict.** The rejection record in `references/why-these-ten.md`
   accounted for the patterns the descope removed, and attestation —

--- a/skills/ci-secure/references/why-these-ten.md
+++ b/skills/ci-secure/references/why-these-ten.md
@@ -1,9 +1,13 @@
 # Why these ten — the selection criterion behind the critical-only catalog
 
-ci-secure deliberately detects **ten** attack vectors, not the 28 patterns
-its catalog once held — the ten kept, and the 18 the rejection record below
+ci-secure deliberately detects **ten** attack vectors, not the 27 patterns
+its catalog held before the critical-only descope — the nine of today's ten
+that survived it, and the 18 the rejection record below
 names and accounts for, plus one adjacent practice recorded there as
-considered and excluded. This document is the reasoning, shipped with the skill
+considered and excluded. The tenth vector (P14.25) was admitted after the
+descope and was never in that catalog; its own evaluation is below, which is
+why this document shipped as why-these-nine.md until then.
+This document is the reasoning, shipped with the skill
 so every finding can answer "why is this one of only ten?" — and so every
 future "shouldn't we add pattern X?" is tested against a written criterion
 instead of instinct. A census test binds the list below to the scanner's
@@ -150,20 +154,36 @@ these three were removed without being written down:
   finding. `pull_request_target` and its siblings are the entry condition for
   three vectors that ARE in the ten — the shared-cache write (P14.7), fork code
   executed with privileges (P14.9), and `pull-requests: write` on an untrusted
-  trigger (P14.18) — so a maintainer whose repo is clean against those three has
-  nothing left to do about the trigger itself. Naming it separately restates the
-  precondition of findings the scan already raises.
+  trigger (P14.18) — and the template injection those events feed (P14.10) is
+  raised on its own, independent of the trigger — so a maintainer whose repo is
+  clean against those has nothing left to do about the trigger itself. Naming it
+  separately restates the precondition of findings the scan already raises.
 - **Secret passed on the command line (P14.21)** fails the outsider-chain test.
   Process arguments are readable to whatever already executes on that runner, so
-  the exposure widens a breach rather than starting one. That places it with the
-  blast-radius class above: real, and not a chain that starts at outsider.
-- **Secrets accessible to jobs without environment scoping (P14.4)** is a
-  manual-review checklist entry, like P14.6. It asks a human a question rather
-  than raising a finding, and the descope removed the checklist.
+  the exposure widens a breach rather than starting one. Its second arm — the
+  value reaching a run log, which on a public repo anyone can read, and where
+  transforming the secret defeats GitHub's literal-string masking — does start
+  at outsider, but only when the command echoes the value back. The detector
+  never established that: it fired on the interpolation alone. A chain
+  conditional on a shape the check does not test is not the complete chain the
+  filter requires. That places it with the blast-radius class above: real, and
+  not a chain that starts at outsider.
+- **Secrets accessible to jobs without environment scoping (P14.4)** fails the
+  outsider-chain test. It listed every job reading a stored secret without an
+  `environment:` gate — the structural precondition, not proof the secret is a
+  sensitive publish credential, and not a chain an outsider can walk. The
+  routes an attacker actually takes to that secret are already in the ten: a
+  compromised test job, or a workflow added on a malicious PR, both mean
+  execution on the runner first. That places it with the blast-radius class
+  above. Its output also needed per-job human triage to tell release tokens
+  from benign build ones — advisory as flagged, and only HIGH once a human
+  confirmed which jobs mattered.
 
-None of the three is shipped with the skill. Re-admitting any of them means
-passing the three tests above and updating the census, exactly as for any other
-entry in this record.
+No detector for any of the three ships, so none of them can raise a finding.
+Test fixtures named for two of them (`p14_1_*`, `p14_21_*`) do still ship, kept
+deliberately as the negative space the scan must stay silent on. Re-admitting
+any of the three means passing the three tests above and updating the census,
+exactly as for any other entry in this record.
 
 Two catalog-MEDIUM patterns **passed** the filter and stayed: the fork-code
 trust chain (P14.9 — its severity was raised to HIGH with the rebuilt

--- a/skills/ci-secure/references/why-these-ten.md
+++ b/skills/ci-secure/references/why-these-ten.md
@@ -1,7 +1,7 @@
 # Why these ten — the selection criterion behind the critical-only catalog
 
-ci-secure deliberately detects **ten** attack vectors, not the 25 patterns
-its catalog once held — the ten kept, and the 15 the rejection record below
+ci-secure deliberately detects **ten** attack vectors, not the 28 patterns
+its catalog once held — the ten kept, and the 18 the rejection record below
 names and accounts for, plus one adjacent practice recorded there as
 considered and excluded. This document is the reasoning, shipped with the skill
 so every finding can answer "why is this one of only ten?" — and so every
@@ -141,6 +141,29 @@ the gate they can already see, on a vector already in the ten, is capable
 of restricting anything.
 These either became scored config facts — where a one-line
 pass/fail is the honest weight for a presence fact — or were dropped.
+
+**Three more from the old catalog, named here for completeness.** A rejection
+record is only usable if it accounts for every id the old catalog carried, and
+these three were removed without being written down:
+
+- **Untrusted-event trigger presence (P14.1)** reports a precondition, not a
+  finding. `pull_request_target` and its siblings are the entry condition for
+  three vectors that ARE in the ten — the shared-cache write (P14.7), fork code
+  executed with privileges (P14.9), and `pull-requests: write` on an untrusted
+  trigger (P14.18) — so a maintainer whose repo is clean against those three has
+  nothing left to do about the trigger itself. Naming it separately restates the
+  precondition of findings the scan already raises.
+- **Secret passed on the command line (P14.21)** fails the outsider-chain test.
+  Process arguments are readable to whatever already executes on that runner, so
+  the exposure widens a breach rather than starting one. That places it with the
+  blast-radius class above: real, and not a chain that starts at outsider.
+- **Secrets accessible to jobs without environment scoping (P14.4)** is a
+  manual-review checklist entry, like P14.6. It asks a human a question rather
+  than raising a finding, and the descope removed the checklist.
+
+None of the three is shipped with the skill. Re-admitting any of them means
+passing the three tests above and updating the census, exactly as for any other
+entry in this record.
 
 Two catalog-MEDIUM patterns **passed** the filter and stayed: the fork-code
 trust chain (P14.9 — its severity was raised to HIGH with the rebuilt

--- a/skills/ci-secure/tests/test_census_why_these_ten.py
+++ b/skills/ci-secure/tests/test_census_why_these_ten.py
@@ -266,8 +266,19 @@ def test_the_rejection_record_accounts_for_the_catalog_size_it_claims():
     """The opening line states how big the old catalog was; the rejection
     record below it is the ONLY evidence for that number, and the two disagreed
     three ways — the prose said "~27 patterns", a sibling test said "removed
-    19", and the record itself names 15. A claim ABOUT the data has to be
-    checked AGAINST the data, so count the record instead of trusting prose.
+    19", and the record itself named only 15.
+
+    The count moved from 15 to 18 because the record was missing three ids the
+    old catalog actually carried: P14.1 (untrusted-event trigger presence),
+    P14.21 (secret passed on the command line), and P14.4 (the
+    environment-scoping manual-review entry). Those three were removed from
+    the scanner without ever being written down here, so anything citing them
+    had no document defining them. The independent check is a downstream
+    vendored copy of the old ci-secure catalog, which carries 27 ci-secure
+    ids: nine of the ten (P14.25 is absent there) plus exactly 18 non-ten
+    ids — 10 + 18 = 28, matching the corrected opening line. A claim ABOUT
+    the data has to be checked AGAINST the data, so count the record instead
+    of trusting prose.
     """
     text = _WHY.read_text()
     named = _catalog_pattern_ids(text)
@@ -275,7 +286,7 @@ def test_the_rejection_record_accounts_for_the_catalog_size_it_claims():
     assert THE_TEN <= named, (
         "why-these-ten.md must name every kept pattern: "
         f"missing {sorted(THE_TEN - named)}")
-    assert len(removed) == 15, (
+    assert len(removed) == 18, (
         "the rejection record names a different number of removed patterns "
         f"than the prose claims: {len(removed)} — {sorted(removed)}")
     assert f"not the {len(named)} patterns" in text, (

--- a/skills/ci-secure/tests/test_census_why_these_ten.py
+++ b/skills/ci-secure/tests/test_census_why_these_ten.py
@@ -28,6 +28,16 @@ THE_TEN = {
     "P14.15", "P14.18", "P14.19", "P14.24", "P14.25",
 }
 
+# Vectors admitted AFTER the 2026-08-01 critical-only descope. They are part of
+# today's ten but were never in the old catalog, so they must not be counted
+# into its size. CHANGELOG.md's descope entry is the record: "Critical-only
+# descope: the nine attack chains" / "The catalog is now exactly nine
+# outsider -> compromise chains" — which is why this document shipped as
+# why-these-nine.md until P14.25 was admitted 2026-08-06 and renamed it.
+# Without this set the census would derive the historical size from a set that
+# includes a later addition, and could never fail on that error.
+_ADMITTED_AFTER_THE_DESCOPE = {"P14.25"}
+
 
 def _doc_patterns() -> set[str]:
     """Pattern ids from the doc's 'The ten' table (| # | Pattern | ... rows)."""
@@ -126,7 +136,7 @@ def _catalog_pattern_ids(text: str) -> set[str]:
 def test_no_shipped_doc_cites_a_removed_pattern():
     """A whole-catalog + SKILL.md sweep, not a section-scoped one.
 
-    The descope removed 15 patterns. A reader who meets `P8.3` or `P14.22` in
+    The descope removed 18 patterns. A reader who meets `P8.3` or `P14.22` in
     shipped prose has no way to resolve it — the id exists nowhere in the
     installed skill. why-these-ten.md is exempt: naming the removed ids IS
     its rejection record.
@@ -273,25 +283,42 @@ def test_the_rejection_record_accounts_for_the_catalog_size_it_claims():
     P14.21 (secret passed on the command line), and P14.4 (the
     environment-scoping manual-review entry). Those three were removed from
     the scanner without ever being written down here, so anything citing them
-    had no document defining them. The independent check is a downstream
-    vendored copy of the old ci-secure catalog, which carries 27 ci-secure
-    ids: nine of the ten (P14.25 is absent there) plus exactly 18 non-ten
-    ids — 10 + 18 = 28, matching the corrected opening line. A claim ABOUT
-    the data has to be checked AGAINST the data, so count the record instead
-    of trusting prose.
+    had no document defining them.
+
+    The independent check is in this repository and any reader can open it:
+    CHANGELOG.md's "Removed" entry for the descope already recorded "the 18
+    presence-shaped/blast-radius patterns", while this document named only 15
+    — a gap of exactly three, written down here long before it was closed. Two
+    of the three also still have their era's fixtures under
+    tests/fixtures/dot-github/workflows/ (`p14_1_*`, `p14_21_*`), which is
+    direct evidence the old catalog carried them.
+
+    The old catalog's SIZE is nine plus those 18, not ten plus 18. The same
+    CHANGELOG records the descope as "the nine attack chains", and P14.25 was
+    admitted 2026-08-06, after it — so the tenth vector was never in the
+    catalog whose size this line states. Deriving that size from every id the
+    document names would silently count it, which is why the post-descope
+    admissions are subtracted explicitly.
+
+    A claim ABOUT the data has to be checked AGAINST the data, so count the
+    record instead of trusting prose.
     """
     text = _WHY.read_text()
     named = _catalog_pattern_ids(text)
     removed = named - THE_TEN
+    kept_from_the_old_catalog = THE_TEN - _ADMITTED_AFTER_THE_DESCOPE
+    old_catalog_size = len(kept_from_the_old_catalog) + len(removed)
     assert THE_TEN <= named, (
         "why-these-ten.md must name every kept pattern: "
         f"missing {sorted(THE_TEN - named)}")
     assert len(removed) == 18, (
         "the rejection record names a different number of removed patterns "
         f"than the prose claims: {len(removed)} — {sorted(removed)}")
-    assert f"not the {len(named)} patterns" in text, (
-        f"the opening line must say {len(named)} — ten kept plus the "
-        f"{len(removed)} the record accounts for")
+    assert f"not the {old_catalog_size} patterns" in text, (
+        f"the opening line must say {old_catalog_size} — the "
+        f"{len(kept_from_the_old_catalog)} of today's ten that were in the old "
+        f"catalog, plus the {len(removed)} the record accounts for "
+        f"(P14.25 was admitted after the descope and was never in it)")
     assert f"the {len(removed)} the rejection record below" in text
 
 
@@ -348,7 +375,7 @@ def test_the_rejection_record_keeps_its_attestation_verdict():
     """Build provenance / attestation is the practice a reader is most likely
     to expect beside these ten, and its exclusion is the first entry in the
     rejection record that carries no pattern id — so the census equality above
-    (`len(removed) == 15`), which pins every other entry, cannot see it. It
+    (`len(removed) == 18`), which pins every other entry, cannot see it. It
     could be deleted, reversed or contradicted with the whole suite green.
     No test can prove the reasoning is right; what a test can do is stop the
     verdict being dropped the next time this file is trimmed, which is the


### PR DESCRIPTION
## TL;DR

ci-secure ships one document that is supposed to account for every pattern its scanner used to carry and no longer does — it is what a reader falls back on when they meet an old pattern id and want to know why it went away. Three of those ids were missing from it entirely, and the sentence stating how big the old catalog was had been wrong for longer than that, counting in a vector that was only added a week after the cut. This corrects all of it, and rewrites the reasoning for one entry that described a real automated check as a manual questionnaire. Nothing about the scanner or the ten vectors it detects changes.

## What changed

**The three missing ids.** `references/why-these-ten.md` now carries rejections for untrusted-event trigger presence (P14.1), secret passed on the command line (P14.21), and secrets accessible to jobs without environment scoping (P14.4), each written in the document's existing idiom.

**The catalog size.** The opening line claimed the old catalog held 25 patterns, "the ten kept". Both halves were wrong, and the first correction to 28 would have kept the error:

```
stated:   10 kept + 18 removed = 28
actual:    9 kept + 18 removed = 27   (P14.25 admitted 2026-08-06, after the cut)
```

The descope kept nine — the changelog records it as "Critical-only descope: the nine attack chains", and this document shipped as `why-these-nine.md` until the tenth vector was admitted. The census guard could not catch this because it derived the historical size from every id the document names, which includes that later admission; it now subtracts post-descope admissions explicitly, so the invariant can fail on the error instead of restating it.

**One rejection that described the wrong thing.** P14.4 was written up as a manual-review checklist entry that "asks a human a question rather than raising a finding". It was an automated correlated detector that listed every job reading a stored secret without an `environment:` gate, one finding per job. Its rejection is now the blast-radius one that actually applies. P14.21's entry likewise rested only on the process-argument exposure; its log arm is now stated and rejected on the ground that fits it.

**Housekeeping.** Two sibling docstrings still stated the superseded count. The guard's supporting citation pointed at an artifact outside this repository and now points at the changelog entry here that independently records the 18. The claim that none of the three ships is narrowed to detectors, since fixtures named for two of them ship deliberately as negative space.

A dated entry is added to the skill's changelog.

## Verification

- Red proof for the guard change: with the new invariant in place and the document left at its "28 patterns / the ten kept" claim, the census fails with `AssertionError: the opening line must say 27 — the 9 of today's ten that were in the old catalog, plus the 18 the record accounts for`. Correcting the line returns it to green.
- The count of 18 is corroborated inside this repository: the changelog's "Removed" entry for the descope already recorded "the 18 presence-shaped/blast-radius patterns" while the document named only 15 — the gap of exactly three, written down before it was closed.
- The three rejection rewrites were checked against the pre-descope catalog archive rather than inferred: P14.4 carries `detector: yaml-job-correlated`, P14.1 `yaml-on-trigger`, P14.21 `yaml-run-injection`. None was a manual entry.
- Scanner untouched: no file under `scripts/` is in the diff.

## Known unrelated red check

`registry scan` is failing, and it fails identically on `main` and has since 2026-08-19. The upstream scanner dropped the `--ignore-issues-codes` argument the workflow passes, so the step exits before scanning anything. It is not a required check and not a security finding on this branch. Worth a separate fix, since the workflow currently reports that break as though it were a critical finding.

## Follow-ups, deliberately not in this diff

- Five shipped fixture headers still assert scanner expectations for P14.1 and P14.21 that can no longer hold ("exactly 2 P14.1 findings on this file"). Pre-existing, and correcting them touches files unrelated to this correction.
- `_DROPPED_PATTERN_FIXTURE_STEMS` in the scan tests omits `p14_21_`, so those fixtures are not covered by the guard that asserts removed shapes raise nothing. The global expected-count manifest still backstops it.
- The census pins the *number* of removed ids rather than the set, so deleting one entry while adding an unrelated id anywhere in the document keeps it green. Freezing the set would make the record self-enforcing.
