### PR TITLE
sling: the skill tracks CLI 0.1.8 and its new agent_skill doctor check

### DIFF
--- a/skills/sling/CHANGELOG.md
+++ b/skills/sling/CHANGELOG.md
@@ -55,18 +55,25 @@ All notable changes to the `sling` skill. Unversioned; dated (UTC).
 
 - **2026-08-31** — **Re-pinned every version-pinned fact against `sling`
   v0.1.8** (what the installer serves since 2026-08-31) and **documented
-  `doctor`'s new `agent_skill` check**: advisory in all three shapes
-  (installed / agent-without-skill / no agent), never a health failure, and
-  a row an agent following this skill must report rather than act on — its
-  own copy of the skill demonstrably exists. Also corrected two stale
-  preflight claims from the 0.1.2 era: an upgrade notice now reads
-  `warn: true` (not `skipped: true`), and the `version` `fix_command` is the
-  real installer one-liner (a shell pipeline to surface to the user), no
-  longer a fake subcommand. All prior probes re-verified unchanged on
-  0.1.8: `--compact` absent, `sling update` unknown, `logs` rejects
-  `--org`, empty scope-flag exits `2`, `exit-codes` lists only `0`–`5`.
-
-
+  `doctor`'s new `agent_skill` check** in all **four** shapes it emits
+  (per-agent home / shared `.agents` home / agent-without-skill /
+  no agent), each quoted as the binary prints it. The row can never make
+  `doctor` unhealthy, and the reason is now stated rather than asserted: a
+  check fails only when it is `ok: false` AND not `skipped`, and this row's
+  only `ok: false` shape is also `skipped: true`. Its `fix_command` is a
+  mutating install and is never for the agent to run — but a `warn` row is
+  no longer described as impossible to see from inside the skill: the check
+  only looks in a fixed set of directories, so a copy delivered any other
+  way reads as "not installed" while the agent is reading it, and that row
+  is worth surfacing to the user. Also corrected two stale preflight claims
+  from the 0.1.2 era: an upgrade notice reads `warn: true` (not
+  `skipped: true`), and the `version` `fix_command` is the real installer
+  one-liner (a shell pipeline to surface to the user), no longer a fake
+  subcommand — with `version`'s own `ok: false, skipped: true`
+  "could not compare" shape kept named. All prior probes re-verified
+  unchanged on 0.1.8: `--compact` absent, `sling update` unknown, `logs`
+  rejects `--org`, empty scope-flag exits `2`, `exit-codes` lists only
+  `0`–`5`.
 - **2026-08-27** — **Re-pinned every version-pinned fact against `sling`
   v0.1.5** (the version the installer now serves; 0.1.3, 0.1.4 and 0.1.5
   shipped across 2026-08-26/27, all release- or test-plumbing only). Re-verified on the new binary:
@@ -84,6 +91,21 @@ All notable changes to the `sling` skill. Unversioned; dated (UTC).
   <github-url>`).
 
 ### Fixed
+
+- **2026-08-31** — **The commands-must-exist guard no longer stops reading at
+  a `"detail"` string.** Documenting `doctor`'s `agent_skill` row meant
+  quoting output that reads as a command (`sling skill installed for …`), and
+  the first pass bought that by exempting every `"detail"` value from the
+  scan — which blinded the guard in the highest-risk place it has, since
+  details are where the binary prints commands (`fix_command: "sling update"`
+  is this skill's founding anecdote) and the preflight tells the agent to read
+  them. One WORD is waved through now instead of one field, so an invented
+  `sling rerun` inside a detail still fails; two tests pin both directions.
+  Three new guards also pin the re-pin itself, which nothing covered before: every
+  live `0.1.x` mention must match `command-surface.json`'s `cli_version`, that
+  file's two provenance dates must agree (they had drifted six days), and
+  every `doctor` check key the reference documents must be named in preflight
+  step 2 — the way a release that adds a check reaches both surfaces.
 
 - **2026-08-26** — **The parse contract was falsified by the binary, in the
   direction that loses data.** SKILL.md said a genuine error writes nothing to

--- a/skills/sling/CHANGELOG.md
+++ b/skills/sling/CHANGELOG.md
@@ -53,6 +53,20 @@ All notable changes to the `sling` skill. Unversioned; dated (UTC).
 
 ### Changed
 
+- **2026-08-31** — **Re-pinned every version-pinned fact against `sling`
+  v0.1.8** (what the installer serves since 2026-08-31) and **documented
+  `doctor`'s new `agent_skill` check**: advisory in all three shapes
+  (installed / agent-without-skill / no agent), never a health failure, and
+  a row an agent following this skill must report rather than act on — its
+  own copy of the skill demonstrably exists. Also corrected two stale
+  preflight claims from the 0.1.2 era: an upgrade notice now reads
+  `warn: true` (not `skipped: true`), and the `version` `fix_command` is the
+  real installer one-liner (a shell pipeline to surface to the user), no
+  longer a fake subcommand. All prior probes re-verified unchanged on
+  0.1.8: `--compact` absent, `sling update` unknown, `logs` rejects
+  `--org`, empty scope-flag exits `2`, `exit-codes` lists only `0`–`5`.
+
+
 - **2026-08-27** — **Re-pinned every version-pinned fact against `sling`
   v0.1.5** (the version the installer now serves; 0.1.3, 0.1.4 and 0.1.5
   shipped across 2026-08-26/27, all release- or test-plumbing only). Re-verified on the new binary:

--- a/skills/sling/SKILL.md
+++ b/skills/sling/SKILL.md
@@ -48,20 +48,29 @@ Do this once per session, before the first `sling` command.
 2. **Is the environment healthy?** `sling doctor --agent`. It emits
    `{"checks": [{"key", "ok", "detail", ...}]}` on stdout and **exits `10`
    when a real check fails** (`0` when healthy). The checks name the
-   problem — `token`, `control_plane`, `clock_skew`, `git_remote`,
-   `patch_tooling`, `version`, `org`, `agent_skill` — so act on the one that is `ok:
-   false` instead of guessing — and when SEVERAL are `ok: false`, act on
+   problem. Seven of the eight are actionable — `token`, `control_plane`,
+   `clock_skew`, `git_remote`, `patch_tooling`, `version`, `org` — so act on
+   the one that is `ok: false` instead of guessing (the eighth, `agent_skill`,
+   is advisory only; see below) — and when SEVERAL are `ok: false`, act on
    `control_plane` first: an unreachable control plane fails `token` and `org`
    as dependents, and the `token` check still attaches `fix_command: "sling
    login"` — a wrong lead during an outage, since the device flow cannot reach
    the control plane either. Network first, never login. `"skipped": true` can
    also mean "not checked" for exactly this reason — read `detail`, not just
    the flag. A `version` check with `warn: true` is an upgrade
-   notice, not a failure — its `fix_command` is the installer one-liner, a
-   shell pipeline, so surface it to the user rather than running it yourself.
-   The `agent_skill` row is likewise advisory and never unhealthy: it reports
-   whether THIS skill is installed for a coding agent on the machine, so if
-   you are reading this, your copy exists — report the row, never "fix" it
+   notice, not a failure — any `fix_command` it carries is the installer
+   one-liner, a shell pipeline, so surface it to the user rather than running
+   it yourself. `version` reads `ok: false, skipped: true` when it could not
+   compare at all (installer URL unreachable, served version unreadable) —
+   that is "not checked", not "out of date".
+   The `agent_skill` row is likewise advisory and can never make `doctor`
+   unhealthy: a check counts as failing only when it is `ok: false` AND not
+   `skipped`, and this row's only `ok: false` shape is also `skipped: true`.
+   It reports whether this skill is installed for a coding agent on the
+   machine, and it can read "not installed" while you are reading the skill,
+   because it only looks in a fixed set of directories. So report the row with
+   its detail and never run its `fix_command` yourself — installing is the
+   user's call
    (see [references/command-reference.md](references/command-reference.md)).
 
 3. **Not authenticated** (`doctor`'s `token` check fails, or a command exits

--- a/skills/sling/SKILL.md
+++ b/skills/sling/SKILL.md
@@ -29,7 +29,7 @@ that owns it and stop. Do not invent a `sling` subcommand for something
 surface](references/command-surface.json) is the complete list.
 
 Every fact in this skill's command reference was read off `sling` itself
-(v0.1.5) rather than from documentation — see
+(v0.1.8) rather than from documentation — see
 [references/command-reference.md](references/command-reference.md) for the
 verified per-command JSON shapes.
 
@@ -49,17 +49,20 @@ Do this once per session, before the first `sling` command.
    `{"checks": [{"key", "ok", "detail", ...}]}` on stdout and **exits `10`
    when a real check fails** (`0` when healthy). The checks name the
    problem — `token`, `control_plane`, `clock_skew`, `git_remote`,
-   `patch_tooling`, `version`, `org` — so act on the one that is `ok:
+   `patch_tooling`, `version`, `org`, `agent_skill` — so act on the one that is `ok:
    false` instead of guessing — and when SEVERAL are `ok: false`, act on
    `control_plane` first: an unreachable control plane fails `token` and `org`
    as dependents, and the `token` check still attaches `fix_command: "sling
    login"` — a wrong lead during an outage, since the device flow cannot reach
    the control plane either. Network first, never login. `"skipped": true` can
    also mean "not checked" for exactly this reason — read `detail`, not just
-   the flag. A `version` check with `"skipped": true` is
-   an upgrade notice, not a failure — and the fix command it suggests is not
-   a real subcommand, so re-run the installer instead of running it (see
-   [references/command-reference.md](references/command-reference.md)).
+   the flag. A `version` check with `warn: true` is an upgrade
+   notice, not a failure — its `fix_command` is the installer one-liner, a
+   shell pipeline, so surface it to the user rather than running it yourself.
+   The `agent_skill` row is likewise advisory and never unhealthy: it reports
+   whether THIS skill is installed for a coding agent on the machine, so if
+   you are reading this, your copy exists — report the row, never "fix" it
+   (see [references/command-reference.md](references/command-reference.md)).
 
 3. **Not authenticated** (`doctor`'s `token` check fails, or a command exits
    `4` **whose stderr does not name an org**): **ask the user to run `sling
@@ -170,7 +173,7 @@ per-command wording.
 
 **Do not describe it as an alias for a longer flag list.** The published docs
 call it "exactly equivalent to `--json --compact --no-input --no-color
---yes`", and on v0.1.5 `--compact` is not a flag this binary has at all:
+--yes`", and on v0.1.8 `--compact` is not a flag this binary has at all:
 passing it changes nothing because unknown flags are ignored, not because it
 does anything. Output is pretty-printed, indented JSON either way, so feed
 stdout to a real JSON parser and never to a line-oriented one that assumes
@@ -330,7 +333,7 @@ a parseable one tells you what happened; only `$?` does.
 | `7` | Rate limited (HTTP 429) | Back off and retry once. On a second `429`, stop: fall back to the `gh` read equivalent and say `sling` was rate limited |
 | `10` | Remote outcome failed — `doctor` unhealthy, or `runs show --wait` on a run that did not succeed | **Not a CLI error.** This is the answer: report the unhealthy check, or the run's failure |
 
-`sling exit-codes` on v0.1.5 prints only `0`–`5`; codes `6`, `7`, and `10`
+`sling exit-codes` on v0.1.8 prints only `0`–`5`; codes `6`, `7`, and `10`
 are real and documented (and `doctor --help` names `10` itself), so treat
 that help text as abridged. Any non-zero code not in this table: surface
 stderr to the user rather than guessing a recovery.
@@ -340,13 +343,13 @@ stderr to the user rather than guessing a recovery.
 These are the places where `sling` behaves differently from what its own
 output, its `--help`, or its documentation implies. Each was found by
 running the binary; none of them announce themselves at runtime. Everything
-version-pinned here was verified against `sling` v0.1.5 and `gh` 2.93.0 —
+version-pinned here was verified against `sling` v0.1.8 and `gh` 2.93.0 —
 re-verify on upgrade.
 
 - **`doctor`'s `fix_command` is advice, not a verified command.** On 0.1.2
   its `version` check recommended a command that did not exist — it emitted
   `"fix_command": "sling update"`, and `sling update` does not exist in any
-  release (0.1.5 still rejects it as unknown; the check now emits the
+  release (0.1.8 still rejects it as unknown; the check now emits the
   installer one-liner instead). Other checks emit templates with unfilled
   placeholders: `git_remote` suggests `git remote add origin <github-url>`
   verbatim. Never run a `fix_command` unchecked. The general lesson outlives

--- a/skills/sling/references/command-reference.md
+++ b/skills/sling/references/command-reference.md
@@ -90,6 +90,11 @@ Exits `0` healthy, **`10` unhealthy**.
              "detail": "sling skill installed for Claude Code"}]}
 ```
 
+The `version` row above is shown deliberately in its OUTDATED shape, so the
+upgrade fields are visible; a current binary reports
+`{"key": "version", "ok": true, "detail": "up to date (0.1.8)"}` with no
+`warn` and no `fix_command`. Every other row is a live 0.1.8 capture.
+
 `"skipped": true` means the check produced NO verdict — a check that could
 not run at all (`clock_skew` and `org` under an unreachable control plane
 read `ok: false, skipped: true, "not checked"`). Read `detail`; a skipped
@@ -97,16 +102,31 @@ check is never a pass. An outdated-but-working version reads `ok: true,
 warn: true` with the upgrade one-liner in `fix_command` — advisory, not a
 failure (up to date it reads `ok: true, "up to date (<version>)"`).
 
-**`agent_skill` (new in 0.1.8) is advisory and can never fail the run.** It
-reports whether this very skill is installed for a coding agent on the
-machine, in three shapes: installed → `ok: true` naming the agents it was
-found under; a coding agent present but no skill → `ok: true, warn: true`
-with the install command in `fix_command`; no coding agent at all →
-`ok: false, skipped: true` ("no coding agent detected"), which per the rule
-above is a non-verdict, not a failure. An agent following this skill needs
-to do nothing with this row: if you are reading this file, your copy of the
-skill exists — report the row's detail if asked, and never run its
-`fix_command` to "fix" your own environment.
+**`agent_skill` (new in 0.1.8) is advisory and can never fail the run.**
+`doctor` is unhealthy only when a check is `ok: false` AND not `skipped`, and
+this check's only `ok: false` shape is also `skipped: true` — so it never
+contributes to exit `10`. It reports whether this skill is installed for a
+coding agent on the machine, in four shapes:
+
+| Shape | Row |
+|---|---|
+| Installed under a per-agent home (`.claude` / `.codex` / `.cursor`) | `ok: true`, `"sling skill installed for <agents>"` |
+| Installed under the shared `.agents` home | `ok: true`, `"sling skill installed"` — no agent named |
+| A coding agent is present but the skill is not | `ok: true, warn: true`, `"not installed — …, to install:"`, with the install command in `fix_command` |
+| No coding agent found | `ok: false, skipped: true`, `"no supported coding agent detected"` (the detail closes "— sling is usable directly") — per the rule above a non-verdict, not a failure |
+
+**Never run this row's `fix_command` yourself** — it is a mutating install,
+and the machine's own agent configuration is the user's to change.
+
+**Do not read a `warn` row as proof your own copy is missing.** The check
+only looks under `<root>/{.claude,.codex,.cursor,.agents}/skills/sling/`, for
+`$HOME` and for the current directory walked up to the first `.git` — so a
+skill delivered any other way (a plugin or marketplace directory, a repo
+checkout, an outer repo above a nested `.git`, a different `HOME` than the
+one `sling` sees) reads as "not installed" while you are demonstrably
+reading it. That row is still worth surfacing: it means the user has no
+installed copy for their agent, and the `fix_command` is what fixes it. Report
+it with its detail; do not act on it, and do not treat it as a failure.
 
 ### `sling whoami [--agent]`
 

--- a/skills/sling/references/command-reference.md
+++ b/skills/sling/references/command-reference.md
@@ -2,7 +2,7 @@
 
 Every flag list and JSON shape below was **read off the binary**, not off
 documentation: each command was run with `--agent` against a live control
-plane on **`sling` v0.1.5**, 2026-08-27. Where the published docs and the
+plane on **`sling` v0.1.8**, 2026-08-31. Where the published docs and the
 binary disagree, the binary wins and the disagreement is noted.
 
 Field names are `snake_case` everywhere **except `whoami`**. Objects are
@@ -32,7 +32,7 @@ Available on the root command and every subcommand **except `sling logs`**, whos
 
 | Flag | Meaning |
 |---|---|
-| `--agent` | Machine mode. The PUBLISHED DOCS call it equivalent to `--json --compact --no-input --no-color --yes`; no help page says that, and `--compact` is not a flag this binary has (0.1.5) — it changes nothing because unknown flags are ignored. Pass it on every **data** command — never on `sling login`, and give `sling org switch` an explicit slug |
+| `--agent` | Machine mode. The PUBLISHED DOCS call it equivalent to `--json --compact --no-input --no-color --yes`; no help page says that, and `--compact` is not a flag this binary has (0.1.8) — it changes nothing because unknown flags are ignored. Pass it on every **data** command — never on `sling login`, and give `sling org switch` an explicit slug |
 | `--json` | JSON on stdout (implied by `--agent`) |
 | `--org <slug>` | Org context. Auto-resolved when unambiguous; default set by `sling org switch` |
 | `--repo <owner/name>` | Repo context. Defaults to the git remote of the current directory |
@@ -83,9 +83,11 @@ Exits `0` healthy, **`10` unhealthy**.
             {"key": "git_remote", "ok": true, "detail": "origin → …"},
             {"key": "patch_tooling", "ok": true, "detail": "git found (/usr/bin/git)"},
             {"key": "version", "ok": true, "warn": true,
-             "detail": "version 0.1.4\n0.1.5 is available, to update:",
+             "detail": "version 0.1.7\n0.1.8 is available, to update:",
              "fix_command": "<the installer one-liner from the installation page>"},
-            {"key": "org", "ok": true, "detail": "starslingdev (paid)"}]}
+            {"key": "org", "ok": true, "detail": "starslingdev (paid)"},
+            {"key": "agent_skill", "ok": true,
+             "detail": "sling skill installed for Claude Code"}]}
 ```
 
 `"skipped": true` means the check produced NO verdict — a check that could
@@ -94,6 +96,17 @@ read `ok: false, skipped: true, "not checked"`). Read `detail`; a skipped
 check is never a pass. An outdated-but-working version reads `ok: true,
 warn: true` with the upgrade one-liner in `fix_command` — advisory, not a
 failure (up to date it reads `ok: true, "up to date (<version>)"`).
+
+**`agent_skill` (new in 0.1.8) is advisory and can never fail the run.** It
+reports whether this very skill is installed for a coding agent on the
+machine, in three shapes: installed → `ok: true` naming the agents it was
+found under; a coding agent present but no skill → `ok: true, warn: true`
+with the install command in `fix_command`; no coding agent at all →
+`ok: false, skipped: true` ("no coding agent detected"), which per the rule
+above is a non-verdict, not a failure. An agent following this skill needs
+to do nothing with this row: if you are reading this file, your copy of the
+skill exists — report the row's detail if asked, and never run its
+`fix_command` to "fix" your own environment.
 
 ### `sling whoami [--agent]`
 

--- a/skills/sling/references/command-surface.json
+++ b/skills/sling/references/command-surface.json
@@ -1,6 +1,6 @@
 {
-  "_comment": "The complete set of sling subcommands, captured from `sling --help` on v0.1.5 (2026-08-27). This file exists so a test can prove SKILL.md never routes to a subcommand that does not exist. Update it, and the changelog, when a sling release adds or removes a command.",
-  "cli_version": "0.1.5",
+  "_comment": "The complete set of sling subcommands, captured from `sling --help` on v0.1.8 (2026-08-31). This file exists so a test can prove SKILL.md never routes to a subcommand that does not exist. Update it, and the changelog, when a sling release adds or removes a command.",
+  "cli_version": "0.1.8",
   "captured_utc": "2026-08-25",
   "read_only": true,
   "groups": {

--- a/skills/sling/references/command-surface.json
+++ b/skills/sling/references/command-surface.json
@@ -1,7 +1,7 @@
 {
   "_comment": "The complete set of sling subcommands, captured from `sling --help` on v0.1.8 (2026-08-31). This file exists so a test can prove SKILL.md never routes to a subcommand that does not exist. Update it, and the changelog, when a sling release adds or removes a command.",
   "cli_version": "0.1.8",
-  "captured_utc": "2026-08-25",
+  "captured_utc": "2026-08-31",
   "read_only": true,
   "groups": {
     "auth_and_setup": [

--- a/skills/sling/tests/test_sling_routing.py
+++ b/skills/sling/tests/test_sling_routing.py
@@ -120,6 +120,12 @@ def test_detector_recognises_a_real_and_a_fake_command():
     assert _mentions("`sling logs 97912608061 --agent --limit 60`") == {"logs"}
 
 
+# Words that follow `sling` in output the binary PRINTS, where they are plain
+# English rather than a subcommand. Keep this list one word long if you can:
+# every entry is a word the guard can no longer catch anywhere.
+_QUOTED_OUTPUT_NOUNS = {"skill"}
+
+
 def _assert_only_real_commands(text: str, where: str) -> None:
     """A `sling <cmd>` a reader could act on must exist — with one allowance:
     naming a non-command in order to WARN about it is the opposite of the
@@ -127,13 +133,16 @@ def _assert_only_real_commands(text: str, where: str) -> None:
     `sling update` is the live case: `sling doctor` recommends it and the
     binary rejects it, so warning about it by name is the useful thing to do.
 
-    A `"detail": "..."` string is exempt before scanning: details quote what
-    the binary PRINTS (doctor's `agent_skill` row says "sling skill installed
-    for …"), and quoted output is not a command a reader could route to."""
-    scanned = re.sub(r'"detail":\s*"[^"]*"', '"detail": ""', text)
-    unknown = _mentions(scanned) - _COMMANDS
+    One WORD is waved through rather than one field: `doctor`'s `agent_skill`
+    row prints "sling skill installed for …", and `skill` is a noun there, not
+    a subcommand a reader could route to. Exempting the whole `"detail"` value
+    instead would blind the guard in the highest-risk place it has — details
+    are where the binary prints commands (`fix_command: "sling update"` is
+    this skill's founding anecdote) and step 2 tells the agent to read them —
+    so an invented `sling rerun` inside a detail must still fail."""
+    unknown = _mentions(text) - _COMMANDS - _QUOTED_OUTPUT_NOUNS
     warned = {c for c in unknown
-              if re.search(rf"`sling {c}`[^.]{{0,120}}?does not\s+exist", scanned, re.S)}
+              if re.search(rf"`sling {c}`[^.]{{0,120}}?does not\s+exist", text, re.S)}
     invented = unknown - warned
     assert not invented, (
         f"{where} routes to sling subcommand(s) that do not exist: "
@@ -166,6 +175,41 @@ def test_the_warning_allowance_does_not_swallow_a_plain_invention():
     beside it must still fail, or the exemption quietly disables the guard."""
     with pytest.raises(AssertionError):
         _assert_only_real_commands("Just run `sling rerun 123` to retry.", "sample")
+
+
+# A `"detail"` value quoting the binary is the shape the quoted-output
+# allowance exists for; anything else inside one is still routing a reader.
+_DETAIL_BLOCK = (
+    '```json\n'
+    '{"checks": [{"key": "agent_skill", "ok": true,\n'
+    '             "detail": "%s"}]}\n'
+    '```\n'
+)
+
+
+@pytest.mark.parametrize("invention", ["frobnicate", "rerun"])
+def test_a_detail_string_does_not_launder_an_invented_command(invention):
+    """Teeth check on the quoted-output allowance. `doctor` details are the
+    HIGHEST-risk place for a command that does not exist, not the lowest: the
+    skill's founding anecdote is the binary itself printing `sling update`,
+    and step 2 tells the agent to read `detail` and act on it. So exempting a
+    whole `"detail"` value would blind the guard exactly where it is needed —
+    `rerun` is the canonical case, the invention this whole file exists to
+    stop. Only the phrase the binary really prints may be waved through."""
+    with pytest.raises(AssertionError):
+        _assert_only_real_commands(
+            _DETAIL_BLOCK % f"run `sling {invention} 123` to fix", "sample")
+
+
+def test_the_quoted_output_allowance_covers_the_detail_the_binary_prints():
+    """The other direction: `doctor`'s `agent_skill` row prints "sling skill
+    installed for …", so documenting that row verbatim must NOT trip the
+    guard. Without this the reference cannot quote the binary at all."""
+    _assert_only_real_commands(
+        _DETAIL_BLOCK % "sling skill installed for Claude Code", "sample")
+    _assert_only_real_commands(
+        _DETAIL_BLOCK % "not installed \u2014 the sling skill lets your coding "
+                        "agent run sling for you, to install:", "sample")
 
 
 # The canonical state-changing actions, as the routing table names them.
@@ -866,3 +910,58 @@ def test_evals_encode_rules_the_suite_cannot_otherwise_see():
                        for k in ("hand", "read", "did not", "not invoke", "never")), (
                 f"eval {case['id']} is should-not-trigger but its assertions do not "
                 "describe a refusal or handoff")
+
+
+# --- Re-pin parity: the facts a version bump must carry to every surface ----
+#
+# This skill's whole premise is "every fact was read off the binary at a pinned
+# version". Two things make that premise rot silently, and both have happened:
+# a re-pin that updates some surfaces and not others, and a documented `doctor`
+# shape that drifts from the check list the preflight tells an agent to act on.
+
+# Versions the docs cite deliberately as HISTORY, not as the current pin:
+# 0.1.2 is the `fix_command: "sling update"` anecdote, and 0.1.7 is the
+# outdated-binary side of the reference's illustrative `version` upgrade row.
+_HISTORICAL_VERSIONS = {"0.1.2", "0.1.7"}
+# Scoped to sling's own 0.1.x family: these files also cite `gh` and the
+# Actions runner, whose versions are not this skill's to pin.
+_VERSION_RE = re.compile(r"\bv?(0\.1\.\d+)\b")
+
+
+@pytest.mark.parametrize("name", ["SKILL.md", "references/command-reference.md"])
+def test_every_live_version_pin_matches_the_captured_cli_version(name):
+    """A re-pin that misses a surface leaves the skill asserting two different
+    versions of the truth, and nothing goes red. `command-surface.json` is the
+    capture of record, so every other live mention must agree with it."""
+    pinned = _SURFACE["cli_version"]
+    text = _BODY if name == "SKILL.md" else (_SKILL / name).read_text()
+    found = set(_VERSION_RE.findall(text)) - _HISTORICAL_VERSIONS
+    assert found == {pinned}, (
+        f"{name} cites version(s) {sorted(found)} but "
+        f"command-surface.json pins {pinned!r}. Re-pin every surface together, "
+        f"or add a deliberate historical citation to _HISTORICAL_VERSIONS.")
+
+
+def test_the_surface_captures_provenance_agree_with_each_other():
+    """`_comment` and `captured_utc` are the file's only provenance, and they
+    drifted six days apart once because a re-pin moved one and not the other."""
+    assert _SURFACE["captured_utc"] in _SURFACE["_comment"], (
+        f"captured_utc {_SURFACE['captured_utc']!r} is not the date named in "
+        f"_comment: {_SURFACE['_comment']!r}")
+
+
+def test_every_doctor_check_key_is_named_in_the_preflight():
+    """The preflight tells an agent which rows to act on; the reference
+    documents what `doctor` emits. A release that adds a check (0.1.8 added
+    `agent_skill`) must land on BOTH, or the agent meets a row its contract
+    never mentions."""
+    ref = (_SKILL / "references" / "command-reference.md").read_text()
+    block = ref[ref.index('{"checks": ['):]
+    block = block[:block.index("```")]
+    keys = re.findall(r'"key":\s*"([a-z_]+)"', block)
+    assert len(keys) >= 8, f"doctor example lists only {keys}"
+    step = _preflight_step(2)
+    missing = [k for k in keys if f"`{k}`" not in step]
+    assert not missing, (
+        f"preflight step 2 never names doctor check(s) {missing}, which "
+        f"references/command-reference.md documents `doctor` as emitting.")

--- a/skills/sling/tests/test_sling_routing.py
+++ b/skills/sling/tests/test_sling_routing.py
@@ -125,10 +125,15 @@ def _assert_only_real_commands(text: str, where: str) -> None:
     naming a non-command in order to WARN about it is the opposite of the
     failure, so it passes only when the same file says the command is not real.
     `sling update` is the live case: `sling doctor` recommends it and the
-    binary rejects it, so warning about it by name is the useful thing to do."""
-    unknown = _mentions(text) - _COMMANDS
+    binary rejects it, so warning about it by name is the useful thing to do.
+
+    A `"detail": "..."` string is exempt before scanning: details quote what
+    the binary PRINTS (doctor's `agent_skill` row says "sling skill installed
+    for …"), and quoted output is not a command a reader could route to."""
+    scanned = re.sub(r'"detail":\s*"[^"]*"', '"detail": ""', text)
+    unknown = _mentions(scanned) - _COMMANDS
     warned = {c for c in unknown
-              if re.search(rf"`sling {c}`[^.]{{0,120}}?does not\s+exist", text, re.S)}
+              if re.search(rf"`sling {c}`[^.]{{0,120}}?does not\s+exist", scanned, re.S)}
     invented = unknown - warned
     assert not invented, (
         f"{where} routes to sling subcommand(s) that do not exist: "
@@ -597,7 +602,7 @@ def test_the_scope_flags_are_not_claimed_to_be_universal():
 def test_agent_is_not_described_as_an_alias_for_flags_it_does_not_have():
     """The reference's stated premise is that it was read off the binary.
 
-    `--compact` does not exist in v0.1.5 — the published docs call `--agent`
+    `--compact` does not exist in v0.1.8 — the published docs call `--agent`
     "exactly equivalent to --json --compact --no-input --no-color --yes", and
     repeating that attributes to the tool a contract no help page states.
     """


### PR DESCRIPTION
## TL;DR

The CLI shipped three releases since the skill launched, and the newest one added a row to its health check that tells users whether the agent skill is installed. This updates the skill to match what a fresh install serves today, with every documented fact re-read off the released binary. Two things the first pass got wrong are fixed here: the new row has four shapes rather than three, and the skill told agents to ignore it on the reasoning that "if you are reading this, your copy exists" — which is false precisely when the row fires, because the check only looks in a fixed set of directories. Documenting the row also required quoting output that reads like a command, and the shortcut taken for that had blinded the skill's commands-must-exist guard to every quoted diagnostic string; that is narrowed back down here, with tests pinning both directions.

## What's in the PR

**The re-pin.** Every version pin moves 0.1.5 to 0.1.8, with the full probe set re-run against the released binary. All previously documented behaviors are unchanged: `--compact` absent, `sling update` unknown, `logs` rejects `--org`/`--repo`, empty scope-flag exits `2`, `exit-codes` lists only `0`-`5`.

**`doctor`'s new `agent_skill` check**, documented in all four shapes the binary emits — installed under a per-agent home, installed under the shared `.agents` home (`ok: true` with no agent named), a coding agent present without the skill (`warn: true` with the install command), and no coding agent at all (`ok: false, skipped: true`) — each quoted as the binary prints it. The "never a health failure" contract is now shown rather than asserted: a check fails only when it is `ok: false` **and** not `skipped`, and this row's only `ok: false` shape is also `skipped: true`.

**The row's guidance is corrected.** A `warn` row is a true, user-facing signal, not something for an agent to dismiss — the check only scans `$HOME` and the current directory up to the first `.git`, for a fixed set of skill directories, so a copy delivered any other way (a plugin directory, a repo checkout, an outer repo above a nested `.git`) reads as "not installed" while the agent is reading it. The rule that stands is: report the row, never run its `fix_command` — that is a mutating install and the user's call. `agent_skill` also moves out of the list of rows to *act* on, which the same paragraph then told the agent never to act on.

**Two stale preflight claims from the 0.1.2 era** are corrected: an upgrade notice reads `warn: true` (not `skipped: true`), and the `version` check's `fix_command` is the real installer one-liner — a shell pipeline to surface to the user, not to run. `version`'s own `ok: false, skipped: true` "could not compare" shape is kept named, so the row is not left with only one documented failure mode.

**The commands-must-exist guard keeps its teeth.** Quoting the `agent_skill` detail meant shipping text that scans as a command, and the first pass bought that by exempting every `"detail"` value before scanning — which blinded the guard in the highest-risk place it has, since details are where the binary prints commands and preflight step 2 tells the agent to read them. One word is waved through now instead of one field, so an invented `sling rerun` inside a detail still fails.

**Three new guards pin the re-pin itself**, which nothing covered before: every live `0.1.x` mention must match `command-surface.json`'s `cli_version`; that file's two provenance dates must agree (they had drifted six days, and `captured_utc` is corrected); and every `doctor` check key the reference documents must be named in preflight step 2, so a release that adds a check has to reach both surfaces.

## Verification

The probe set ran against the released 0.1.8 binary installed via the public installer, and the `agent_skill` shapes were checked against the binary's own implementation rather than inferred.

The guard narrowing carries a red-first proof — the two boundary tests were run against the blanket exemption before it was narrowed and failed there:

```
FAILED test_a_detail_string_does_not_launder_an_invented_command[frobnicate]
FAILED test_a_detail_string_does_not_launder_an_invented_command[rerun]
E   Failed: DID NOT RAISE <class 'AssertionError'>
```

`sling rerun` inside a detail string shipped green under the exemption — the exact invention the file was written to stop. Each of the three new parity guards was mutation-checked and observed failing on a mutant. The skill's own suite passes (71 tests), and the full repo suite ran green in the pre-commit hook (4506 passed).
