### PR TITLE
ci-speedup: full-history checkout stops recommending a fix that breaks the job

### DIFF
--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -245,6 +245,26 @@ unversioned and updates by reinstall from `main`.
 
 ### Fixed
 
+- **2026-09-02** — **Full-history checkout now reads a `$` on a `git diff` line
+  as a base ref only where a ref can stand, and stops treating a blob read at
+  `HEAD` as a history operation.** The carve-out that spares a load-bearing
+  `fetch-depth: 0` had been widened to recognise a base ref held in a shell
+  variable, including one passed as a positional parameter (`git diff "$1"
+  HEAD`). But it accepted a `$` anywhere on the line, so four ordinary commands
+  that read nothing older than the working tree silenced the finding: a diff
+  written to a file (`git diff --stat >> $GITHUB_STEP_SUMMARY`, `git diff >
+  $OUT`), and a diff restricted to a path after the `--` separator (`git diff
+  --exit-code -- "$FILE"`). A redirection target is never a ref and everything
+  after a bare `--` is a pathspec, so neither position counts any more; option
+  flags such as `--name-only` are unaffected. Separately, `git cat-file` was
+  treated as a history operation unconditionally, but `git cat-file -p
+  HEAD:package.json` reads a blob at the checked-out commit, which is present at
+  any clone depth — a `HEAD` operand (though not `HEAD~1` or `HEAD^`) no longer
+  suppresses. Every genuine history read the carve-out already recognised —
+  merge-base diffs, two-SHA diffs, a variable or positional base ref, an
+  object-reachability probe, all of them across a line continuation — still
+  suppresses.
+
 - **2026-09-02** — **Full-history checkout no longer tells you to shallow a job
   that reads git history across a line continuation, diffs against a base held
   in a shell variable, or probes an object's presence.** The check that spares a

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -245,6 +245,21 @@ unversioned and updates by reinstall from `main`.
 
 ### Fixed
 
+- **2026-09-02** — **Full-history checkout no longer tells you to shallow a job
+  that reads git history across a line continuation, diffs against a base held
+  in a shell variable, or probes an object's presence.** The check that spares a
+  job whose `fetch-depth: 0` is load-bearing read one line at a time, so a git
+  command split over two lines with a trailing backslash — a very common way to
+  write a merge-base diff in a `run:` block — looked to it like no git command at
+  all, and the job got a recommendation that would have broken it. Two more real
+  history operations were also missing from what it recognises: a `git diff`
+  whose base operand is a shell variable rather than a literal ref, and
+  `git cat-file`, which only succeeds when the object is actually in the clone.
+  Line continuations are now joined before the check runs, on every surface it
+  reads — a job's run blocks, its `uses:` refs, and the body of a local composite
+  action it invokes — and both operations are recognised. The pattern's stance is
+  unchanged: the cost of a miss is a lost finding, never a fix that breaks a job.
+
 - **2026-08-22** — **OPT74 no longer claims a fork PR can't restore the base
   branch's cache — it can; and every fork disclosure now names the reason that
   actually makes a fork colder.** The pattern's anti-pattern text said a fork-PR

--- a/skills/ci-speedup/scripts/scan.py
+++ b/skills/ci-speedup/scripts/scan.py
@@ -275,6 +275,15 @@ _GIT_HISTORY_RE = re.compile(
     # full history just like a `...` merge-base diff — but it has neither `...`
     # nor `origin/`. Match a `git diff` line that references a `.sha` expression.
     r"git\s+diff\b[^\n|]*\.sha\b|"
+    # Diff against a base ref held in a shell variable: `git diff --name-only
+    # "$base" HEAD`. The base commit is just as absent from a shallow clone as a
+    # literal `<sha>...HEAD` is — it simply carries no `...`, no `origin/` and no
+    # `.sha` for the clauses above to see.
+    r"git\s+diff\b[^\n|]*\$[({]?[A-Za-z_]|"
+    # Object-reachability probe: `git cat-file -e "${base}^{commit}"` succeeds
+    # only when the object is present in the clone, which is exactly what full
+    # history buys.
+    r"git\s+cat-file\b|"
     r"fetch-tags|--tags|"
     # Change-detection actions that diff the head against a BASE ref need base
     # history: `dorny/paths-filter` with `base:` set, and `tj-actions/changed-files`
@@ -297,6 +306,20 @@ _HISTORY_JOB_NAME_RE = re.compile(
 # once per scan() from the referenced action files; consulted by
 # `_job_needs_git_history` so OPT28 never recommends shallowing such a job.
 _GIT_HISTORY_LOCAL_ACTIONS: set[str] = set()
+
+
+# A `run:` block routinely breaks ONE shell command across several lines with a
+# trailing backslash, and every clause of `_GIT_HISTORY_RE` is line-scoped. Join
+# the continuations back together before matching, so a git command whose
+# history-revealing operand sits on the next line is still seen as one command.
+_LINE_CONTINUATION_RE = re.compile(r"\\\n[ \t]*")
+
+
+def _has_git_history_op(text: str) -> bool:
+    """True when `text` runs a git operation that needs full history. Applied to
+    every surface `_GIT_HISTORY_RE` is matched against, so line continuations are
+    joined in exactly one place."""
+    return bool(_GIT_HISTORY_RE.search(_LINE_CONTINUATION_RE.sub(" ", text)))
 
 
 def _index_local_git_actions(root: Path, parsed: list[tuple[str, dict, str]]) -> set[str]:
@@ -322,7 +345,7 @@ def _index_local_git_actions(root: Path, parsed: list[tuple[str, dict, str]]) ->
                 text = cand.read_text(encoding="utf-8", errors="replace")
             except OSError:
                 continue
-            if _GIT_HISTORY_RE.search(text):
+            if _has_git_history_op(text):
                 out.add(ref)
             break
         else:
@@ -338,7 +361,7 @@ def _index_local_git_actions(root: Path, parsed: list[tuple[str, dict, str]]) ->
 def _job_needs_git_history(job: dict, job_name: str = "") -> bool:
     blob = _job_run_blob(job)
     uses_blob = "\n".join(_uses(s) for s in _steps(job))
-    if _GIT_HISTORY_RE.search(blob) or _GIT_HISTORY_RE.search(uses_blob):
+    if _has_git_history_op(blob) or _has_git_history_op(uses_blob):
         return True
     # A local composite action the job invokes may run the git op internally
     # (the workflow yaml shows only `uses: ./…`). Consult the per-scan index.

--- a/skills/ci-speedup/scripts/scan.py
+++ b/skills/ci-speedup/scripts/scan.py
@@ -276,10 +276,11 @@ _GIT_HISTORY_RE = re.compile(
     # nor `origin/`. Match a `git diff` line that references a `.sha` expression.
     r"git\s+diff\b[^\n|]*\.sha\b|"
     # Diff against a base ref held in a shell variable: `git diff --name-only
-    # "$base" HEAD`. The base commit is just as absent from a shallow clone as a
-    # literal `<sha>...HEAD` is — it simply carries no `...`, no `origin/` and no
+    # "$base" HEAD` or as a positional parameter like `git diff "$1" HEAD`. The
+    # base commit is just as absent from a shallow clone as a literal
+    # `<sha>...HEAD` is — it simply carries no `...`, no `origin/` and no
     # `.sha` for the clauses above to see.
-    r"git\s+diff\b[^\n|]*\$[({]?[A-Za-z_]|"
+    r"git\s+diff\b[^\n|]*\$[({]?[A-Za-z_0-9]|"
     # Object-reachability probe: `git cat-file -e "${base}^{commit}"` succeeds
     # only when the object is present in the clone, which is exactly what full
     # history buys.

--- a/skills/ci-speedup/scripts/scan.py
+++ b/skills/ci-speedup/scripts/scan.py
@@ -280,11 +280,26 @@ _GIT_HISTORY_RE = re.compile(
     # base commit is just as absent from a shallow clone as a literal
     # `<sha>...HEAD` is — it simply carries no `...`, no `origin/` and no
     # `.sha` for the clauses above to see.
-    r"git\s+diff\b[^\n|]*\$[({]?[A-Za-z_0-9]|"
+    #
+    # The variable only counts where a REF operand can stand. Two positions on
+    # the command line can never hold a ref, and a `$` reached through either
+    # one says nothing about history:
+    #   * past a redirection arrow — `git diff --stat >> $GITHUB_STEP_SUMMARY`
+    #     and `git diff > $OUT` name the FILE the diff is written to;
+    #   * past a bare `--` separator — everything after it is a pathspec, so
+    #     `git diff --exit-code -- "$FILE"` names a path, not a base commit.
+    # Option flags such as `--name-only` are not the separator (no trailing
+    # space), so `git diff --no-renames --name-only "$base" HEAD` still counts.
+    r"git\s+diff\b(?:(?!\s--\s|>)[^\n|])*\$[({]?[A-Za-z_0-9]|"
     # Object-reachability probe: `git cat-file -e "${base}^{commit}"` succeeds
     # only when the object is present in the clone, which is exactly what full
-    # history buys.
-    r"git\s+cat-file\b|"
+    # history buys. A cat-file whose operand is anchored at HEAD is the
+    # opposite case — `git cat-file -p HEAD:package.json` reads a blob at the
+    # checked-out commit, which every clone depth already has — so a HEAD
+    # operand (but not `HEAD~1` / `HEAD^`, which do reach back) disqualifies
+    # the clause. The lookahead stops at a command separator so a later,
+    # unrelated HEAD read cannot cancel a genuine probe.
+    r"git\s+cat-file\b(?![^\n|;&]*\bHEAD(?![~^]))|"
     r"fetch-tags|--tags|"
     # Change-detection actions that diff the head against a BASE ref need base
     # history: `dorny/paths-filter` with `base:` set, and `tj-actions/changed-files`

--- a/skills/ci-speedup/tests/test_scan_detectors.py
+++ b/skills/ci-speedup/tests/test_scan_detectors.py
@@ -1270,6 +1270,67 @@ jobs:
     assert "OPT28" in _scan_one(tmp_path, pos)
 
 
+def _opt28_workflow(job: str, run_body: str) -> str:
+    indented = "\n".join("          " + ln for ln in run_body.strip("\n").split("\n"))
+    return f"""name: CI
+on: pull_request
+jobs:
+  {job}:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: |
+{indented}
+"""
+
+
+def test_opt28_fires_when_diff_output_is_redirected_to_a_variable_path(tmp_path: Path):
+    """`git diff --stat >> $GITHUB_STEP_SUMMARY` writes a diff of the working
+    tree into a file whose path is a variable. A redirection target is never a
+    ref, so nothing here reads history and OPT28 must still fire."""
+    wf = _opt28_workflow("summary", 'git diff --stat >> $GITHUB_STEP_SUMMARY')
+    assert "OPT28" in _scan_one(tmp_path, wf, name="summary.yml")
+
+
+def test_opt28_fires_when_diff_output_is_redirected_with_single_arrow(tmp_path: Path):
+    """Same shape with `>` instead of `>>`: the variable is the file being
+    written, not a base ref, so the checkout is still unjustified."""
+    wf = _opt28_workflow("out", 'git diff > $OUT')
+    assert "OPT28" in _scan_one(tmp_path, wf, name="out.yml")
+
+
+def test_opt28_fires_when_variable_after_dash_dash_is_a_pathspec(tmp_path: Path):
+    """After a bare `--` separator every operand is a pathspec, never a ref.
+    `git diff --exit-code -- "$FILE"` compares the working tree against the
+    index for one path and needs no history, so OPT28 must fire."""
+    wf = _opt28_workflow("dirty", 'git diff --exit-code -- "$FILE"')
+    assert "OPT28" in _scan_one(tmp_path, wf, name="dirty.yml")
+
+
+def test_opt28_fires_when_cat_file_reads_a_blob_at_head(tmp_path: Path):
+    """`git cat-file -p HEAD:package.json` reads a blob at the checked-out
+    commit. That object is present at any clone depth, so this is not a
+    history read and OPT28 must fire."""
+    wf = _opt28_workflow("read", 'git cat-file -p HEAD:package.json > pkg.json')
+    assert "OPT28" in _scan_one(tmp_path, wf, name="read.yml")
+
+
+def test_opt28_fires_on_working_tree_git_commands(tmp_path: Path):
+    """`git diff --cached`, `git diff --quiet`, `git status` and `git add` all
+    read the index or the working tree only — none of them reaches back into
+    history, so a `fetch-depth: 0` alongside them stays unjustified."""
+    for job, cmd in (
+        ("cached", "git diff --cached --name-only"),
+        ("quiet", "git diff --quiet"),
+        ("status", "git status --porcelain"),
+        ("add", "git add -A"),
+    ):
+        wf = _opt28_workflow(job, cmd)
+        assert "OPT28" in _scan_one(tmp_path / job, wf, name=f"{job}.yml"), cmd
+
+
 def test_opt35_suppressed_on_diagnostic_matrix(tmp_path: Path):
     """A node-version / named-adapter matrix with fail-fast:false is correct —
     you want each variant's result — so OPT35 must NOT fire."""

--- a/skills/ci-speedup/tests/test_scan_detectors.py
+++ b/skills/ci-speedup/tests/test_scan_detectors.py
@@ -1007,6 +1007,68 @@ jobs:
     assert "OPT28" not in _scan_one(tmp_path, neg, name="regenerate.yml")
 
 
+def test_opt28_suppressed_on_backslash_continued_history_command(tmp_path: Path):
+    """A `run:` block that continues a git command onto the next line with a
+    trailing backslash is ONE shell command. The merge-base diff below needs
+    full history, so `fetch-depth: 0` is load-bearing — OPT28 must not
+    recommend shallowing the job just because the operand sits on line two."""
+    neg = """name: prebuild
+on: pull_request
+jobs:
+  affected-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: |
+          git diff --name-only \\
+            "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \\
+            > /tmp/changed-files.txt
+"""
+    assert "OPT28" not in _scan_one(tmp_path, neg, name="prebuild.yml")
+
+
+def test_opt28_suppressed_on_diff_against_a_variable_base_ref(tmp_path: Path):
+    """A `git diff` whose base operand is a shell variable is still a diff
+    against a base commit — a shallow clone does not contain it — so
+    `fetch-depth: 0` is load-bearing and OPT28 must stay silent."""
+    neg = """name: CI
+on: pull_request
+jobs:
+  changed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: |
+          base=$(cat base.txt)
+          git diff --no-renames --name-only "$base" HEAD
+"""
+    assert "OPT28" not in _scan_one(tmp_path, neg, name="changed.yml")
+
+
+def test_opt28_suppressed_on_cat_file_reachability_probe(tmp_path: Path):
+    """`git cat-file -e <sha>^{commit}` probes whether an object is present in
+    the clone — it only succeeds with the history fetched, so the job needs
+    `fetch-depth: 0` and OPT28 must not flag it."""
+    neg = """name: CI
+on: pull_request
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          git cat-file -e "${base}^{commit}"
+"""
+    assert "OPT28" not in _scan_one(tmp_path, neg, name="probe.yml")
+
+
 def test_opt28_line_points_at_the_flagged_job_not_the_first_match(tmp_path: Path):
     """A per-job OPT28 hit must record ITS OWN `fetch-depth: 0` line, not the
     file-global first match. prebuild.yml has depth:0 in the `changes` job (two-SHA

--- a/skills/ci-speedup/tests/test_scan_detectors.py
+++ b/skills/ci-speedup/tests/test_scan_detectors.py
@@ -1069,6 +1069,26 @@ jobs:
     assert "OPT28" not in _scan_one(tmp_path, neg, name="probe.yml")
 
 
+def test_opt28_suppressed_on_positional_parameter_base_ref(tmp_path: Path):
+    """A `git diff` whose base operand is a positional parameter like `$1` is
+    still a diff against a base commit that must be in the history — a shallow
+    clone does not contain it — so `fetch-depth: 0` is load-bearing and OPT28
+    must not recommend shallowing."""
+    neg = """name: CI
+on: pull_request
+jobs:
+  changed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: |
+          git diff --name-only "$1" HEAD
+"""
+    assert "OPT28" not in _scan_one(tmp_path, neg, name="changed.yml")
+
+
 def test_opt28_line_points_at_the_flagged_job_not_the_first_match(tmp_path: Path):
     """A per-job OPT28 hit must record ITS OWN `fetch-depth: 0` line, not the
     file-global first match. prebuild.yml has depth:0 in the `changes` job (two-SHA


### PR DESCRIPTION
## TL;DR

The speed audit tells a repository when a job clones the whole git history it does not need — a real and often large saving. It is supposed to stay silent whenever the job actually reads that history, because shallowing such a job breaks it. Four ordinary ways of reading history slipped past that safety check, so the audit was handing out a fix that would have broken the very jobs it named. Closing them means teaching the check to recognise a `$` on a `git diff` line as a base commit — which, done loosely, silences the finding on four equally ordinary commands that read no history at all, including a diff simply written to a file. This closes the four misses and draws the boundary so the four safe shapes are still reported.

## What was wrong

The carve-out that spares a load-bearing `fetch-depth: 0` reads a job's shell text one line at a time. Three shapes defeat it:

1. **A git command continued onto the next line.** A trailing backslash splits one shell command across lines. Written that way, a merge-base diff — the single most common reason a job needs full history — matched nothing at all, because the operand that reveals it sits on the following line. This is provable from a fixture already committed here: `skills/ci-score/tests/fixtures/checkouts-src/mastra/dot-github/workflows/prebuild.yml.fixture` (job `affected-tests`) writes exactly that shape, and the pattern fires on it.

2. **A diff whose base operand is a shell variable.** The existing diff clauses need a literal `...`, an `origin/` prefix, or a `.sha` expression. A base ref carried in a variable has none of them, but the base commit is just as absent from a shallow clone.

3. **`git cat-file`.** Used to probe whether an object is present in the clone — a check that only passes with the history fetched.

## What changed

- Line continuations are joined before the history check runs, applied at the one place the check is performed, so all three surfaces it reads benefit: the job's run blocks, its `uses:` refs, and the body of a local composite action the job invokes. Joining happens inside the history check only, so no other pattern's view of the shell text moves.
- Two clauses added: a diff against a variable base ref (named, or a positional parameter such as `git diff "$1" HEAD`), and `git cat-file`.
- Both of those clauses are bounded to the positions where a ref can actually stand. A `$` reached past a redirection arrow is the file the diff is written to (`git diff --stat >> $GITHUB_STEP_SUMMARY`, `git diff > $OUT`), and a `$` reached past a bare `--` separator is a pathspec (`git diff --exit-code -- "$FILE"`) — neither is a base commit, so neither suppresses. Option flags such as `--name-only` are not the separator. Likewise `git cat-file -p HEAD:package.json` reads a blob at the checked-out commit, present at any clone depth, so a `HEAD` operand disqualifies the cat-file clause; `HEAD~1` and `HEAD^` do reach back and still suppress.
- `git merge-base` was verified to match already, via the existing pull/rebase/merge/cherry-pick alternation (the word boundary falls between `merge` and the hyphen), so no duplicate clause was added. `git symbolic-ref` was deliberately not added — it needs no history.

The direction of the change only ever removes findings. That is the stance the pattern already documents: the cost of a miss is a lost finding, never a fix that breaks a job.

## Tests

Nine new cases in `skills/ci-speedup/tests/test_scan_detectors.py`, each run against the unfixed scanner first and failed.

Four for the widened carve-out — one per shape that was wrongly getting a shallow-checkout recommendation:

```
FAILED test_opt28_suppressed_on_backslash_continued_history_command
E   assert 'OPT28' not in {'OPT28', 'OPT32', 'OPT33', 'OPT45'}
FAILED test_opt28_suppressed_on_diff_against_a_variable_base_ref
E   assert 'OPT28' not in {'OPT28', 'OPT32', 'OPT45'}
FAILED test_opt28_suppressed_on_cat_file_reachability_probe
E   assert 'OPT28' not in {'OPT28', 'OPT32', 'OPT45'}
FAILED test_opt28_suppressed_on_positional_parameter_base_ref
E   assert 'OPT28' not in {'OPT28', 'OPT32', 'OPT45'}
```

Four for the narrowing that keeps the carve-out honest — one per shape that was wrongly being silenced:

```
FAILED test_opt28_fires_when_diff_output_is_redirected_to_a_variable_path
E   AssertionError: assert 'OPT28' in {'OPT32', 'OPT45'}
FAILED test_opt28_fires_when_diff_output_is_redirected_with_single_arrow
E   AssertionError: assert 'OPT28' in {'OPT32', 'OPT45'}
FAILED test_opt28_fires_when_variable_after_dash_dash_is_a_pathspec
E   AssertionError: assert 'OPT28' in {'OPT32', 'OPT45'}
FAILED test_opt28_fires_when_cat_file_reads_a_blob_at_head
E   AssertionError: assert 'OPT28' in {'OPT32', 'OPT45'}
```

A ninth case pins the working-tree commands that must always be flagged — `git diff --cached`, `git diff --quiet`, `git status`, `git add`. It was green before the change and guards against a future widening.

All nine pass with the fix.

## Pinned snapshots: nothing moves

The finding on the fixture named above is pinned as `f13` in `skills/ci-score/tests/fixtures/corpora/mastra/findings.json`. That pin does not move in this PR, and it does not need to:

- Those corpora are frozen snapshots, copied at the skill split and documented as such in `skills/ci-score/tests/test_ci_score_contract.py`. They are read as data, never regenerated by any test.
- The best-practices grade computed from them comes from each corpus's `practice_facts`, not from its findings list, so a scanner change cannot move a pinned score.
- The two skills install and run independently; nothing under `skills/ci-score/` imports the speed scanner. Re-scanning the cloaked fixture checkout is not something any suite does.

Re-scanning both frozen control checkouts with the scanner before and after this branch produces an identical finding set either way — better-auth 30 findings, mastra 28, none added and none removed — so no pinned verdict moves.

Editing a frozen snapshot to match today's scanner would quietly destroy what the snapshot is for — a record of what the pipeline produced at a fixed point. A deliberate refresh re-pins the whole corpus at once; that is a separate exercise.

## Scoped test runs

```
python3 -m pytest skills/ci-speedup/tests/test_scan_detectors.py -q      -> 168 passed
python3 -m pytest skills/ci-score/tests/test_ci_score_contract.py \
  skills/ci-speedup/tests/test_structural_findings.py \
  skills/ci-speedup/tests/test_offline_pipeline_e2e.py \
  skills/ci-speedup/tests/test_evidence_claim_guards.py \
  skills/ci-speedup/tests/test_committed_reports.py -q                   -> 290 passed, 7 skipped
python3 -m pytest tests/ -q --ignore=tests/test_pre_commit_hook.py       -> 395 passed, 1 skipped
```

(The ignored module needs `tomllib`, absent on the local Python 3.9; CI runs it.)

The changelog carries a dated Fixed entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
