### PR TITLE
ci-speedup: a documented reason for full history now silences the finding

### DIFF
--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -251,11 +251,26 @@ unversioned and updates by reinstall from `main`.
   and comments are discarded when the workflow is parsed, so the one artifact
   that settles the question was invisible. A comment within six lines above the
   line, naming a git-history operation or history work in general, now
-  suppresses the finding for that step. The reading is deliberately narrow: the
-  word `depth` is not part of the vocabulary, so a comment saying the depth is
-  unnecessary still leaves the finding standing, and a comment that belongs to
-  an earlier step is out of range. The check can only ever remove this one
-  finding — it never creates a finding and touches no other pattern.
+  suppresses the finding for that step. The six-line region is closed early by
+  a blank line, and it never reaches into a neighbouring step: a comment above
+  the step but indented deeper than it — the last line of the previous step's
+  `run: |` block, say — belongs to that step, and ordinary configuration above
+  the step ends the region too. Inside the region the step's own body counts,
+  so the justification can be written above the step, between `- uses:` and
+  `with:`, or on the line directly above the key. The reading is deliberately
+  narrow: the word `depth` is not part of the vocabulary, so a comment saying
+  the depth is unnecessary still leaves the finding standing. The check can only
+  ever remove this one finding — it never creates a finding and touches no other
+  pattern.
+
+- **2026-09-02** — **A comment that quotes `fetch-depth: 0` no longer swallows
+  a checkout's finding.** Locating which line a finding belongs to counted every
+  line containing the key, comments included. A job with two full-history
+  checkouts under a comment mentioning `fetch-depth: 0` therefore reported one
+  finding instead of two, pointed it at the comment rather than at any
+  configuration line, and left the genuinely unjustified checkout unreported —
+  the exact case the reader most needs to see. Full-line comments are no longer
+  counted; a trailing comment sits on a real key line and still is.
 
 - **2026-09-02** — **Full-history checkout now reads a `$` on a `git diff` line
   as a base ref only where a ref can stand, and stops treating a blob read at

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -245,6 +245,26 @@ unversioned and updates by reinstall from `main`.
 
 ### Fixed
 
+- **2026-09-02** — **Full-history checkout now reads a `$` on a `git diff` line
+  as a base ref only where a ref can stand, and stops treating a blob read at
+  `HEAD` as a history operation.** The carve-out that spares a load-bearing
+  `fetch-depth: 0` had been widened to recognise a base ref held in a shell
+  variable, including one passed as a positional parameter (`git diff "$1"
+  HEAD`). But it accepted a `$` anywhere on the line, so four ordinary commands
+  that read nothing older than the working tree silenced the finding: a diff
+  written to a file (`git diff --stat >> $GITHUB_STEP_SUMMARY`, `git diff >
+  $OUT`), and a diff restricted to a path after the `--` separator (`git diff
+  --exit-code -- "$FILE"`). A redirection target is never a ref and everything
+  after a bare `--` is a pathspec, so neither position counts any more; option
+  flags such as `--name-only` are unaffected. Separately, `git cat-file` was
+  treated as a history operation unconditionally, but `git cat-file -p
+  HEAD:package.json` reads a blob at the checked-out commit, which is present at
+  any clone depth — a `HEAD` operand (though not `HEAD~1` or `HEAD^`) no longer
+  suppresses. Every genuine history read the carve-out already recognised —
+  merge-base diffs, two-SHA diffs, a variable or positional base ref, an
+  object-reachability probe, all of them across a line continuation — still
+  suppresses.
+
 - **2026-09-02** — **Full-history checkout no longer tells you to shallow a job
   that reads git history across a line continuation, diffs against a base held
   in a shell variable, or probes an object's presence.** The check that spares a

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -245,6 +245,21 @@ unversioned and updates by reinstall from `main`.
 
 ### Fixed
 
+- **2026-09-02** — **Full-history checkout no longer tells you to shallow a job
+  that reads git history across a line continuation, diffs against a base held
+  in a shell variable, or probes an object's presence.** The check that spares a
+  job whose `fetch-depth: 0` is load-bearing read one line at a time, so a git
+  command split over two lines with a trailing backslash — a very common way to
+  write a merge-base diff in a `run:` block — looked to it like no git command at
+  all, and the job got a recommendation that would have broken it. Two more real
+  history operations were also missing from what it recognises: a `git diff`
+  whose base operand is a shell variable rather than a literal ref, and
+  `git cat-file`, which only succeeds when the object is actually in the clone.
+  Line continuations are now joined before the check runs, on every surface it
+  reads — a job's run blocks, its `uses:` refs, and the body of a local composite
+  action it invokes — and both operations are recognised. The pattern's stance is
+  unchanged: the cost of a miss is a lost finding, never a fix that breaks a job.
+
 - **2026-08-22** — **OPT74 no longer claims a fork PR can't restore the base
   branch's cache — it can; and every fork disclosure now names the reason that
   actually makes a fork colder.** The pattern's anti-pattern text said a fork-PR

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -245,6 +245,18 @@ unversioned and updates by reinstall from `main`.
 
 ### Fixed
 
+- **2026-09-02** — **A comment explaining why full history is needed now
+  silences the full-history-checkout finding.** When `fetch-depth: 0` is
+  load-bearing, the reason is usually written in a comment directly above it —
+  and comments are discarded when the workflow is parsed, so the one artifact
+  that settles the question was invisible. A comment within six lines above the
+  line, naming a git-history operation or history work in general, now
+  suppresses the finding for that step. The reading is deliberately narrow: the
+  word `depth` is not part of the vocabulary, so a comment saying the depth is
+  unnecessary still leaves the finding standing, and a comment that belongs to
+  an earlier step is out of range. The check can only ever remove this one
+  finding — it never creates a finding and touches no other pattern.
+
 - **2026-09-02** — **Full-history checkout no longer tells you to shallow a job
   that reads git history across a line continuation, diffs against a base held
   in a shell variable, or probes an object's presence.** The check that spares a

--- a/skills/ci-speedup/scripts/scan.py
+++ b/skills/ci-speedup/scripts/scan.py
@@ -275,6 +275,15 @@ _GIT_HISTORY_RE = re.compile(
     # full history just like a `...` merge-base diff — but it has neither `...`
     # nor `origin/`. Match a `git diff` line that references a `.sha` expression.
     r"git\s+diff\b[^\n|]*\.sha\b|"
+    # Diff against a base ref held in a shell variable: `git diff --name-only
+    # "$base" HEAD`. The base commit is just as absent from a shallow clone as a
+    # literal `<sha>...HEAD` is — it simply carries no `...`, no `origin/` and no
+    # `.sha` for the clauses above to see.
+    r"git\s+diff\b[^\n|]*\$[({]?[A-Za-z_]|"
+    # Object-reachability probe: `git cat-file -e "${base}^{commit}"` succeeds
+    # only when the object is present in the clone, which is exactly what full
+    # history buys.
+    r"git\s+cat-file\b|"
     r"fetch-tags|--tags|"
     # Change-detection actions that diff the head against a BASE ref need base
     # history: `dorny/paths-filter` with `base:` set, and `tj-actions/changed-files`
@@ -297,6 +306,20 @@ _HISTORY_JOB_NAME_RE = re.compile(
 # once per scan() from the referenced action files; consulted by
 # `_job_needs_git_history` so OPT28 never recommends shallowing such a job.
 _GIT_HISTORY_LOCAL_ACTIONS: set[str] = set()
+
+
+# A `run:` block routinely breaks ONE shell command across several lines with a
+# trailing backslash, and every clause of `_GIT_HISTORY_RE` is line-scoped. Join
+# the continuations back together before matching, so a git command whose
+# history-revealing operand sits on the next line is still seen as one command.
+_LINE_CONTINUATION_RE = re.compile(r"\\\n[ \t]*")
+
+
+def _has_git_history_op(text: str) -> bool:
+    """True when `text` runs a git operation that needs full history. Applied to
+    every surface `_GIT_HISTORY_RE` is matched against, so line continuations are
+    joined in exactly one place."""
+    return bool(_GIT_HISTORY_RE.search(_LINE_CONTINUATION_RE.sub(" ", text)))
 
 
 def _index_local_git_actions(root: Path, parsed: list[tuple[str, dict, str]]) -> set[str]:
@@ -322,7 +345,7 @@ def _index_local_git_actions(root: Path, parsed: list[tuple[str, dict, str]]) ->
                 text = cand.read_text(encoding="utf-8", errors="replace")
             except OSError:
                 continue
-            if _GIT_HISTORY_RE.search(text):
+            if _has_git_history_op(text):
                 out.add(ref)
             break
         else:
@@ -338,7 +361,7 @@ def _index_local_git_actions(root: Path, parsed: list[tuple[str, dict, str]]) ->
 def _job_needs_git_history(job: dict, job_name: str = "") -> bool:
     blob = _job_run_blob(job)
     uses_blob = "\n".join(_uses(s) for s in _steps(job))
-    if _GIT_HISTORY_RE.search(blob) or _GIT_HISTORY_RE.search(uses_blob):
+    if _has_git_history_op(blob) or _has_git_history_op(uses_blob):
         return True
     # A local composite action the job invokes may run the git op internally
     # (the workflow yaml shows only `uses: ./…`). Consult the per-scan index.

--- a/skills/ci-speedup/scripts/scan.py
+++ b/skills/ci-speedup/scripts/scan.py
@@ -285,6 +285,13 @@ def _line_of_nth_in_job(raw: str, job_name: str, needle: str, occurrence: int) -
             break
     count = 0
     for k in range(start, end):
+        # A comment that quotes the needle ("TODO: drop fetch-depth: 0") is
+        # prose, not a configuration key. Counting it shifts every later
+        # occurrence's line by one and leaves the LAST one unreachable — the
+        # caller then loses that finding entirely. Full-line comments only:
+        # a trailing comment sits on a real key line, which does count.
+        if lines[k].lstrip().startswith("#"):
+            continue
         if needle in lines[k]:
             count += 1
             if count == occurrence:
@@ -461,44 +468,57 @@ _OPT28_JUSTIFY_RE = re.compile(
 def _opt28_history_justification(raw: str, line: int | None) -> str | None:
     """The nearby comment that documents why this `fetch-depth: 0` is needed, or
     None. Suppressor only: it can remove an OPT28 finding, never create one.
-    Comments must be from the same step (same indentation region) to count as
-    justification — a comment on a prior step is not a justification for this
-    step's checkout."""
+
+    The region is the `_OPT28_JUSTIFY_LOOKBACK` lines directly above the key,
+    closed early by a blank line. Within it, a comment counts only when it
+    belongs to THIS step: the step's own body qualifies, and so does a comment
+    written above the step marker at the step's own indentation. A comment
+    above the marker but indented deeper is inside the preceding step (the tail
+    of its `run: |` block), and ordinary YAML above the marker ends the region —
+    neither is a justification for this checkout."""
     if not line:
         return None
     lines = raw.splitlines()
     idx = line - 1  # 0-based index of the matched `fetch-depth: 0` line
     if idx < 0 or idx >= len(lines):
         return None
-    # Find the step marker by scanning backward from fetch-depth line
+    # The step this key belongs to — the nearest `- ` marker at or above it.
     step_marker_idx = None
     for i in range(idx, -1, -1):
         text = lines[i]
         if not text.strip():
             continue
-        m = re.match(r"^(\s*)-\s", text)
-        if m:
+        if re.match(r"^\s*-\s", text):
             step_marker_idx = i
             break
-
     if step_marker_idx is None:
         return None
+    marker = lines[step_marker_idx]
+    marker_indent = len(marker) - len(marker.lstrip())
 
-    # Scan backward from the line above the step marker, accepting only comments
-    # and blanks. Stop at the first non-comment, non-blank line.
-    for i in range(step_marker_idx - 1, -1, -1):
+    # Walk up from the key, no further than the documented bound.
+    for i in range(idx - 1, max(0, idx - _OPT28_JUSTIFY_LOOKBACK) - 1, -1):
         text = lines[i]
         stripped = text.strip()
 
         if not stripped:
-            # Blank line is OK, continue scanning
-            continue
+            break  # a blank line ends the region
 
         if not stripped.startswith("#"):
-            # Non-comment, non-blank line above the step marker ends the search
+            # Inside this step, the non-comment lines are its own scaffolding
+            # (`- uses:`, `with:`) and a comment may sit among them. Above the
+            # step marker, ordinary YAML ends the region.
+            if i >= step_marker_idx:
+                continue
             break
 
-        # It's a comment - check if it mentions a history operation
+        if i < step_marker_idx and len(text) - len(text.lstrip()) > marker_indent:
+            # A comment above the step marker but indented DEEPER than it is
+            # inside the preceding step — the tail of a `run: |` block, say.
+            # That is the preceding step's shell text, not this step's
+            # justification.
+            break
+
         if _OPT28_JUSTIFY_RE.search(stripped):
             return stripped.lstrip("#").strip()
 

--- a/skills/ci-speedup/scripts/scan.py
+++ b/skills/ci-speedup/scripts/scan.py
@@ -455,38 +455,38 @@ def _opt28_history_justification(raw: str, line: int | None) -> str | None:
     idx = line - 1  # 0-based index of the matched `fetch-depth: 0` line
     if idx < 0 or idx >= len(lines):
         return None
-    # Find the step marker (line starting with "- " at the step level) by
-    # looking backward from the fetch-depth line. This determines the indent
-    # level of the current step, so we can detect step boundaries.
-    step_indent = None
+    # Find the step marker by scanning backward from fetch-depth line
+    step_marker_idx = None
     for i in range(idx, -1, -1):
         text = lines[i]
         if not text.strip():
             continue
         m = re.match(r"^(\s*)-\s", text)
         if m:
-            step_indent = len(m.group(1))
+            step_marker_idx = i
             break
-    for back in range(1, _OPT28_JUSTIFY_LOOKBACK + 1):
-        i = idx - back
-        if i < 0:
-            break
+
+    if step_marker_idx is None:
+        return None
+
+    # Scan backward from the line above the step marker, accepting only comments
+    # and blanks. Stop at the first non-comment, non-blank line.
+    for i in range(step_marker_idx - 1, -1, -1):
         text = lines[i]
         stripped = text.strip()
+
         if not stripped:
-            break  # a blank line ends this step's comment region
-        if not stripped.startswith("#"):
-            # Non-comment, non-blank line. If it's a step boundary (line starting
-            # with "- " at LESS indent than the current step), we've crossed into
-            # a different step's scope and should stop looking. But the current
-            # step's own marker ("- uses:") is OK to cross since we're within it.
-            if step_indent is not None:
-                m = re.match(r"^(\s*)-\s", text)
-                if m and len(m.group(1)) < step_indent:
-                    break  # We've crossed into a previous step
+            # Blank line is OK, continue scanning
             continue
+
+        if not stripped.startswith("#"):
+            # Non-comment, non-blank line above the step marker ends the search
+            break
+
+        # It's a comment - check if it mentions a history operation
         if _OPT28_JUSTIFY_RE.search(stripped):
             return stripped.lstrip("#").strip()
+
     return None
 
 

--- a/skills/ci-speedup/scripts/scan.py
+++ b/skills/ci-speedup/scripts/scan.py
@@ -276,10 +276,11 @@ _GIT_HISTORY_RE = re.compile(
     # nor `origin/`. Match a `git diff` line that references a `.sha` expression.
     r"git\s+diff\b[^\n|]*\.sha\b|"
     # Diff against a base ref held in a shell variable: `git diff --name-only
-    # "$base" HEAD`. The base commit is just as absent from a shallow clone as a
-    # literal `<sha>...HEAD` is — it simply carries no `...`, no `origin/` and no
+    # "$base" HEAD` or as a positional parameter like `git diff "$1" HEAD`. The
+    # base commit is just as absent from a shallow clone as a literal
+    # `<sha>...HEAD` is — it simply carries no `...`, no `origin/` and no
     # `.sha` for the clauses above to see.
-    r"git\s+diff\b[^\n|]*\$[({]?[A-Za-z_]|"
+    r"git\s+diff\b[^\n|]*\$[({]?[A-Za-z_0-9]|"
     # Object-reachability probe: `git cat-file -e "${base}^{commit}"` succeeds
     # only when the object is present in the clone, which is exactly what full
     # history buys.

--- a/skills/ci-speedup/scripts/scan.py
+++ b/skills/ci-speedup/scripts/scan.py
@@ -249,6 +249,49 @@ def _line_of_in_job(raw: str, job_name: str, needle: str) -> int:
     return 0
 
 
+def _line_of_nth_in_job(raw: str, job_name: str, needle: str, occurrence: int) -> int:
+    """1-based line of the Nth occurrence of `needle` within the `job_name:` block.
+    Used when multiple steps in a job contain the same needle (e.g., multiple
+    `fetch-depth: 0` lines). occurrence is 1-based. Returns 0 if not enough
+    occurrences are found."""
+    lines = raw.splitlines()
+    jobs_at = next(
+        (i for i, ln in enumerate(lines) if re.match(r"^jobs:\s*(#.*)?$", ln)), None)
+    if jobs_at is None:
+        return 0
+    indent = None
+    for i in range(jobs_at + 1, len(lines)):
+        ln = lines[i]
+        if not ln.strip() or ln.lstrip().startswith("#"):
+            continue
+        m = re.match(r"^(\s+)\S", ln)
+        indent = len(m.group(1)) if m else None
+        break
+    if not indent:
+        return 0
+    header = re.compile(rf"^\s{{{indent}}}([A-Za-z0-9_.-]+):\s*(#.*)?$")
+    start = None
+    for i in range(jobs_at + 1, len(lines)):
+        m = header.match(lines[i])
+        if m and m.group(1) == job_name:
+            start = i
+            break
+    if start is None:
+        return 0
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        if header.match(lines[j]):
+            end = j
+            break
+    count = 0
+    for k in range(start, end):
+        if needle in lines[k]:
+            count += 1
+            if count == occurrence:
+                return k + 1
+    return 0  # Not enough occurrences
+
+
 def _jobs_from_doc(doc: dict) -> dict[str, dict]:
     jobs = doc.get("jobs") or {}
     return jobs if isinstance(jobs, dict) else {}
@@ -401,24 +444,48 @@ _OPT28_JUSTIFY_RE = re.compile(
 
 def _opt28_history_justification(raw: str, line: int | None) -> str | None:
     """The nearby comment that documents why this `fetch-depth: 0` is needed, or
-    None. Suppressor only: it can remove an OPT28 finding, never create one."""
+    None. Suppressor only: it can remove an OPT28 finding, never create one.
+    Comments must be from the same step (same indentation region) to count as
+    justification — a comment on a prior step is not a justification for this
+    step's checkout."""
     if not line:
         return None
     lines = raw.splitlines()
     idx = line - 1  # 0-based index of the matched `fetch-depth: 0` line
     if idx < 0 or idx >= len(lines):
         return None
+    # Find the step marker (line starting with "- " at the step level) by
+    # looking backward from the fetch-depth line. This determines the indent
+    # level of the current step, so we can detect step boundaries.
+    step_indent = None
+    for i in range(idx, -1, -1):
+        text = lines[i]
+        if not text.strip():
+            continue
+        m = re.match(r"^(\s*)-\s", text)
+        if m:
+            step_indent = len(m.group(1))
+            break
     for back in range(1, _OPT28_JUSTIFY_LOOKBACK + 1):
         i = idx - back
         if i < 0:
             break
-        text = lines[i].strip()
-        if not text:
+        text = lines[i]
+        stripped = text.strip()
+        if not stripped:
             break  # a blank line ends this step's comment region
-        if not text.startswith("#"):
+        if not stripped.startswith("#"):
+            # Non-comment, non-blank line. If it's a step boundary (line starting
+            # with "- " at LESS indent than the current step), we've crossed into
+            # a different step's scope and should stop looking. But the current
+            # step's own marker ("- uses:") is OK to cross since we're within it.
+            if step_indent is not None:
+                m = re.match(r"^(\s*)-\s", text)
+                if m and len(m.group(1)) < step_indent:
+                    break  # We've crossed into a previous step
             continue
-        if _OPT28_JUSTIFY_RE.search(text):
-            return text.lstrip("#").strip()
+        if _OPT28_JUSTIFY_RE.search(stripped):
+            return stripped.lstrip("#").strip()
     return None
 
 
@@ -442,6 +509,7 @@ def _detect_opt28(doc: dict, raw: str) -> list[Hit]:
             continue
         if _job_needs_git_history(job, job_name):
             continue  # depth:0 is load-bearing here — removing it breaks the job
+        checkout_index = 0  # Track which checkout step this is (1-based)
         for step in (job.get("steps") or []):
             if not isinstance(step, dict):
                 continue
@@ -450,7 +518,10 @@ def _detect_opt28(doc: dict, raw: str) -> list[Hit]:
                 continue
             depth = (step.get("with") or {}).get("fetch-depth")
             if str(depth) == "0":
-                line = _line_of_in_job(raw, job_name, "fetch-depth: 0")
+                checkout_index += 1
+                # Find the line for THIS checkout (the Nth occurrence of "fetch-depth: 0"
+                # in the job block), not the first one.
+                line = _line_of_nth_in_job(raw, job_name, "fetch-depth: 0", checkout_index)
                 # A documented justification above the line settles it: the
                 # depth is load-bearing, so stay silent for this step. A comment
                 # can be stale or wrong, and this trades a possible missed

--- a/skills/ci-speedup/scripts/scan.py
+++ b/skills/ci-speedup/scripts/scan.py
@@ -280,11 +280,26 @@ _GIT_HISTORY_RE = re.compile(
     # base commit is just as absent from a shallow clone as a literal
     # `<sha>...HEAD` is — it simply carries no `...`, no `origin/` and no
     # `.sha` for the clauses above to see.
-    r"git\s+diff\b[^\n|]*\$[({]?[A-Za-z_0-9]|"
+    #
+    # The variable only counts where a REF operand can stand. Two positions on
+    # the command line can never hold a ref, and a `$` reached through either
+    # one says nothing about history:
+    #   * past a redirection arrow — `git diff --stat >> $GITHUB_STEP_SUMMARY`
+    #     and `git diff > $OUT` name the FILE the diff is written to;
+    #   * past a bare `--` separator — everything after it is a pathspec, so
+    #     `git diff --exit-code -- "$FILE"` names a path, not a base commit.
+    # Option flags such as `--name-only` are not the separator (no trailing
+    # space), so `git diff --no-renames --name-only "$base" HEAD` still counts.
+    r"git\s+diff\b(?:(?!\s--\s|>)[^\n|])*\$[({]?[A-Za-z_0-9]|"
     # Object-reachability probe: `git cat-file -e "${base}^{commit}"` succeeds
     # only when the object is present in the clone, which is exactly what full
-    # history buys.
-    r"git\s+cat-file\b|"
+    # history buys. A cat-file whose operand is anchored at HEAD is the
+    # opposite case — `git cat-file -p HEAD:package.json` reads a blob at the
+    # checked-out commit, which every clone depth already has — so a HEAD
+    # operand (but not `HEAD~1` / `HEAD^`, which do reach back) disqualifies
+    # the clause. The lookahead stops at a command separator so a later,
+    # unrelated HEAD read cannot cancel a genuine probe.
+    r"git\s+cat-file\b(?![^\n|;&]*\bHEAD(?![~^]))|"
     r"fetch-tags|--tags|"
     # Change-detection actions that diff the head against a BASE ref need base
     # history: `dorny/paths-filter` with `base:` set, and `tj-actions/changed-files`

--- a/skills/ci-speedup/scripts/scan.py
+++ b/skills/ci-speedup/scripts/scan.py
@@ -375,6 +375,53 @@ def _job_needs_git_history(job: dict, job_name: str = "") -> bool:
     return bool(_HISTORY_JOB_NAME_RE.search(job_name))
 
 
+# When `fetch-depth: 0` is load-bearing, maintainers routinely say so in a YAML
+# comment right above it — and comments are dropped at parse time, so the one
+# artifact that settles the question is invisible to the detector. Read it back
+# out of the raw text and treat it as a carve-out: a nearby comment that names a
+# history operation means "do not recommend shallowing this step".
+#
+# The bound is six lines above the matched `fetch-depth: 0`, and a blank line
+# ends the region. Six is what it takes to reach a comment written above the
+# step itself — `- uses:` and `with:` sit between — with room for a two- or
+# three-line comment block; beyond that the comment belongs to an earlier step
+# and is not a justification for this one.
+_OPT28_JUSTIFY_LOOKBACK = 6
+
+# Deliberately tight. `depth` is NOT in the vocabulary: "fetch-depth: 0 is
+# unnecessary here" must not read as a justification — hence also the
+# `fetch(?!-depth)` guard, so the key's own name never counts as `git fetch`.
+_OPT28_JUSTIFY_RE = re.compile(
+    r"\b(?:rev-list|rev-parse|merge-base|describe|blame|history|ancestors?|"
+    r"changelog|tags?|log)\b|"
+    r"\bfetch(?!-depth)\b|"
+    r"\bshallow\s+clone\b",
+    re.I)
+
+
+def _opt28_history_justification(raw: str, line: int | None) -> str | None:
+    """The nearby comment that documents why this `fetch-depth: 0` is needed, or
+    None. Suppressor only: it can remove an OPT28 finding, never create one."""
+    if not line:
+        return None
+    lines = raw.splitlines()
+    idx = line - 1  # 0-based index of the matched `fetch-depth: 0` line
+    if idx < 0 or idx >= len(lines):
+        return None
+    for back in range(1, _OPT28_JUSTIFY_LOOKBACK + 1):
+        i = idx - back
+        if i < 0:
+            break
+        text = lines[i].strip()
+        if not text:
+            break  # a blank line ends this step's comment region
+        if not text.startswith("#"):
+            continue
+        if _OPT28_JUSTIFY_RE.search(text):
+            return text.lstrip("#").strip()
+    return None
+
+
 def _detect_opt28(doc: dict, raw: str) -> list[Hit]:
     """`actions/checkout@v?` with `fetch-depth: 0` — but ONLY when the job does
     not actually need full history. A job running changeset versioning/publish,
@@ -404,6 +451,13 @@ def _detect_opt28(doc: dict, raw: str) -> list[Hit]:
             depth = (step.get("with") or {}).get("fetch-depth")
             if str(depth) == "0":
                 line = _line_of_in_job(raw, job_name, "fetch-depth: 0")
+                # A documented justification above the line settles it: the
+                # depth is load-bearing, so stay silent for this step. A comment
+                # can be stale or wrong, and this trades a possible missed
+                # finding for never recommending a fix that breaks a job — the
+                # direction this pattern already chose.
+                if _opt28_history_justification(raw, line):
+                    continue
                 hits.append(Hit(
                     line=line,
                     affected_jobs=[job_name],

--- a/skills/ci-speedup/tests/test_scan_detectors.py
+++ b/skills/ci-speedup/tests/test_scan_detectors.py
@@ -1069,6 +1069,68 @@ jobs:
     assert "OPT28" not in _scan_one(tmp_path, neg, name="probe.yml")
 
 
+def test_opt28_suppressed_by_a_documented_history_justification_comment(tmp_path: Path):
+    """A YAML comment above `fetch-depth: 0` naming a history command is the one
+    artifact that settles whether the depth is load-bearing — and comments are
+    dropped at parse time, so the detector never saw it. It must now stay
+    silent rather than recommend a change that breaks the job."""
+    neg = """name: CI
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # full history is required: the version stamp comes from `git describe`
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: make build
+"""
+    assert "OPT28" not in _scan_one(tmp_path, neg, name="build.yml")
+
+
+def test_opt28_still_fires_when_a_comment_denies_the_depth_is_needed(tmp_path: Path):
+    """The justification suppressor must read the comment, not merely notice one.
+    A comment saying the depth is unnecessary is not a justification, and the
+    word `depth` alone never suppresses."""
+    pos = """name: CI
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # fetch-depth: 0 is unnecessary here, left over from an old job
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: make build
+"""
+    assert "OPT28" in _scan_one(tmp_path, pos, name="build.yml")
+
+
+def test_opt28_ignores_a_history_comment_too_far_above_the_step(tmp_path: Path):
+    """The suppressor reads a NEARBY comment block. A history comment attached to
+    an earlier step is not a justification for this one, and must not silence it."""
+    pos = """name: CI
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # this earlier step is the one that needs `git log`
+      - run: echo one
+      - run: echo two
+      - run: echo three
+      - run: echo four
+      - run: echo five
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: make build
+"""
+    assert "OPT28" in _scan_one(tmp_path, pos, name="build.yml")
+
+
 def test_opt28_line_points_at_the_flagged_job_not_the_first_match(tmp_path: Path):
     """A per-job OPT28 hit must record ITS OWN `fetch-depth: 0` line, not the
     file-global first match. prebuild.yml has depth:0 in the `changes` job (two-SHA

--- a/skills/ci-speedup/tests/test_scan_detectors.py
+++ b/skills/ci-speedup/tests/test_scan_detectors.py
@@ -1129,6 +1129,8 @@ jobs:
       - run: make build
 """
     assert "OPT28" in _scan_one(tmp_path, pos, name="build.yml")
+
+
 def test_opt28_suppressed_on_positional_parameter_base_ref(tmp_path: Path):
     """A `git diff` whose base operand is a positional parameter like `$1` is
     still a diff against a base commit that must be in the history — a shallow
@@ -3702,3 +3704,164 @@ jobs:
     result = _scan_one(tmp_path, yml, name="boundary.yml")
     assert "OPT28" in result, \
         "checkout must NOT be suppressed by history comment inside preceding step"
+
+
+def test_opt28_blank_line_ends_the_justification_region(tmp_path: Path):
+    """The justification region is bounded and a blank line closes it. A history
+    comment separated from the step by a blank line is a note about something
+    else, so the finding must still fire."""
+    pos = """name: CI
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # full history is required: the version stamp comes from `git describe`
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: make build
+"""
+    assert "OPT28" in _scan_one(tmp_path, pos, name="blank.yml")
+
+
+def test_opt28_justification_region_stops_six_lines_above_the_key(tmp_path: Path):
+    """The region reaches six lines above the matched `fetch-depth: 0` — enough
+    for a comment block written above the step. A history comment pushed beyond
+    that by four unrelated comment lines is out of range and must not suppress."""
+    pos = """name: CI
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # full history is required: the version stamp comes from `git describe`
+      # note four
+      # note three
+      # note two
+      # note one
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: make build
+"""
+    assert "OPT28" in _scan_one(tmp_path, pos, name="far.yml")
+
+
+def test_opt28_comment_ending_a_preceding_run_block_does_not_suppress(tmp_path: Path):
+    """A comment written as the last line of the preceding step's `run: |` block
+    sits directly above the checkout's step marker, but it is shell text
+    belonging to that step — not a justification for this checkout."""
+    pos = """name: CI
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prev
+        run: |
+          echo one
+          # this step walks the ancestors, so it needs the history
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: make build
+"""
+    assert "OPT28" in _scan_one(tmp_path, pos, name="scalar.yml")
+
+
+def test_opt28_justification_comment_between_uses_and_with_suppresses(tmp_path: Path):
+    """The region is the six lines above the key, so it covers the step's own
+    body. A justification written between `- uses:` and `with:` is as much this
+    step's justification as one written above the step."""
+    neg = """name: CI
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        # full history is required: the version stamp comes from `git describe`
+        with:
+          fetch-depth: 0
+      - run: make build
+"""
+    assert "OPT28" not in _scan_one(tmp_path, neg, name="inuses.yml")
+
+
+def test_opt28_justification_comment_above_the_key_suppresses(tmp_path: Path):
+    """A justification written on the line immediately above `fetch-depth: 0`,
+    inside `with:`, is the closest place a maintainer can put it and must
+    suppress."""
+    neg = """name: CI
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # full history is required: the version stamp comes from `git describe`
+          fetch-depth: 0
+      - run: make build
+"""
+    assert "OPT28" not in _scan_one(tmp_path, neg, name="inwith.yml")
+
+
+def test_opt28_comment_quoting_the_key_does_not_consume_a_checkout_slot(tmp_path: Path):
+    """A comment that quotes `fetch-depth: 0` is not a checkout. Counting it as
+    one shifts every checkout's reported line by one and drops the last
+    checkout's finding entirely: here the second, unjustified checkout would
+    never be reached."""
+    yml = """name: CI
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # keep fetch-depth: 0 here — the version stamp comes from `git describe`
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: echo one
+      - uses: actions/checkout@v4
+        with:
+          path: vendor
+          fetch-depth: 0
+      - run: make build
+"""
+    _write_workflow(tmp_path, "quote.yml", yml)
+    opt28 = [f for f in _scan(tmp_path)["findings"] if f["pattern"] == "OPT28"]
+    lines = yml.split("\n")
+    depth_lines = [i + 1 for i, ln in enumerate(lines)
+                   if ln.strip() == "fetch-depth: 0"]
+    assert len(depth_lines) == 2
+    assert len(opt28) == 1, opt28
+    # The justified first checkout is suppressed; the finding belongs to the
+    # second checkout's own line, not to the comment that quotes the key.
+    assert opt28[0]["line"] == depth_lines[1]
+
+
+def test_opt28_single_checkout_is_reported_on_the_key_not_a_comment(tmp_path: Path):
+    """With one checkout and a comment quoting `fetch-depth: 0` above it, the
+    finding must still point at the configuration line, not at the comment."""
+    yml = """name: CI
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # TODO: drop fetch-depth: 0 once the stamp moves into the build script
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: make build
+"""
+    _write_workflow(tmp_path, "single.yml", yml)
+    opt28 = [f for f in _scan(tmp_path)["findings"] if f["pattern"] == "OPT28"]
+    lines = yml.split("\n")
+    depth_line = next(i + 1 for i, ln in enumerate(lines)
+                      if ln.strip() == "fetch-depth: 0")
+    assert len(opt28) == 1, opt28
+    assert opt28[0]["line"] == depth_line

--- a/skills/ci-speedup/tests/test_scan_detectors.py
+++ b/skills/ci-speedup/tests/test_scan_detectors.py
@@ -1270,6 +1270,67 @@ jobs:
     assert "OPT28" in _scan_one(tmp_path, pos)
 
 
+def _opt28_workflow(job: str, run_body: str) -> str:
+    indented = "\n".join("          " + ln for ln in run_body.strip("\n").split("\n"))
+    return f"""name: CI
+on: pull_request
+jobs:
+  {job}:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: |
+{indented}
+"""
+
+
+def test_opt28_fires_when_diff_output_is_redirected_to_a_variable_path(tmp_path: Path):
+    """`git diff --stat >> $GITHUB_STEP_SUMMARY` writes a diff of the working
+    tree into a file whose path is a variable. A redirection target is never a
+    ref, so nothing here reads history and OPT28 must still fire."""
+    wf = _opt28_workflow("summary", 'git diff --stat >> $GITHUB_STEP_SUMMARY')
+    assert "OPT28" in _scan_one(tmp_path, wf, name="summary.yml")
+
+
+def test_opt28_fires_when_diff_output_is_redirected_with_single_arrow(tmp_path: Path):
+    """Same shape with `>` instead of `>>`: the variable is the file being
+    written, not a base ref, so the checkout is still unjustified."""
+    wf = _opt28_workflow("out", 'git diff > $OUT')
+    assert "OPT28" in _scan_one(tmp_path, wf, name="out.yml")
+
+
+def test_opt28_fires_when_variable_after_dash_dash_is_a_pathspec(tmp_path: Path):
+    """After a bare `--` separator every operand is a pathspec, never a ref.
+    `git diff --exit-code -- "$FILE"` compares the working tree against the
+    index for one path and needs no history, so OPT28 must fire."""
+    wf = _opt28_workflow("dirty", 'git diff --exit-code -- "$FILE"')
+    assert "OPT28" in _scan_one(tmp_path, wf, name="dirty.yml")
+
+
+def test_opt28_fires_when_cat_file_reads_a_blob_at_head(tmp_path: Path):
+    """`git cat-file -p HEAD:package.json` reads a blob at the checked-out
+    commit. That object is present at any clone depth, so this is not a
+    history read and OPT28 must fire."""
+    wf = _opt28_workflow("read", 'git cat-file -p HEAD:package.json > pkg.json')
+    assert "OPT28" in _scan_one(tmp_path, wf, name="read.yml")
+
+
+def test_opt28_fires_on_working_tree_git_commands(tmp_path: Path):
+    """`git diff --cached`, `git diff --quiet`, `git status` and `git add` all
+    read the index or the working tree only — none of them reaches back into
+    history, so a `fetch-depth: 0` alongside them stays unjustified."""
+    for job, cmd in (
+        ("cached", "git diff --cached --name-only"),
+        ("quiet", "git diff --quiet"),
+        ("status", "git status --porcelain"),
+        ("add", "git add -A"),
+    ):
+        wf = _opt28_workflow(job, cmd)
+        assert "OPT28" in _scan_one(tmp_path / job, wf, name=f"{job}.yml"), cmd
+
+
 def test_opt35_suppressed_on_diagnostic_matrix(tmp_path: Path):
     """A node-version / named-adapter matrix with fail-fast:false is correct —
     you want each variant's result — so OPT35 must NOT fire."""

--- a/skills/ci-speedup/tests/test_scan_detectors.py
+++ b/skills/ci-speedup/tests/test_scan_detectors.py
@@ -3594,3 +3594,27 @@ jobs:
     assert len(hits) == 1
     assert "git lfs pull" in hits[0]["evidence_snippet"]
     assert "install" not in hits[0]["evidence_snippet"]
+
+
+def test_opt28_multiple_checkouts_each_reported_on_own_line(tmp_path: Path):
+    """Regression: when a job has multiple checkouts with fetch-depth: 0,
+    each must be reported on its OWN line. The first has a justifying comment
+    (suppressed); the second has no justification (reported)."""
+    yml = """name: CI
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # checkout 1 needs history for git describe
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: echo one
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: make build
+"""
+    result = _scan_one(tmp_path, yml, name="multi.yml")
+    assert "OPT28" in result, "Expected OPT28 finding for the unjustified checkout"

--- a/skills/ci-speedup/tests/test_scan_detectors.py
+++ b/skills/ci-speedup/tests/test_scan_detectors.py
@@ -3618,3 +3618,26 @@ jobs:
 """
     result = _scan_one(tmp_path, yml, name="multi.yml")
     assert "OPT28" in result, "Expected OPT28 finding for the unjustified checkout"
+
+
+def test_opt28_preceding_step_comment_does_not_suppress(tmp_path: Path):
+    """Regression: a history-naming comment INSIDE a preceding step's body
+    should not suppress the following checkout's finding. The comment belongs
+    to that earlier step, not to the checkout that follows it."""
+    yml = """name: CI
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prev
+        # this step is the one that needs `git rev-list`
+        run: echo hi
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: make build
+"""
+    result = _scan_one(tmp_path, yml, name="boundary.yml")
+    assert "OPT28" in result, \
+        "checkout must NOT be suppressed by history comment inside preceding step"

--- a/skills/ci-speedup/tests/test_scan_detectors.py
+++ b/skills/ci-speedup/tests/test_scan_detectors.py
@@ -1007,6 +1007,68 @@ jobs:
     assert "OPT28" not in _scan_one(tmp_path, neg, name="regenerate.yml")
 
 
+def test_opt28_suppressed_on_backslash_continued_history_command(tmp_path: Path):
+    """A `run:` block that continues a git command onto the next line with a
+    trailing backslash is ONE shell command. The merge-base diff below needs
+    full history, so `fetch-depth: 0` is load-bearing — OPT28 must not
+    recommend shallowing the job just because the operand sits on line two."""
+    neg = """name: prebuild
+on: pull_request
+jobs:
+  affected-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: |
+          git diff --name-only \\
+            "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \\
+            > /tmp/changed-files.txt
+"""
+    assert "OPT28" not in _scan_one(tmp_path, neg, name="prebuild.yml")
+
+
+def test_opt28_suppressed_on_diff_against_a_variable_base_ref(tmp_path: Path):
+    """A `git diff` whose base operand is a shell variable is still a diff
+    against a base commit — a shallow clone does not contain it — so
+    `fetch-depth: 0` is load-bearing and OPT28 must stay silent."""
+    neg = """name: CI
+on: pull_request
+jobs:
+  changed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: |
+          base=$(cat base.txt)
+          git diff --no-renames --name-only "$base" HEAD
+"""
+    assert "OPT28" not in _scan_one(tmp_path, neg, name="changed.yml")
+
+
+def test_opt28_suppressed_on_cat_file_reachability_probe(tmp_path: Path):
+    """`git cat-file -e <sha>^{commit}` probes whether an object is present in
+    the clone — it only succeeds with the history fetched, so the job needs
+    `fetch-depth: 0` and OPT28 must not flag it."""
+    neg = """name: CI
+on: pull_request
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          git cat-file -e "${base}^{commit}"
+"""
+    assert "OPT28" not in _scan_one(tmp_path, neg, name="probe.yml")
+
+
 def test_opt28_line_points_at_the_flagged_job_not_the_first_match(tmp_path: Path):
     """A per-job OPT28 hit must record ITS OWN `fetch-depth: 0` line, not the
     file-global first match. prebuild.yml has depth:0 in the `changes` job (two-SHA

--- a/skills/ci-speedup/tests/test_scan_detectors.py
+++ b/skills/ci-speedup/tests/test_scan_detectors.py
@@ -1069,6 +1069,26 @@ jobs:
     assert "OPT28" not in _scan_one(tmp_path, neg, name="probe.yml")
 
 
+def test_opt28_suppressed_on_positional_parameter_base_ref(tmp_path: Path):
+    """A `git diff` whose base operand is a positional parameter like `$1` is
+    still a diff against a base commit that must be in the history — a shallow
+    clone does not contain it — so `fetch-depth: 0` is load-bearing and OPT28
+    must not recommend shallowing."""
+    neg = """name: CI
+on: pull_request
+jobs:
+  changed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: |
+          git diff --name-only "$1" HEAD
+"""
+    assert "OPT28" not in _scan_one(tmp_path, neg, name="changed.yml")
+
+
 def test_opt28_line_points_at_the_flagged_job_not_the_first_match(tmp_path: Path):
     """A per-job OPT28 hit must record ITS OWN `fetch-depth: 0` line, not the
     file-global first match. prebuild.yml has depth:0 in the `changes` job (two-SHA


### PR DESCRIPTION
## TL;DR

When a job clones the whole git history on purpose, the reason is almost always written in a comment on the line above — and that comment is thrown away before the speed audit ever looks at the workflow. So the audit kept telling people to remove a setting whose written justification was sitting right there, unread. This teaches it to read that comment and back off.

Stacked on #82 — review that one first; this branch merges it.

## What changed

The full-history-checkout pattern already receives the workflow's raw text. It now scans upward from the matched `fetch-depth: 0` line and stays silent for that step when a nearby comment names a git-history operation.

Three defects in that scan are fixed here as well:

- **The six-line bound described below was not implemented.** The constant existed but nothing read it, and the walk stepped past blank lines, so a history comment far above a step still silenced it. The bound and the blank-line stop are now real.
- **A comment ending a preceding step's `run: |` block** sat directly above the next step's marker and was read as its justification. Indentation now settles it: a comment above the marker counts only at the step's own indentation or shallower.
- **A full-line comment quoting `fetch-depth: 0` was counted as a checkout.** With two full-history checkouts under such a comment, one finding was reported, pointed at the comment, and the second, unjustified checkout was never reached — a lost finding, not just a misplaced line.

**An undocumented narrowing, reverted.** Moving the scan's start to the step marker also stopped two placements from suppressing that used to: a comment between `- uses:` and `with:`, and one between `with:` and `fetch-depth:`. That was a side effect, not a decision, and it is the wrong one — both comments are inside the step they justify and both are within the documented six lines of the key. Both suppress again, and each has a test so the placement cannot be dropped silently a second time.

```
      # full history: the version stamp comes from `git describe`   <- read
      - uses: actions/checkout@v4                                    |
        with:                                                        | 6-line
          fetch-depth: 0                                             v window
```

**The bound is six lines, and a blank line ends the region.** Six is what it takes to reach a comment written above the step rather than above the key — `- uses:` and `with:` sit in between — with room left for a two- or three-line comment block. Beyond that the comment belongs to a previous step and is not a justification for this one.

Because the region is measured from the key, it covers the step's own body as well. All three of these placements suppress:

```
      # above the step
      - uses: actions/checkout@v4
        # between `- uses:` and `with:`
        with:
          # directly above the key
          fetch-depth: 0
```

**Where the region stops.** A blank line closes it. Ordinary configuration above the step closes it. And a comment sitting above the step marker but indented deeper than the marker is inside the PREVIOUS step — the last line of its `run: |` block, for instance — so it closes the region too rather than reading as this checkout's justification.

**Vocabulary and trade-offs**: The suppression keywords are history operation names (`rev-list`, `rev-parse`, `merge-base`, `log`, `describe`, `blame`, `fetch`, `tag`) and history-related words (`history`, `ancestor`, `changelog`, `shallow clone`). The word `depth` alone never suppresses — a comment saying "fetch-depth: 0 is unnecessary" will not silence the finding. However, a comment that **names a history operation will suppress even if arguing against the need** — e.g., "this job does not need full history" contains the word "history" and will suppress. This is accepted because the failure direction is a missed finding rather than a broken job (the pattern's documented stance).

**Step-boundary handling**: a comment inside the preceding step is excluded, whether it sits in that step's YAML body or is the last line of its `run: |` block scalar. Both are that step's text, not a statement about the checkout that follows.

## The trade, stated plainly

A comment can be stale, or simply wrong. Trusting one trades a possible missed finding for never recommending a change that breaks a job. That is the direction this pattern already chose and documents: the cost of a miss is a lost finding, never a broken build.

## Blast radius

The comment check is a suppressor by construction: it sits on the path that appends the finding and can only skip it, it reads nothing outside the one workflow's own text, and no other pattern calls it. The line-attribution fix is the one part that can change a finding's presence, and only in the restoring direction — it stops a comment consuming a checkout's slot, so a checkout that was being skipped is reported again. That helper cites the Nth occurrence of a key inside a job block; the full-history checkout is its only caller today. Re-scanning both frozen control checkouts shows no finding added or removed on either.

One deviation worth flagging: the scanner has no suppression channel in its output today — a suppressed step simply produces no finding, and there is no evidence string left to annotate. Rather than invent a new output surface in a fix, the reason is recorded in the code and the changelog. A structured "why this was suppressed" channel would be a separate change across all the pattern's carve-outs.

## Tests

Red-first throughout. Two cases failed against 255f9e0, the commit that introduced the suppressor:

```
AssertionError: Expected OPT28 finding for the unjustified checkout
assert 'OPT28' in {'OPT32', 'OPT45'}
AssertionError: checkout must NOT be suppressed by history comment inside preceding step
assert 'OPT28' in {'OPT32', 'OPT45'}
```

Seven more pin the region's real edges — the bound, the block-scalar boundary, the in-step placements, and the line attribution. Each failed against d4da119:

```
FAILED test_opt28_blank_line_ends_the_justification_region
E       AssertionError: assert 'OPT28' in {'OPT32', 'OPT45'}
FAILED test_opt28_justification_region_stops_six_lines_above_the_key
E       AssertionError: assert 'OPT28' in {'OPT32', 'OPT45'}
FAILED test_opt28_comment_ending_a_preceding_run_block_does_not_suppress
E       AssertionError: assert 'OPT28' in {'OPT32', 'OPT45'}
FAILED test_opt28_justification_comment_between_uses_and_with_suppresses
E       AssertionError: assert 'OPT28' not in {'OPT28', 'OPT32', 'OPT45'}
FAILED test_opt28_justification_comment_above_the_key_suppresses
E       AssertionError: assert 'OPT28' not in {'OPT28', 'OPT32', 'OPT45'}
FAILED test_opt28_comment_quoting_the_key_does_not_consume_a_checkout_slot
E       assert 7 == 15
FAILED test_opt28_single_checkout_is_reported_on_the_key_not_a_comment
E       assert 7 == 10
```

All pass with the fix. Re-scanning both frozen control checkouts before and after this branch produces an identical finding set either way — better-auth 30, mastra 28, none added and none removed.

## Scoped test runs

```
python3 -m pytest skills/ci-speedup/tests/test_scan_detectors.py -q   -> 180 passed
python3 -m pytest skills/ci-score/tests skills/ci-speedup/tests -q    -> 2762 passed, 13 skipped
python3 -m pytest tests/ -q --ignore=tests/test_pre_commit_hook.py    -> 395 passed, 1 skipped
```

(The ignored module needs `tomllib`, absent on the local Python 3.9; CI runs it.)