### PR TITLE
ci-speedup: mark the GitHub-boolean workflow re-read as a safe YAML load

### DIFF
--- a/skills/ci-speedup/scripts/scan.py
+++ b/skills/ci-speedup/scripts/scan.py
@@ -2970,7 +2970,10 @@ def _github_bool_jobs(raw: str) -> dict[str, Any]:
     mapping as NOT advisory: silence is the safe direction for a disclosure, and a sentence
     resting on a boolean this scan could not confirm is worse than no sentence."""
     try:
-        doc = yaml.load(raw, Loader=_GitHubBoolLoader)
+        # Not an unsafe load: _GitHubBoolLoader subclasses SafeLoader and changes only the
+        # implicit boolean resolvers, so the SafeConstructor still rejects arbitrary object
+        # tags. Scanners that match on the loader's NAME rather than its bases need telling.
+        doc = yaml.load(raw, Loader=_GitHubBoolLoader)  # nosec B506
     except yaml.YAMLError:
         return {}
     return _jobs_from_doc(doc) if isinstance(doc, dict) else {}

--- a/skills/ci-speedup/tests/test_scan_detectors.py
+++ b/skills/ci-speedup/tests/test_scan_detectors.py
@@ -3767,6 +3767,40 @@ jobs:
     # The literal GitHub does accept still reads as advisory: the fix narrows the
     # detection, it does not switch it off.
     assert jobs["really_advisory"]["continue_on_error"] is True
+
+
+def test_github_bool_reread_still_refuses_python_object_tags():
+    """The narrowed boolean re-read must stay a SAFE load — nothing may be constructed.
+
+    `_github_bool_jobs` re-reads a workflow through `_GitHubBoolLoader`, which exists only
+    to drop PyYAML's YAML-1.1 boolean words (see the test above). That loader subclasses
+    `SafeLoader` and replaces nothing but the implicit boolean resolvers, so PyYAML's
+    SafeConstructor still refuses to instantiate objects from `!!python/...` tags.
+
+    Because the call sits behind a permanent `# nosec B506` annotation, static analysis
+    will NOT notice if that loader ever stops inheriting from `SafeLoader` or gains a
+    permissive constructor. This test is what stands in the scanner's place: it fails if a
+    hostile tag is ever constructed instead of rejected. The payload calls `os.getcwd`,
+    which does nothing observable if it runs — the assertion is that the parse is refused,
+    not that the damage was small.
+
+    The benign leg is here so the test cannot pass by the re-read being broken outright."""
+    if not _have_yaml():
+        pytest.skip("PyYAML not installed in the test runner")
+    import sys as _sys
+    _sys.path.insert(0, str(_SKILL_DIR / "scripts"))
+    import scan  # noqa: E402
+
+    hostile = "jobs:\n  evil: !!python/object/apply:os.getcwd []\n"
+    assert scan._github_bool_jobs(hostile) == {}, (
+        "the boolean re-read constructed a Python object from a workflow tag: "
+        "_GitHubBoolLoader is no longer a safe loader, and the B506 suppression on it "
+        "is now hiding a real finding")
+
+    benign = "jobs:\n  advisory:\n    continue-on-error: true\n"
+    assert scan._github_bool_jobs(benign)["advisory"]["continue-on-error"] is True, (
+        "the re-read must still parse an ordinary workflow; a loader that refuses "
+        "everything would pass the hostile leg while reporting nothing")
 def test_opt28_multiple_checkouts_each_reported_on_own_line(tmp_path: Path):
     """Regression: when a job has multiple checkouts with fetch-depth: 0,
     each must be reported on its OWN line. The first has a justifying comment


### PR DESCRIPTION
## TL;DR

GitHub's code scanning flags one line of the CI-speed engine as an unsafe way to read a workflow file, at medium severity. It isn't — the reader in question is the safe one, with a single narrow change to how it spells true and false, and the scanner is matching on its name rather than on what it actually does. The finding sits on the dashboard forever unless the line says otherwise, and a standing false alarm on a public security surface is the kind of thing that gets a published skill's audit badge questioned. This adds the annotation, plus a test that keeps the annotation honest. No behavior changes.

## What the flagged line does

The engine parses each workflow file once, the normal safe way. One fact — whether a job is marked advisory, meaning a failure doesn't block the merge — is then re-read through a second, deliberately narrow reader, because GitHub accepts only `true` and `false` there while the YAML standard also accepts `yes`, `on` and `y`. Without that re-read, a workflow written with `yes` would have the report calling a job advisory on the strength of a spelling GitHub does not honour.

```
workflow.yml --> safe parse ------------------> every detector
             \-> narrow re-read (bools only) -> the one advisory-job fact
```

That narrow reader is built on top of the safe one and swaps out only the boolean spellings, so unsafe object tags are still rejected exactly as before. The scanning rule doesn't look at that: it checks whether the reader's name is literally the well-known safe one, and this one has a different name.

## Verification

`bandit -t B506` on the file: **1 result before, 0 after.**

## Changelog

No entry: nothing about the engine's behavior or output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
