### PR TITLE
ci-secure: resolve required checks from a matrix-templated job name

### DIFF
--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -151,36 +151,57 @@ entries are dated (UTC). Format loosely follows
   these workflows reports it") and the fact went UNMEASURED, so a repository
   that shards a required job lost a security fact it could have been graded on.
   Templated names are now rendered against the matrix's literal values through
-  the SAME enumeration that produces the `(…)` suffixes, so both readings of a
-  matrix job's contexts share one set of refusals: a matrix that cannot be
-  enumerated (`fromJSON()` or any other computed value, `include:`, a nested
-  shape), a placeholder that is not a plain `matrix.<axis>` reference, an axis
-  the matrix does not declare, a DEGENERATE template (one carrying no literal
-  WORD to anchor it, whose rendering matching an external app's check name is a
-  coincidence — punctuation does not anchor, so `${{ matrix.a }}/${{ matrix.b }}`
-  rendering `security/snyk` is refused alongside a bare `${{ matrix.target }}`),
-  a leg that is EMPTY or whose whitespace normalising the rendering would
-  rewrite (neither substitutes the way GitHub substitutes it), a `name:` whose
-  own interior whitespace that normalisation rewrote, an `exclude:` this scan
-  cannot read (a key naming no declared axis, or a computed value — both were
-  silent no-ops, and an exclude that fails to remove leaves EXTRA renderings,
-  the dangerous direction), and a rendering a genuine reusable caller in these
-  files also claims, all still leave the check UNTRACED and the fact
-  UNMEASURED — an unknown must never render as a known negative. That last
-  refusal now keys on the competing CLAIM rather than on the template
-  beginning with a placeholder: position was only ever a proxy for the hazard,
-  and one literal word in front (`Nightly ${{ matrix.variant }} / build` against
-  a `Nightly Suite` caller) walked straight past it. The competitor lookup also
-  renders a caller's OWN templated `name:` through the same enumeration and
-  treats a caller it cannot render as one it cannot rule out; comparing a
-  required context against unrendered template text matched nothing, so a
-  matrix caller claimed no name at all. Each of those gaps let a foreign
-  `always()` matrix job certify a check the real caller produces behind a
-  condition. Because the fact is SCORED, `security_score` changes on any
-  repository with matrix-templated required checks: the fact enters the scored
-  denominator where it used to sit out, as a PASS where the newly traced
-  producers always run and as a FAIL — lowering the score — where one of them
-  can skip.
+  the SAME enumeration that produces the `(…)` suffixes, and legs are read the
+  way GitHub substitutes them rather than the way Python prints them — a `true`
+  leg renders `true`, and a `null` leg renders nothing at all.
+
+  Both readings of a matrix job's contexts therefore share one set of refusals,
+  and each leaves the check UNTRACED and the fact UNMEASURED, because an
+  unknown must never render as a known negative:
+
+  - a matrix that cannot be enumerated — `fromJSON()` or any other computed
+    value, `include:`, a nested or non-list shape;
+  - a placeholder that is not a plain `matrix.<axis>` reference, and a `${{`
+    that is never closed (not a templated name at all, and it was letting a
+    matrix job stand in for the bare context GitHub never emits for it);
+  - an axis the name references that the matrix does not declare;
+  - a name with no literal LETTER anchoring it, whose rendering matching an
+    external app's check name is a coincidence. Punctuation was already refused
+    (`${{ matrix.a }}/${{ matrix.b }}` rendering `security/snyk`); underscores
+    and digits are refused with it, since `${{ matrix.os }}_${{ matrix.arch }}`
+    rendering a required `ubuntu_x64` is the same coincidence and a far more
+    ordinary job name. One literal letter still anchors, so `v${{ matrix.n }}`
+    binds;
+  - an EMPTY leg, which renders exactly what GitHub renders and thereby loses
+    the anchoring text the name was admitted on, and interior whitespace in a
+    leg or in the `name:`, which this scan normalises and GitHub does not;
+  - an `exclude:` this scan cannot read — a key naming no declared axis, a
+    computed value, or a value that is not a scalar. All three were silent
+    no-ops, and an exclude that fails to remove leaves EXTRA renderings, the
+    dangerous direction;
+  - a rendering a genuine reusable caller in these files also claims. That
+    refusal keys on the competing CLAIM, not on the template beginning with a
+    placeholder: position was only ever a proxy, and one literal word in front
+    (`Nightly ${{ matrix.variant }} / build` against a `Nightly Suite` caller)
+    walked straight past it. The competitor lookup renders a caller's own
+    templated `name:` through the same enumeration, and a caller it cannot
+    render competes for the names its literal text could still produce — not,
+    as it first did, for every name in the repository, which switched the whole
+    resolution off for any repository holding one `deploy ${{ matrix.env }}`
+    over a computed matrix. A job is no longer its own competitor.
+
+  Every one of those refusals now says which one it was. They shared a single
+  sentence — "a job name templated over a matrix this scan cannot enumerate" —
+  which is false for most of them, since in a degenerate name, a whitespace
+  rewrite, a misspelled axis or a competing reusable call the matrix enumerates
+  perfectly well. The evidence names the job that nearly produced the check and
+  why it did not, and names only a job whose literal text could have produced
+  that context.
+
+  Because the fact is SCORED, `security_score` changes on any repository with
+  matrix-templated required checks: the fact enters the scored denominator
+  where it used to sit out, as a PASS where the newly traced producers always
+  run and as a FAIL — lowering the score — where one of them can skip.
 
 - **2026-08-19** — **A deferred file that cannot be read is now a stop, not an
   improvisation.** SKILL.md defers load-bearing procedure to reference files in

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -141,6 +141,31 @@ entries are dated (UTC). Format loosely follows
 
 ### Fixed
 
+- **2026-09-03** — **A required check produced by a matrix-templated job name
+  now resolves to its job.** `sec.required-checks.skippable` matched a job's
+  display name only when that name was literal. A job named `build shard
+  ${{ matrix.shard }}/4` with literal legs `[1, 2, 3, 4]` produces the required
+  checks `build shard 1/4` through `build shard 4/4`, and the resolver could
+  not map any of them back to the job that declares them: checks fully
+  determinable from the workflow YAML were reported as untraceable ("no job in
+  these workflows reports it") and the fact went UNMEASURED, so a repository
+  that shards a required job lost a security fact it could have been graded on.
+  Templated names are now rendered against the matrix's literal values through
+  the SAME enumeration that produces the `(…)` suffixes, so both readings of a
+  matrix job's contexts share one set of refusals: a matrix that cannot be
+  enumerated (`fromJSON()` or any other computed value, `include:`, a nested
+  shape), a placeholder that is not a plain `matrix.<axis>` reference, an axis
+  the matrix does not declare, a DEGENERATE template (nothing but a
+  placeholder, whose rendering matching an external app's check name is a
+  coincidence), and a LEADING-placeholder template competing with a genuine
+  reusable caller for the same `<caller> / <child>` check all still leave the
+  check UNTRACED and the fact UNMEASURED — an unknown must never render as a
+  known negative. Because the fact is SCORED, `security_score` changes on any
+  repository with matrix-templated required checks: the fact enters the scored
+  denominator where it used to sit out, as a PASS where the newly traced
+  producers always run and as a FAIL — lowering the score — where one of them
+  can skip.
+
 - **2026-08-19** — **A deferred file that cannot be read is now a stop, not an
   improvisation.** SKILL.md defers load-bearing procedure to reference files in
   several places, each phrased as "read this before acting". While that

--- a/skills/ci-secure/CHANGELOG.md
+++ b/skills/ci-secure/CHANGELOG.md
@@ -155,12 +155,28 @@ entries are dated (UTC). Format loosely follows
   matrix job's contexts share one set of refusals: a matrix that cannot be
   enumerated (`fromJSON()` or any other computed value, `include:`, a nested
   shape), a placeholder that is not a plain `matrix.<axis>` reference, an axis
-  the matrix does not declare, a DEGENERATE template (nothing but a
-  placeholder, whose rendering matching an external app's check name is a
-  coincidence), and a LEADING-placeholder template competing with a genuine
-  reusable caller for the same `<caller> / <child>` check all still leave the
-  check UNTRACED and the fact UNMEASURED — an unknown must never render as a
-  known negative. Because the fact is SCORED, `security_score` changes on any
+  the matrix does not declare, a DEGENERATE template (one carrying no literal
+  WORD to anchor it, whose rendering matching an external app's check name is a
+  coincidence — punctuation does not anchor, so `${{ matrix.a }}/${{ matrix.b }}`
+  rendering `security/snyk` is refused alongside a bare `${{ matrix.target }}`),
+  a leg that is EMPTY or whose whitespace normalising the rendering would
+  rewrite (neither substitutes the way GitHub substitutes it), a `name:` whose
+  own interior whitespace that normalisation rewrote, an `exclude:` this scan
+  cannot read (a key naming no declared axis, or a computed value — both were
+  silent no-ops, and an exclude that fails to remove leaves EXTRA renderings,
+  the dangerous direction), and a rendering a genuine reusable caller in these
+  files also claims, all still leave the check UNTRACED and the fact
+  UNMEASURED — an unknown must never render as a known negative. That last
+  refusal now keys on the competing CLAIM rather than on the template
+  beginning with a placeholder: position was only ever a proxy for the hazard,
+  and one literal word in front (`Nightly ${{ matrix.variant }} / build` against
+  a `Nightly Suite` caller) walked straight past it. The competitor lookup also
+  renders a caller's OWN templated `name:` through the same enumeration and
+  treats a caller it cannot render as one it cannot rule out; comparing a
+  required context against unrendered template text matched nothing, so a
+  matrix caller claimed no name at all. Each of those gaps let a foreign
+  `always()` matrix job certify a check the real caller produces behind a
+  condition. Because the fact is SCORED, `security_score` changes on any
   repository with matrix-templated required checks: the fact enters the scored
   denominator where it used to sit out, as a PASS where the newly traced
   producers always run and as a FAIL — lowering the score — where one of them

--- a/skills/ci-secure/references/security-facts.md
+++ b/skills/ci-secure/references/security-facts.md
@@ -108,8 +108,9 @@ two moved numbers.
   satisfied by never running it. The pass shape is the always-running verdict
   job that `needs:` the conditional suites and asserts their results. Required
   contexts no workflow job produces are named, not judged — external app
-  checks, reusable-workflow jobs, and job names templated over a matrix this
-  scan cannot enumerate all land there — and a PASS is a statement about EVERY
+  checks, reusable-workflow jobs, and templated job names whose rendering this
+  scan will not guess all land there, each with the reason it was refused —
+  and a PASS is a statement about EVERY
   required check, so ANY context that could
   not be traced leaves the fact unmeasured rather than green — the ordinary
   shape of a mature repository is a dozen required contexts with most coming
@@ -125,23 +126,39 @@ two moved numbers.
   A matrix job's contexts come from the combinations the matrix can actually
   run: a literal `name:` takes GitHub's appended `(value, …)` suffix, and a
   `name:` templated over the matrix (`build shard ${{ matrix.shard }}/4` over
-  `shard: [1, 2, 3, 4]`) renders its legs directly. Both readings enumerate the
+  `shard: [1, 2, 3, 4]`) renders its legs directly. Legs are read the way
+  GitHub substitutes them, so a `true` leg is `true` and a `null` leg is
+  nothing at all. Both readings enumerate the
   same combinations, so both refuse the same unknowables — `fromJSON()` or any
-  other computed value, `include:`, a nested shape, a placeholder that is not a
-  plain `matrix.<axis>` reference, an `exclude:` naming no declared axis or
-  carrying a computed value — and an unenumerable matrix leaves the check
+  other computed value, `include:`, a nested or non-list shape, a placeholder
+  that is not a plain `matrix.<axis>` reference, an axis a name references but
+  the matrix does not declare, and an `exclude:` this scan cannot read (a key
+  naming no declared axis, a computed value, or a value that is not a scalar)
+  — and an unenumerable matrix leaves the check
   untraced rather than guessed. Further shapes are refused even when they
-  do enumerate: a name carrying no literal WORD to anchor it — a bare
-  `${{ matrix.target }}`, but equally `${{ matrix.a }}/${{ matrix.b }}` or
-  `${{ matrix.s }} (${{ matrix.l }})`, since punctuation anchors nothing and
-  those render an external app's `security/snyk` and `Analyze (javascript)`
-  names on a coincidence — a leg that is empty or carries interior double
-  spaces (GitHub substitutes the value verbatim, so neither renders the name
-  this scan would compare), and a rendering that a genuine reusable caller in
-  these files ALSO claims as its own check or as the `<caller> / <child>` leaf
-  of its invocation — whether or not the template begins with the placeholder,
-  and counting a caller whose own `name:` is templated unless this scan can
-  render that name and rule it out.
+  do enumerate:
+
+  - **A name with no literal LETTER to anchor it** — a bare
+    `${{ matrix.target }}`, but equally `${{ matrix.a }}/${{ matrix.b }}`,
+    `${{ matrix.s }} (${{ matrix.l }})` or `${{ matrix.a }}_${{ matrix.b }}`.
+    Punctuation, underscores and digits anchor nothing, and those render an
+    external app's `security/snyk`, `Analyze (javascript)` and `ubuntu_x64`
+    names on a coincidence. One literal letter is enough: `v${{ matrix.n }}`
+    binds.
+  - **An EMPTY leg**, which renders exactly what GitHub renders and that is the
+    problem: `${{ matrix.p }}lint` over `p: ['']` collapses to the bare `lint`
+    another job owns, so the anchoring the name was admitted on is gone from
+    the rendering.
+  - **Interior whitespace** in the `name:` or in a leg. Renderings are
+    whitespace-normalised so they can be compared and GitHub normalises none,
+    so the compared string is one GitHub never emits.
+  - **A rendering a genuine reusable caller in these files ALSO claims**, as
+    its own check or as the `<caller> / <child>` leaf of its invocation. Where
+    the placeholder sits in the template has nothing to do with it; the
+    competing claim is the whole rule. A caller whose own `name:` is templated
+    is rendered the same way, and one this scan cannot render competes for the
+    names its literal text could still produce — not, as it once did, for
+    every name in the repository.
   A push filtered to specific branches or paths is UNKNOWN: it may or may not
   run on a given pull request's head branch, so its jobs still count against
   the check but can never be the evidence that one always reports. Unknown is

--- a/skills/ci-secure/references/security-facts.md
+++ b/skills/ci-secure/references/security-facts.md
@@ -109,8 +109,8 @@ two moved numbers.
   job that `needs:` the conditional suites and asserts their results. Required
   contexts no workflow job produces are named, not judged — external app
   checks, reusable-workflow jobs, and job names templated over a matrix this
-  scan cannot enumerate all land there — and
-  a PASS is a statement about EVERY required check, so ANY context that could
+  scan cannot enumerate all land there — and a PASS is a statement about EVERY
+  required check, so ANY context that could
   not be traced leaves the fact unmeasured rather than green — the ordinary
   shape of a mature repository is a dozen required contexts with most coming
   from external apps, and a green earned off the one traceable check would be
@@ -128,12 +128,20 @@ two moved numbers.
   `shard: [1, 2, 3, 4]`) renders its legs directly. Both readings enumerate the
   same combinations, so both refuse the same unknowables — `fromJSON()` or any
   other computed value, `include:`, a nested shape, a placeholder that is not a
-  plain `matrix.<axis>` reference — and an unenumerable matrix leaves the check
-  untraced rather than guessed. Two templated shapes are refused even when they
-  do enumerate: a name that is NOTHING but a placeholder (it would certify a
-  check on a coincidence with an external app's name), and a name BEGINNING
-  with a placeholder when a real reusable caller competes for the same
-  `<caller> / <child>` check.
+  plain `matrix.<axis>` reference, an `exclude:` naming no declared axis or
+  carrying a computed value — and an unenumerable matrix leaves the check
+  untraced rather than guessed. Further shapes are refused even when they
+  do enumerate: a name carrying no literal WORD to anchor it — a bare
+  `${{ matrix.target }}`, but equally `${{ matrix.a }}/${{ matrix.b }}` or
+  `${{ matrix.s }} (${{ matrix.l }})`, since punctuation anchors nothing and
+  those render an external app's `security/snyk` and `Analyze (javascript)`
+  names on a coincidence — a leg that is empty or carries interior double
+  spaces (GitHub substitutes the value verbatim, so neither renders the name
+  this scan would compare), and a rendering that a genuine reusable caller in
+  these files ALSO claims as its own check or as the `<caller> / <child>` leaf
+  of its invocation — whether or not the template begins with the placeholder,
+  and counting a caller whose own `name:` is templated unless this scan can
+  render that name and rule it out.
   A push filtered to specific branches or paths is UNKNOWN: it may or may not
   run on a given pull request's head branch, so its jobs still count against
   the check but can never be the evidence that one always reports. Unknown is

--- a/skills/ci-secure/references/security-facts.md
+++ b/skills/ci-secure/references/security-facts.md
@@ -108,7 +108,8 @@ two moved numbers.
   satisfied by never running it. The pass shape is the always-running verdict
   job that `needs:` the conditional suites and asserts their results. Required
   contexts no workflow job produces are named, not judged — external app
-  checks, reusable-workflow jobs, and templated job names all land there — and
+  checks, reusable-workflow jobs, and job names templated over a matrix this
+  scan cannot enumerate all land there — and
   a PASS is a statement about EVERY required check, so ANY context that could
   not be traced leaves the fact unmeasured rather than green — the ordinary
   shape of a mature repository is a dozen required contexts with most coming
@@ -121,6 +122,18 @@ two moved numbers.
   CAN report, so an always-running job there certifies the check. A push
   restricted to TAGS provably cannot — no pull-request branch push matches it —
   so a same-named job in a tag-only release workflow is not a producer at all.
+  A matrix job's contexts come from the combinations the matrix can actually
+  run: a literal `name:` takes GitHub's appended `(value, …)` suffix, and a
+  `name:` templated over the matrix (`build shard ${{ matrix.shard }}/4` over
+  `shard: [1, 2, 3, 4]`) renders its legs directly. Both readings enumerate the
+  same combinations, so both refuse the same unknowables — `fromJSON()` or any
+  other computed value, `include:`, a nested shape, a placeholder that is not a
+  plain `matrix.<axis>` reference — and an unenumerable matrix leaves the check
+  untraced rather than guessed. Two templated shapes are refused even when they
+  do enumerate: a name that is NOTHING but a placeholder (it would certify a
+  check on a coincidence with an external app's name), and a name BEGINNING
+  with a placeholder when a real reusable caller competes for the same
+  `<caller> / <child>` check.
   A push filtered to specific branches or paths is UNKNOWN: it may or may not
   run on a given pull request's head branch, so its jobs still count against
   the check but can never be the evidence that one always reports. Unknown is

--- a/skills/ci-secure/scripts/config_facts.py
+++ b/skills/ci-secure/scripts/config_facts.py
@@ -1891,9 +1891,11 @@ def _matrix_near_miss(docs: list[tuple[str, dict]], context: str) -> str | None:
         for key, job in _jobs(doc):
             shown = _display_name(key, job)
             if _EXPRESSION_RE.search(shown):
-                # A templated display name is not knowable, which is why the
-                # producer match skips it; the near miss has to skip it too or
-                # it would name a job as the cause on a guess.
+                # This near miss is about the bare-name-versus-expansion
+                # mismatch, which needs a literal name to compare. A templated
+                # name has its own note — see `_templated_refusal_note`, which
+                # rules a job out by its literal text before naming it, rather
+                # than naming one on a guess.
                 continue
             if shown == context and _job_has_matrix(job):
                 return (f"{rel}: the matrix job `{key}` produces "

--- a/skills/ci-secure/scripts/config_facts.py
+++ b/skills/ci-secure/scripts/config_facts.py
@@ -1313,6 +1313,13 @@ def _context_producers(
         for key, job in jobs.items():
             shown = _display_name(key, job)
             if _EXPRESSION_RE.search(shown):
+                # A `${{ matrix.* }}` name over ENUMERABLE literal legs renders
+                # a knowable set of contexts, and one of them may be the check.
+                # See `_templated_name_renderings` for what is refused.
+                if context in (_templated_name_renderings(job, shown) or ()) \
+                        and not (_name_template_leads_with_placeholder(shown)
+                                 and _reusable_caller_claims(docs, context)):
+                    out.append((rel, key, job, jobs, doc, ability))
                 continue
             if context == shown and not _job_has_matrix(job):
                 # A MATRIX job never reports its bare name — GitHub appends the
@@ -1343,9 +1350,9 @@ def _job_has_matrix(job: dict) -> bool:
     return bool(matrix) if not isinstance(matrix, (str, int, float)) else True
 
 
-def _matrix_expansions(job: dict) -> set[str] | None:
-    """Every `(…)` suffix this job's matrix can actually render, or None when
-    the matrix is not knowable from the YAML.
+def _matrix_combinations(job: dict) -> list[dict[str, str]] | None:
+    """Every axis assignment this job's matrix can actually run — `[{"shard":
+    "1"}, …]` — or None when the matrix is not knowable from the YAML.
 
     Only a matrix expands a job into `name (value, …)` contexts; it expands
     into its own values; and it expands into the COMBINATIONS it can really
@@ -1367,6 +1374,11 @@ def _matrix_expansions(job: dict) -> set[str] | None:
     extend existing ones, and guessing its rendering is how the three defects
     above happened. An unknowable matrix produces NO match, which leaves the
     context disclosed as not judged; a wrong match is a silent pass.
+
+    Both readings of a matrix job's context come from here — the appended
+    `(…)` suffix of a literal `name:`, and the rendering of a `${{ matrix.* }}`
+    templated one — so the two can never disagree about the same matrix, and a
+    refusal added for one is a refusal for both.
     """
     strategy = job.get("strategy")
     matrix = strategy.get("matrix") if isinstance(strategy, dict) else None
@@ -1400,14 +1412,29 @@ def _matrix_expansions(job: dict) -> set[str] | None:
             return None
         excluded.append({str(k): str(v).strip() for k, v in entry.items()})
 
-    out: set[str] = set()
+    out: list[dict[str, str]] = []
     for combo in itertools.product(*axes):
         assignment = dict(zip(names, combo))
         if any(all(assignment.get(k) == v for k, v in rule.items())
                for rule in excluded):
             continue
-        out.add(", ".join(combo))
+        out.append(assignment)
     return out or None
+
+
+def _matrix_expansions(job: dict) -> set[str] | None:
+    """The `(…)` suffixes this job's matrix can render, or None when unknowable.
+
+    The values in an expansion appear in the order the axes are DECLARED, which
+    is why the combinations carry their axis names rather than a bare tuple:
+    the templated-name renderer needs to know which value belongs to which
+    axis, and both readings have to come from one enumeration or they can
+    disagree about the same matrix.
+    """
+    combos = _matrix_combinations(job)
+    if combos is None:
+        return None
+    return {", ".join(a.values()) for a in combos} or None
 
 
 def _matrix_produces(job: dict, suffix: str) -> bool:
@@ -1416,6 +1443,104 @@ def _matrix_produces(job: dict, suffix: str) -> bool:
     if expansions is None:
         return False
     return " ".join(suffix.split()) in expansions
+
+
+# A job `name:` may be TEMPLATED over the matrix — `build shard
+# ${{ matrix.shard }}/4` over `shard: [1, 2, 3, 4]`. GitHub renders the name;
+# it does NOT also append the `(…)` combination. So the contexts such a job
+# produces are the renderings, and when the legs are literals sitting in the
+# YAML they are as enumerable as any other expansion.
+#
+# Read as unknowable, every required check a sharded job produces went
+# untraced and this fact dropped to UNMEASURED — so a repository that shards a
+# required job lost a security fact its own YAML answers outright. The
+# expansion is rendered EXACTLY, not matched by a wildcard regex: a rendering
+# is a concrete string that either is the required context or is not.
+_PLACEHOLDER_RE = re.compile(r"\$\{\{(.*?)\}\}", re.S)
+_MATRIX_REF_RE = re.compile(r"^matrix\.([A-Za-z_][A-Za-z0-9_-]*)$")
+
+
+def _name_template_is_degenerate(template: str) -> bool:
+    """A `name:` that is NOTHING but placeholders — `${{ matrix.target }}`.
+
+    It carries no literal text to anchor it, so a rendering that equals a
+    required context is indistinguishable from a coincidence: an external
+    app's `Header rules` check and a matrix leg spelled the same way are the
+    same string. Certifying a required check on that coincidence is a silent
+    pass, and an unresolved check is merely unmeasured — so this shape is
+    refused.
+    """
+    return not _PLACEHOLDER_RE.sub("", template).strip()
+
+
+def _name_template_leads_with_placeholder(template: str) -> bool:
+    """A `name:` whose first character is a placeholder — `${{ matrix.variant
+    }} / build`. GitHub names a reusable invocation's leaf checks `<caller job>
+    / <child>`, and such a template can render exactly that string, so it can
+    impersonate a check a genuine reusable caller in ANOTHER file produces.
+    Refused only when such a caller actually competes (see
+    `_reusable_caller_claims`) — a blanket refusal would drop a real matrix
+    job that is the sole producer of `linux / build`.
+    """
+    if "${{" not in template:
+        return False
+    return not _PLACEHOLDER_RE.split(template)[0].strip()
+
+
+def _reusable_caller_claims(docs: list[tuple[str, dict]], context: str) -> bool:
+    """Does some reusable-workflow CALL in these files claim `context` as its
+    own check or as the `<caller> / <child>` leaf of its invocation?"""
+    for _rel, doc in docs:
+        for key, job in _jobs(doc):
+            if not isinstance(job.get("uses"), str):
+                continue
+            shown = _display_name(key, job)
+            if context == shown or context.startswith(shown + " / "):
+                return True
+    return False
+
+
+def _templated_name_renderings(job: dict, shown: str) -> set[str] | None:
+    """Every display name a templated `name:` can actually render, or None.
+
+    None — the check stays UNTRACED and the fact UNMEASURED — whenever the
+    rendering is not knowable from the YAML, which is every case below. An
+    unknown must never come out as a known negative, and unmeasured beats a
+    confident wrong answer:
+
+      * a placeholder that is not a plain `matrix.<axis>` reference
+        (`${{ github.ref_name }}`, a function call, `matrix['x']`) renders
+        from the run, not the file;
+      * a matrix this scan cannot enumerate — `fromJSON()` or any other
+        computed value, an `include:`, a nested shape — which is the same
+        refusal `_matrix_expansions` already makes, reached through the same
+        enumeration so the two cannot disagree;
+      * an axis the name references that the matrix does not declare.
+
+    A DEGENERATE template is refused here too: it renders concrete strings,
+    but with no literal text anchoring them the match is a coincidence.
+    """
+    if _name_template_is_degenerate(shown):
+        return None
+    axes_used = []
+    for expr in _PLACEHOLDER_RE.findall(shown):
+        ref = _MATRIX_REF_RE.match(expr.strip())
+        if ref is None:
+            return None
+        axes_used.append(ref.group(1))
+    combos = _matrix_combinations(job)
+    if combos is None:
+        return None
+    out: set[str] = set()
+    for assignment in combos:
+        if any(axis not in assignment for axis in axes_used):
+            return None
+        rendered = _PLACEHOLDER_RE.sub(
+            lambda m: assignment[_MATRIX_REF_RE.match(
+                m.group(1).strip()).group(1)],
+            shown)
+        out.add(" ".join(rendered.split()))
+    return out or None
 
 
 # A 403 from the admin-only classic endpoint is ORDINARY — most readers of this
@@ -1637,8 +1762,9 @@ def _required_checks_skippable(
             unjudged.append(
                 f"`{context}` ({near})" if near else
                 f"`{context}` (no job in these workflows reports it — an "
-                f"external app check, a reusable-workflow job, a templated "
-                f"job name, or a stale entry)")
+                f"external app check, a reusable-workflow job, a job name "
+                f"templated over a matrix this scan cannot enumerate, or a "
+                f"stale entry)")
             continue
         skips: list[str] = []
         unknown: list[str] = []

--- a/skills/ci-secure/scripts/config_facts.py
+++ b/skills/ci-secure/scripts/config_facts.py
@@ -1303,9 +1303,12 @@ def _context_producers(
     its key — and a matrix job expands to `name (value, value)`. Both spellings
     are matched. A display name built from an expression is matched only when
     the expression is a plain `matrix.<axis>` over legs this scan can enumerate
-    from the YAML, and only when nothing makes the rendering a coincidence —
-    see `_templated_name_renderings`. Everything else stays unmatched, because
-    what it renders to is not knowable here.
+    from the YAML, and only when nothing makes the rendering a coincidence.
+    Those two refusals live in two places, and a reader chasing an unresolved
+    check needs both: `_render_templated_name` refuses what the rendering
+    itself cannot settle, and `_reusable_caller_claims`, applied here, refuses
+    a rendering some reusable call in these files also claims. Everything else
+    stays unmatched, because what it renders to is not knowable here.
     """
     out = []
     for rel, doc in docs:
@@ -1320,7 +1323,7 @@ def _context_producers(
                 # a knowable set of contexts, and one of them may be the check.
                 # See `_templated_name_renderings` for what is refused.
                 if context in (_templated_name_renderings(job, shown) or ()) \
-                        and not _reusable_caller_claims(docs, context):
+                        and not _reusable_caller_claims(docs, context, job):
                     out.append((rel, key, job, jobs, doc, ability))
                 continue
             if context == shown and not _job_has_matrix(job):
@@ -1337,6 +1340,28 @@ def _context_producers(
 
 
 _MATRIX_META = {"include", "exclude"}
+
+
+def _leg_text(entry) -> str | None:
+    """A matrix leg as GITHUB substitutes it, or None when it is not a scalar.
+
+    `str()` is Python's spelling, not GitHub's, and the difference is not
+    cosmetic in either direction. A YAML `true` leg became `True`, so a
+    boolean axis matched nothing and the repository kept losing the very fact
+    this resolution exists to give it back — the safe direction, but silently
+    the whole feature switched off. A `null` leg became `None`, which is worse:
+    GitHub substitutes nothing at all there, so `${{ matrix.p }}deploy` really
+    does render the bare `deploy` some other job owns — and the empty-leg
+    refusal that exists to catch exactly that never fired, because the string
+    `"None"` is not empty.
+    """
+    if isinstance(entry, (dict, list)):
+        return None                              # nested shape: not knowable
+    if entry is None:
+        return ""                                # `null` substitutes nothing
+    if isinstance(entry, bool):
+        return "true" if entry else "false"      # never Python's `True`
+    return str(entry).strip()
 
 
 def _job_has_matrix(job: dict) -> bool:
@@ -1356,10 +1381,12 @@ def _matrix_combinations(job: dict) -> list[dict[str, str]] | None:
     """Every axis assignment this job's matrix can actually run — `[{"shard":
     "1"}, …]` — or None when the matrix is not knowable from the YAML.
 
-    Only a matrix expands a job into `name (value, …)` contexts; it expands
-    into its own values; and it expands into the COMBINATIONS it can really
-    run, joined in the order its axes are declared. All three clauses matter,
-    and each one was learned from a false green in the same family:
+    A matrix job runs the COMBINATIONS its axes can really produce, in the
+    order those axes are declared, and both readings of its check contexts are
+    built from them. Only a matrix expands a job at all; it expands into its
+    own values; and it expands into the combinations, not the value set. All
+    three clauses matter, and each was learned from a false green in the same
+    family:
 
       * offered to every job, an always-running verdict job named `test` stood
         in as the producer of `test (self-hosted)` — this repository's own CI
@@ -1397,9 +1424,9 @@ def _matrix_combinations(job: dict) -> list[dict[str, str]] | None:
             return None
         values: list[str] = []
         for entry in node:
-            if isinstance(entry, (dict, list)):
+            text = _leg_text(entry)
+            if text is None:
                 return None                      # nested shape: not knowable
-            text = str(entry).strip()
             if _EXPRESSION_RE.search(text):
                 return None                      # computed: not knowable
             values.append(text)
@@ -1412,17 +1439,21 @@ def _matrix_combinations(job: dict) -> list[dict[str, str]] | None:
     for entry in matrix.get("exclude") or []:
         if not isinstance(entry, dict):
             return None
-        rule = {str(k): str(v).strip() for k, v in entry.items()}
         # An exclude this scan cannot READ is not an exclude it may ignore.
         # Skipping it keeps combinations the run really removes, and EXTRA
         # combinations are the dangerous direction: they manufacture renderings
-        # GitHub never emits, any one of which can certify a required check. A
-        # key naming no declared axis matched nothing (`assignment.get(k)` is
-        # None), and a computed value was compared as its literal `${{ … }}`
-        # text — both silently no-ops.
-        if any(k not in names or _EXPRESSION_RE.search(v)
-               for k, v in rule.items()):
-            return None
+        # GitHub never emits, any one of which can certify a required check.
+        # Three ways a rule went unread, all silent no-ops: a key naming no
+        # declared axis, a computed value, and a value that is not a scalar at
+        # all — the last one flattened to text like `"[1]"`, which matches no
+        # assignment. The values go through the same `_leg_text` as the axes,
+        # or the two sides of the comparison disagree about `true` and `null`.
+        rule = {}
+        for k, v in entry.items():
+            text = _leg_text(v)
+            if text is None or str(k) not in names or _EXPRESSION_RE.search(text):
+                return None
+            rule[str(k)] = text
         excluded.append(rule)
 
     out: list[dict[str, str]] = []
@@ -1438,11 +1469,12 @@ def _matrix_combinations(job: dict) -> list[dict[str, str]] | None:
 def _matrix_expansions(job: dict) -> set[str] | None:
     """The `(…)` suffixes this job's matrix can render, or None when unknowable.
 
-    The values in an expansion appear in the order the axes are DECLARED, which
-    is why the combinations carry their axis names rather than a bare tuple:
-    the templated-name renderer needs to know which value belongs to which
-    axis, and both readings have to come from one enumeration or they can
-    disagree about the same matrix.
+    The values appear in the order the axes are DECLARED, so joining an
+    assignment's values reproduces the suffix GitHub appends. The combinations
+    carry their axis NAMES rather than a bare tuple for a different reason:
+    the templated-name renderer has to know which value belongs to which axis,
+    and both readings have to come from one enumeration or they can disagree
+    about the same matrix.
     """
     combos = _matrix_combinations(job)
     if combos is None:
@@ -1459,16 +1491,23 @@ def _matrix_produces(job: dict, suffix: str) -> bool:
 
 
 # A job `name:` may be TEMPLATED over the matrix — `build shard
-# ${{ matrix.shard }}/4` over `shard: [1, 2, 3, 4]`. GitHub renders the name;
-# it does NOT also append the `(…)` combination. So the contexts such a job
-# produces are the renderings, and when the legs are literals sitting in the
-# YAML they are as enumerable as any other expansion.
+# ${{ matrix.shard }}/4` over `shard: [1, 2, 3, 4]`. As OBSERVED of the runner,
+# GitHub renders such a name and does NOT also append the `(…)` combination
+# (it is not written down in GitHub's documentation, and the whole reading
+# below rests on it). So the contexts such a job produces are the renderings,
+# and when the legs are literals sitting in the YAML they are as enumerable as
+# any other expansion.
 #
-# Read as unknowable, every required check a sharded job produces went
-# untraced and this fact dropped to UNMEASURED — so a repository that shards a
-# required job lost a security fact its own YAML answers outright. The
-# expansion is rendered EXACTLY, not matched by a wildcard regex: a rendering
-# is a concrete string that either is the required context or is not.
+# The rendering is EXACT, never a wildcard match: a rendering is a concrete
+# string that either is the required context or is not. Wildcards appear in
+# this module only to RULE a template OUT (`_template_could_render`), never to
+# rule one in.
+#
+# One shape neither GitHub's naming nor this reading covers: a templated name
+# that omits an axis the matrix declares (`build ${{ matrix.os }}` over
+# `os` × `arch`) renders COLLIDING names for several legs. This scan treats
+# each rendering as a context the job can report, which stays true of a
+# collision — every colliding leg really does report that name.
 _PLACEHOLDER_RE = re.compile(r"\$\{\{(.*?)\}\}", re.S)
 _MATRIX_REF_RE = re.compile(r"^matrix\.([A-Za-z_][A-Za-z0-9_-]*)$")
 
@@ -1490,103 +1529,199 @@ def _name_template_is_degenerate(template: str) -> bool:
     (${{ matrix.l }})` renders the `Analyze (javascript)` shape a scanning app
     reports — every discriminating character supplied by a matrix value, the
     `/` and ` ()` supplying none. Nothing in these files competes for an
-    EXTERNAL app's name, so the leading-placeholder rule cannot catch these
-    either. The anchor therefore has to be a word character.
+    EXTERNAL app's name, so the reusable-caller refusal cannot catch these
+    either.
+
+    Neither are UNDERSCORES or DIGITS, and spelling the anchor `\\w` said they
+    were: `\\w` is `[A-Za-z0-9_]`, so `${{ matrix.os }}_${{ matrix.arch }}`
+    over `[ubuntu]` and `[x64]` certified a required `ubuntu_x64` on the same
+    coincidence the `/` beside it was refused for — and an underscore between
+    two matrix values is a far more ordinary job name than either shape this
+    refusal was first written against. A digit is no better: `${{ matrix.t }}
+    2` renders `Header rules 2`. The anchor has to be a LETTER, which is the
+    only character class a matrix value cannot supply for free.
+
+    One letter is enough, and the rule stays about letters rather than length:
+    `v${{ matrix.n }}` is an ordinary release-shard name whose `v` is real
+    literal text, and refusing it would report a traceable check as fileless.
     """
-    return not re.search(r"\w", _PLACEHOLDER_RE.sub("", template))
+    return not re.search(r"[^\W\d_]", _PLACEHOLDER_RE.sub("", template))
 
 
-def _reusable_caller_claims(docs: list[tuple[str, dict]], context: str) -> bool:
-    """Does some reusable-workflow CALL in these files claim `context` as its
-    own check or as the `<caller> / <child>` leaf of its invocation?
+def _template_could_render(template: str, context: str) -> bool:
+    """Could this template's LITERAL text produce `context`, whatever its
+    matrix turns out to hold?
+
+    A template's literal segments survive every substitution, so a template
+    whose segments do not appear in `context`, in order, provably does not
+    render it. That makes this a way to RULE A TEMPLATE OUT, and it is used
+    only where ruling out is the safe direction: narrowing which reusable
+    callers compete for a name, and deciding which job a hint may name.
+
+    It is deliberately NOT a way to rule one IN, and must never become one:
+    the placeholders are matched with a wildcard, and a wildcard match is the
+    coincidence this whole module refuses to certify a check on. Binding stays
+    exact — a rendering either is the required context or is not.
+    """
+    # `_PLACEHOLDER_RE` carries one group, so `split` alternates literal,
+    # captured expression, literal — the literals are the even elements.
+    pattern = ".*".join(re.escape(part)
+                        for part in _PLACEHOLDER_RE.split(template)[::2])
+    return re.fullmatch(pattern, context, re.S) is not None
+
+
+def _reusable_caller_claims(
+    docs: list[tuple[str, dict]], context: str, candidate: dict | None = None,
+) -> tuple[str, str] | None:
+    """The (workflow, job key) of a reusable-workflow CALL in these files that
+    claims `context` as its own check or as the `<caller> / <child>` leaf of
+    its invocation, or None when none does.
 
     A caller's own `name:` may itself be TEMPLATED, and comparing a required
     context against unrendered template text never matches — so a matrix
-    caller claimed nothing, the leading-placeholder refusal never fired, and a
-    foreign `always()` matrix job in another file certified a check the real
-    caller produces behind a condition. That is exactly the silent pass the
-    refusal exists to prevent. A templated caller is therefore rendered by the
-    same enumeration as any other templated name, and one this scan CANNOT
-    render is a competitor it cannot rule out — so it claims the name.
+    caller claimed nothing and a foreign `always()` matrix job in another file
+    certified a check the real caller produces behind a condition. A templated
+    caller is therefore rendered by the same enumeration as any other
+    templated name.
+
+    A caller this scan cannot render is a competitor it cannot rule out — but
+    only for the names it could actually produce. Claiming EVERY context
+    switched the whole matrix-templated resolution off repository-wide for any
+    repository holding one `deploy ${{ matrix.env }}` over a computed matrix,
+    which is the ordinary deploy-per-environment shape. Its literal text rules
+    it out of `build shard 1/4` without guessing at its legs.
+
+    Degeneracy is not an unknowability refusal — a degenerate name enumerates
+    fine, and is refused for BINDING because its rendering carries no anchor.
+    As a competitor it is knowable, so it is rendered here rather than treated
+    as unrenderable.
+
+    `candidate` is the job being decided about, and is skipped: a job carrying
+    both `uses:` and a templated `name:` found ITSELF in this walk and claimed
+    the name against itself, so it could never resolve — while the same job
+    with a literal name resolves. Two readings of one job must not disagree.
     """
-    for _rel, doc in docs:
+    for rel, doc in docs:
         for key, job in _jobs(doc):
-            if not isinstance(job.get("uses"), str):
+            if job is candidate or not isinstance(job.get("uses"), str):
                 continue
             shown = _display_name(key, job)
             if _EXPRESSION_RE.search(shown):
-                renderings = _templated_name_renderings(job, shown)
+                renderings, _reason = _render_templated_name(
+                    job, shown, anchored=False)
                 if renderings is None:
-                    return True
+                    # Two ways this caller could still own the context: as its
+                    # own check, or as the `<caller> / <child>` leaf — whose
+                    # child half names a job in the CALLED file, which this
+                    # scan is not reading, so it is spelled as a placeholder
+                    # because that is the wildcard it genuinely is. Written as
+                    # a bare `" / "` suffix the pattern demanded the context
+                    # END there, and no real leaf ever did, so the leaf half
+                    # of this rule never fired.
+                    if _template_could_render(shown, context) \
+                            or _template_could_render(
+                                shown + " / ${{ child }}", context):
+                        return rel, key
+                    continue
                 if any(context == r or context.startswith(r + " / ")
                        for r in renderings):
-                    return True
+                    return rel, key
                 continue
             if context == shown or context.startswith(shown + " / "):
-                return True
-    return False
+                return rel, key
+    return None
 
 
 def _templated_name_renderings(job: dict, shown: str) -> set[str] | None:
-    """Every display name a templated `name:` can actually render, or None.
+    """Every display name a templated `name:` can actually render, or None."""
+    return _render_templated_name(job, shown)[0]
+
+
+def _render_templated_name(
+    job: dict, shown: str, *, anchored: bool = True,
+) -> tuple[set[str] | None, str | None]:
+    """(renderings, refusal) for a templated `name:` — renderings, or None and
+    the REASON, which the evidence needs so the reader learns the real cause.
 
     None — the check stays UNTRACED and the fact UNMEASURED — whenever the
-    rendering is not knowable from the YAML, which is every case below. An
-    unknown must never come out as a known negative, and unmeasured beats a
-    confident wrong answer:
+    rendering is not knowable from the YAML. An unknown must never come out as
+    a known negative, and unmeasured beats a confident wrong answer:
 
-      * a placeholder that is not a plain `matrix.<axis>` reference
-        (`${{ github.ref_name }}`, a function call, `matrix['x']`) renders
-        from the run, not the file;
-      * a matrix this scan cannot enumerate — `fromJSON()` or any other
-        computed value, an `include:`, a nested shape — which is the same
-        refusal `_matrix_expansions` already makes, reached through the same
-        enumeration so the two cannot disagree;
-      * an axis the name references that the matrix does not declare.
+      * `placeholder`: a placeholder that is not a plain `matrix.<axis>`
+        reference (`${{ github.ref_name }}`, a function call, `matrix['x']`)
+        renders from the run, not the file;
+      * `matrix`: a matrix this scan cannot enumerate — `fromJSON()` or any
+        other computed value, an `include:`, a nested shape, an unreadable
+        `exclude:` — which is the same refusal `_matrix_expansions` already
+        makes, reached through the same enumeration so the two cannot
+        disagree;
+      * `axis`: an axis the name references that the matrix does not declare;
+      * `unclosed`: a `${{` with no closing `}}` — not a templated name at
+        all, since it has no placeholder to resolve. It reached here anyway
+        (the expression test is just `${{`), rendered its raw text unchanged
+        for every combination, and the single rendering equalled the bare
+        display name — reinstating the one thing the literal branch refuses,
+        a MATRIX job standing in for a bare context GitHub never emits for it.
 
-    A DEGENERATE template is refused here too: it renders concrete strings,
-    but with no literal text anchoring them the match is a coincidence.
+    Two further refusals are about the RENDERING rather than its knowability,
+    and each carries its own reason:
+
+      * `degenerate`: no literal text anchors the name, so a rendering that
+        equals a required context is indistinguishable from a coincidence.
+        Callers deciding COMPETITION rather than binding pass `anchored=False`,
+        because a name with no anchor is still perfectly knowable;
+      * `whitespace`: a `name:` or a leg whose whitespace this scan normalises
+        and GitHub does not, so the compared string is one GitHub never emits.
     """
-    if _name_template_is_degenerate(shown):
-        return None
+    if anchored and _name_template_is_degenerate(shown):
+        return None, "degenerate"
     # Display names are whitespace-collapsed so they can be compared; GitHub
-    # collapses nothing. A `name:` carrying interior runs of whitespace
-    # therefore renders, after that collapse, a string GitHub never emits —
-    # and the required check that does spell it belongs to another producer.
+    # collapses no INTERIOR whitespace, in the template or in the value it
+    # substitutes. (Leading and trailing whitespace is stripped from both
+    # before comparison, as a YAML plain scalar's already is.) A `name:`
+    # carrying interior runs of whitespace therefore renders, after that
+    # collapse, a string GitHub never emits — and the required check that does
+    # spell it belongs to another producer.
     raw = job.get("name")
     if isinstance(raw, str) and " ".join(raw.split()) != raw.strip():
-        return None
+        return None, "whitespace"
     axes_used = []
     for expr in _PLACEHOLDER_RE.findall(shown):
         ref = _MATRIX_REF_RE.match(expr.strip())
         if ref is None:
-            return None
+            return None, "placeholder"
         axes_used.append(ref.group(1))
+    if not axes_used:
+        return None, "unclosed"
     combos = _matrix_combinations(job)
     if combos is None:
-        return None
+        return None, "matrix"
     out: set[str] = set()
     for assignment in combos:
         if any(axis not in assignment for axis in axes_used):
-            return None
-        # A leg does not substitute the way GitHub substitutes it when it is
-        # EMPTY — `${{ matrix.p }}lint` over `p: ['']` renders the bare `lint`
-        # a different job owns, the template's discriminating part gone and
-        # the anchoring premise with it — or when normalising the rendering
-        # would REWRITE it: GitHub normalises neither the template nor the
-        # value, so a leg with interior double spaces renders, after the
-        # normalisation that makes renderings comparable, a string GitHub
-        # never emits, whose real producer this scan has not looked at.
+            missing = next(a for a in axes_used if a not in assignment)
+            return None, f"axis:{missing}"
+        # An EMPTY leg renders exactly what GitHub renders, and that is the
+        # problem: `${{ matrix.p }}lint` over `p: ['']` collapses to the bare
+        # `lint` a different job owns. The anchoring the template was admitted
+        # on is supplied by the literal text, and here the discriminating part
+        # of the rendering is gone — so the check that survives the anchor
+        # test at parse time no longer survives it at render time.
+        #
+        # A leg whose interior whitespace normalising would REWRITE is the
+        # opposite case: there the rendering DIVERGES from GitHub's, so the
+        # string compared is one GitHub never emits, whose real producer this
+        # scan has not looked at.
         if any(not assignment[a]
                or " ".join(assignment[a].split()) != assignment[a]
                for a in axes_used):
-            return None
+            return None, "whitespace"
         rendered = _PLACEHOLDER_RE.sub(
             lambda m: assignment[_MATRIX_REF_RE.match(
                 m.group(1).strip()).group(1)],
             shown)
         out.add(" ".join(rendered.split()))
-    return out or None
+    return (out, None) if out else (None, "matrix")
 
 
 # A 403 from the admin-only classic endpoint is ORDINARY — most readers of this
@@ -1768,6 +1903,69 @@ def _matrix_near_miss(docs: list[tuple[str, dict]], context: str) -> str | None:
     return None
 
 
+_TEMPLATE_REFUSALS = {
+    "degenerate": ("its name is built only from matrix values, so a rendering "
+                   "equal to this context would be a coincidence — this scan "
+                   "will not certify a check on one"),
+    "whitespace": ("its name or a matrix leg carries interior whitespace, "
+                   "which this scan normalises and GitHub does not, so what "
+                   "it renders is not the string compared here"),
+    "placeholder": ("its name interpolates something that is not a plain "
+                    "`matrix.<axis>` value, so it renders from the run, not "
+                    "from this file"),
+    "matrix": ("its name is templated over a matrix this scan cannot "
+               "enumerate"),
+    "unclosed": "its name carries a `${{` that is never closed",
+}
+
+
+def _templated_refusal_note(docs: list[tuple[str, dict]], context: str) -> str | None:
+    """Why a TEMPLATED job that looks like this context's producer was not
+    accepted as one, or None when no such job is in these files.
+
+    Six distinct refusals shared one sentence — "templated over a matrix this
+    scan cannot enumerate" — which is false for five of them: in a degenerate
+    name, a whitespace rewrite, an undeclared axis and a competing reusable
+    call, the matrix enumerates perfectly well. This fact's evidence is the
+    surface a reader uses to win back a security grade they lost, and it was
+    sending anyone whose axis name held a typo off to hunt for an external app
+    that does not exist.
+
+    Only a job whose LITERAL text could produce this context is named. A hint
+    pointing at a job that could not have produced it is worse than the
+    generic sentence, so ruling out comes first — and ruling out is all this
+    match does; nothing here binds a producer.
+    """
+    for rel, doc in docs:
+        for key, job in _jobs(doc):
+            shown = _display_name(key, job)
+            if not _EXPRESSION_RE.search(shown) \
+                    or not _template_could_render(shown, context):
+                continue
+            renderings, reason = _render_templated_name(job, shown)
+            if renderings is not None and context in renderings:
+                # It renders this context exactly, so what stopped it is the
+                # competing claim — the one refusal applied outside the
+                # renderer, and the one a reader is least able to guess.
+                claim = _reusable_caller_claims(docs, context, job)
+                if claim is None:
+                    return None
+                return (f"{rel}: the job `{key}` renders `{context}`, but the "
+                        f"reusable call `{claim[1]}` in {claim[0]} claims that "
+                        f"name too, so which of them reports the check is not "
+                        f"settled here")
+            if reason is None:
+                continue
+            if reason.startswith("axis:"):
+                return (f"{rel}: the job `{key}` interpolates "
+                        f"`matrix.{reason[5:]}`, which its own matrix does not "
+                        f"declare, so what its name renders to is not knowable "
+                        f"here")
+            return f"{rel}: the job `{key}` does not resolve — " \
+                   f"{_TEMPLATE_REFUSALS[reason]}"
+    return None
+
+
 def _required_checks_skippable(
     docs: list[tuple[str, dict]],
     repo: str | None,
@@ -1805,12 +2003,20 @@ def _required_checks_skippable(
         producers = _context_producers(docs, context)
         if not producers:
             near = _matrix_near_miss(docs, context)
+            if near:
+                unjudged.append(f"`{context}` ({near})")
+                continue
+            # The generic sentence lists where an untraceable context USUALLY
+            # comes from; the note, when there is one, names the job in these
+            # files that nearly produced it and why it did not. It is appended
+            # rather than substituted, because the generic list stays true —
+            # the note is the part the reader cannot work out for themselves.
+            note = _templated_refusal_note(docs, context)
             unjudged.append(
-                f"`{context}` ({near})" if near else
                 f"`{context}` (no job in these workflows reports it — an "
-                f"external app check, a reusable-workflow job, a job name "
-                f"templated over a matrix this scan cannot enumerate, or a "
-                f"stale entry)")
+                f"external app check, a reusable-workflow job, a templated "
+                f"job name, or a stale entry"
+                + (f"; {note})" if note else ")"))
             continue
         skips: list[str] = []
         unknown: list[str] = []

--- a/skills/ci-secure/scripts/config_facts.py
+++ b/skills/ci-secure/scripts/config_facts.py
@@ -1301,8 +1301,11 @@ def _context_producers(
 
     A check context is the job's DISPLAY name — its `name:` if it has one, else
     its key — and a matrix job expands to `name (value, value)`. Both spellings
-    are matched; a display name built from an expression (`name: test ${{ … }}`)
-    is not matched at all, because what it renders to is not knowable here.
+    are matched. A display name built from an expression is matched only when
+    the expression is a plain `matrix.<axis>` over legs this scan can enumerate
+    from the YAML, and only when nothing makes the rendering a coincidence —
+    see `_templated_name_renderings`. Everything else stays unmatched, because
+    what it renders to is not knowable here.
     """
     out = []
     for rel, doc in docs:
@@ -1317,8 +1320,7 @@ def _context_producers(
                 # a knowable set of contexts, and one of them may be the check.
                 # See `_templated_name_renderings` for what is refused.
                 if context in (_templated_name_renderings(job, shown) or ()) \
-                        and not (_name_template_leads_with_placeholder(shown)
-                                 and _reusable_caller_claims(docs, context)):
+                        and not _reusable_caller_claims(docs, context):
                     out.append((rel, key, job, jobs, doc, ability))
                 continue
             if context == shown and not _job_has_matrix(job):
@@ -1410,7 +1412,18 @@ def _matrix_combinations(job: dict) -> list[dict[str, str]] | None:
     for entry in matrix.get("exclude") or []:
         if not isinstance(entry, dict):
             return None
-        excluded.append({str(k): str(v).strip() for k, v in entry.items()})
+        rule = {str(k): str(v).strip() for k, v in entry.items()}
+        # An exclude this scan cannot READ is not an exclude it may ignore.
+        # Skipping it keeps combinations the run really removes, and EXTRA
+        # combinations are the dangerous direction: they manufacture renderings
+        # GitHub never emits, any one of which can certify a required check. A
+        # key naming no declared axis matched nothing (`assignment.get(k)` is
+        # None), and a computed value was compared as its literal `${{ … }}`
+        # text — both silently no-ops.
+        if any(k not in names or _EXPRESSION_RE.search(v)
+               for k, v in rule.items()):
+            return None
+        excluded.append(rule)
 
     out: list[dict[str, str]] = []
     for combo in itertools.product(*axes):
@@ -1461,40 +1474,54 @@ _MATRIX_REF_RE = re.compile(r"^matrix\.([A-Za-z_][A-Za-z0-9_-]*)$")
 
 
 def _name_template_is_degenerate(template: str) -> bool:
-    """A `name:` that is NOTHING but placeholders — `${{ matrix.target }}`.
+    """A `name:` carrying no literal WORD to anchor it — `${{ matrix.target }}`,
+    and equally `${{ matrix.a }}/${{ matrix.b }}` or `${{ matrix.s }}
+    (${{ matrix.l }})`.
 
-    It carries no literal text to anchor it, so a rendering that equals a
-    required context is indistinguishable from a coincidence: an external
-    app's `Header rules` check and a matrix leg spelled the same way are the
-    same string. Certifying a required check on that coincidence is a silent
-    pass, and an unresolved check is merely unmeasured — so this shape is
-    refused.
+    Without anchoring text a rendering that equals a required context is
+    indistinguishable from a coincidence: an external app's `Header rules`
+    check and a matrix leg spelled the same way are the same string.
+    Certifying a required check on that coincidence is a silent pass, and an
+    unresolved check is merely unmeasured — so this shape is refused.
+
+    Punctuation is NOT that anchoring text, and reading it as such is how the
+    refusal was escaped: `${{ matrix.a }}/${{ matrix.b }}` over `[security]`
+    and `[snyk]` renders `security/snyk`, and `${{ matrix.s }}
+    (${{ matrix.l }})` renders the `Analyze (javascript)` shape a scanning app
+    reports — every discriminating character supplied by a matrix value, the
+    `/` and ` ()` supplying none. Nothing in these files competes for an
+    EXTERNAL app's name, so the leading-placeholder rule cannot catch these
+    either. The anchor therefore has to be a word character.
     """
-    return not _PLACEHOLDER_RE.sub("", template).strip()
-
-
-def _name_template_leads_with_placeholder(template: str) -> bool:
-    """A `name:` whose first character is a placeholder — `${{ matrix.variant
-    }} / build`. GitHub names a reusable invocation's leaf checks `<caller job>
-    / <child>`, and such a template can render exactly that string, so it can
-    impersonate a check a genuine reusable caller in ANOTHER file produces.
-    Refused only when such a caller actually competes (see
-    `_reusable_caller_claims`) — a blanket refusal would drop a real matrix
-    job that is the sole producer of `linux / build`.
-    """
-    if "${{" not in template:
-        return False
-    return not _PLACEHOLDER_RE.split(template)[0].strip()
+    return not re.search(r"\w", _PLACEHOLDER_RE.sub("", template))
 
 
 def _reusable_caller_claims(docs: list[tuple[str, dict]], context: str) -> bool:
     """Does some reusable-workflow CALL in these files claim `context` as its
-    own check or as the `<caller> / <child>` leaf of its invocation?"""
+    own check or as the `<caller> / <child>` leaf of its invocation?
+
+    A caller's own `name:` may itself be TEMPLATED, and comparing a required
+    context against unrendered template text never matches — so a matrix
+    caller claimed nothing, the leading-placeholder refusal never fired, and a
+    foreign `always()` matrix job in another file certified a check the real
+    caller produces behind a condition. That is exactly the silent pass the
+    refusal exists to prevent. A templated caller is therefore rendered by the
+    same enumeration as any other templated name, and one this scan CANNOT
+    render is a competitor it cannot rule out — so it claims the name.
+    """
     for _rel, doc in docs:
         for key, job in _jobs(doc):
             if not isinstance(job.get("uses"), str):
                 continue
             shown = _display_name(key, job)
+            if _EXPRESSION_RE.search(shown):
+                renderings = _templated_name_renderings(job, shown)
+                if renderings is None:
+                    return True
+                if any(context == r or context.startswith(r + " / ")
+                       for r in renderings):
+                    return True
+                continue
             if context == shown or context.startswith(shown + " / "):
                 return True
     return False
@@ -1522,6 +1549,13 @@ def _templated_name_renderings(job: dict, shown: str) -> set[str] | None:
     """
     if _name_template_is_degenerate(shown):
         return None
+    # Display names are whitespace-collapsed so they can be compared; GitHub
+    # collapses nothing. A `name:` carrying interior runs of whitespace
+    # therefore renders, after that collapse, a string GitHub never emits —
+    # and the required check that does spell it belongs to another producer.
+    raw = job.get("name")
+    if isinstance(raw, str) and " ".join(raw.split()) != raw.strip():
+        return None
     axes_used = []
     for expr in _PLACEHOLDER_RE.findall(shown):
         ref = _MATRIX_REF_RE.match(expr.strip())
@@ -1534,6 +1568,18 @@ def _templated_name_renderings(job: dict, shown: str) -> set[str] | None:
     out: set[str] = set()
     for assignment in combos:
         if any(axis not in assignment for axis in axes_used):
+            return None
+        # A leg does not substitute the way GitHub substitutes it when it is
+        # EMPTY — `${{ matrix.p }}lint` over `p: ['']` renders the bare `lint`
+        # a different job owns, the template's discriminating part gone and
+        # the anchoring premise with it — or when normalising the rendering
+        # would REWRITE it: GitHub normalises neither the template nor the
+        # value, so a leg with interior double spaces renders, after the
+        # normalisation that makes renderings comparable, a string GitHub
+        # never emits, whose real producer this scan has not looked at.
+        if any(not assignment[a]
+               or " ".join(assignment[a].split()) != assignment[a]
+               for a in axes_used):
             return None
         rendered = _PLACEHOLDER_RE.sub(
             lambda m: assignment[_MATRIX_REF_RE.match(

--- a/skills/ci-secure/tests/test_config_facts.py
+++ b/skills/ci-secure/tests/test_config_facts.py
@@ -3215,6 +3215,56 @@ jobs:
     assert f["outcome"] == "pass", f["evidence"]
 
 
+def test_a_caller_with_interior_whitespace_still_claims_its_leaf(tmp_path):
+    """Narrowing an unrenderable caller to the names its literal text could
+    produce compares that text against the required context, so it has to use
+    the SAME spelling the rest of this scan does — the collapsed display name,
+    never the raw `name:`.
+
+    Both sides are collapsed today, which is why this passes rather than
+    catching a live defect. It is pinned because the consistency is easy to
+    lose: built from the raw `name:`, a caller carrying interior whitespace
+    stops matching a context it really claims, stops competing for it, and a
+    foreign always-running template certifies a check whose real producer
+    carries a condition."""
+    caller = """\
+name: cd
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  suite:
+    name: "Rel  ${{ matrix.tier }}"
+    if: github.event.pull_request.draft == false
+    strategy:
+      matrix:
+        tier: ${{ fromJSON(needs.plan.outputs.tiers) }}
+    uses: ./.github/workflows/reusable.yml
+"""
+    foreign = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  make:
+    name: Rel ${{ matrix.v }} / build
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        v: [Suite, Other]
+    steps:
+      - run: make build
+"""
+    f = _outcome(
+        _facts_with(tmp_path, {"cd.yml": caller, "ci.yml": foreign},
+                    ["Rel Suite / build"]),
+        _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+    assert "← .github/workflows/ci.yml" not in f["evidence"], f["evidence"]
+
+
 def test_a_caller_whose_rendering_does_not_match_does_not_suppress(tmp_path):
     """A renderable caller that simply does not produce this context is not a
     competitor at all. Nothing pinned this branch, so tightening the claim

--- a/skills/ci-secure/tests/test_config_facts.py
+++ b/skills/ci-secure/tests/test_config_facts.py
@@ -2427,6 +2427,358 @@ jobs:
     assert f["outcome"] == "pass", f["evidence"]
 
 
+def test_a_templated_reusable_caller_still_competes_for_its_own_check(tmp_path):
+    """The competitor lookup has to recognise a caller whose OWN `name:` is
+    templated. Comparing a required context against unrendered template text
+    never matches, so a matrix reusable caller claimed nothing, the
+    leading-placeholder refusal never fired, and a foreign `always()` matrix
+    job in another file certified a check the real caller produces behind a
+    condition — the exact silent pass that refusal exists to prevent. A caller
+    this scan cannot render is a competitor it cannot rule out."""
+    caller = """\
+name: release
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  tier:
+    name: ${{ matrix.tier }}
+    if: github.event.pull_request.draft == false
+    strategy:
+      matrix:
+        tier: [Suite, Nightly]
+    uses: ./.github/workflows/reusable.yml
+"""
+    foreign = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  make:
+    name: ${{ matrix.variant }} / build
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        variant: [Suite, Other]
+    steps:
+      - run: make build
+"""
+    f = _outcome(
+        _facts_with(tmp_path, {"release.yml": caller, "ci.yml": foreign},
+                    ["Suite / build"]),
+        _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+    assert "ci.yml" not in f["evidence"], f["evidence"]
+
+
+def test_punctuation_is_not_literal_text_anchoring_a_template(tmp_path):
+    """The degenerate refusal asks whether the template carries literal text
+    anchoring it. Punctuation is not that text: `${{ matrix.a }}/${{ matrix.b }}`
+    over `[security] / [snyk]` renders `security/snyk` — an EXTERNAL check name
+    this scan never saw a producer for — with every discriminating character
+    coming from matrix values. Nothing in these files competes for an external
+    app's name, so the leading-placeholder rule cannot catch it either, and the
+    check was certified on a pure coincidence: a scored PASS over a producer
+    that is not the producer."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  scan:
+    name: ${{ matrix.a }}/${{ matrix.b }}
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        a: [security]
+        b: [snyk]
+    steps:
+      - run: make scan
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["security/snyk"]),
+                 _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+
+
+def test_a_bracketing_template_does_not_impersonate_an_appended_suffix(tmp_path):
+    """`${{ matrix.s }} (${{ matrix.l }})` renders `Analyze (javascript)` — the
+    exact shape GitHub gives a MATRIX leg of a job named `Analyze`, and the
+    exact name a code-scanning app reports. The only literal text is ` ()`.
+    Binding it certifies a required check against a job that merely spells the
+    same string."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  scan:
+    name: ${{ matrix.s }} (${{ matrix.l }})
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        s: [Analyze]
+        l: [javascript]
+    steps:
+      - run: make scan
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body},
+                             ["Analyze (javascript)"]), _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+
+
+def test_an_empty_matrix_leg_does_not_render_a_neighbours_bare_name(tmp_path):
+    """An axis whose leg is the empty string contributes NOTHING to the name,
+    so `${{ matrix.p }}lint` renders the bare `lint` that a different job in
+    another file legitimately owns. The template's discriminating part vanished
+    — the anchoring premise with it — and because ANY always-running producer
+    settles the context, the decoy converted a real conditional producer's FAIL
+    into a PASS."""
+    real = """\
+name: lint
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  real:
+    name: lint
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - run: make lint
+"""
+    decoy = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  j:
+    name: ${{ matrix.p }}lint
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        p: ['']
+    steps:
+      - run: make build
+"""
+    f = _outcome(
+        _facts_with(tmp_path, {"lint.yml": real, "ci.yml": decoy}, ["lint"]),
+        _FACT)
+    assert f["outcome"] == "fail", f["evidence"]
+
+
+def test_a_leg_whose_whitespace_would_be_rewritten_does_not_render(tmp_path):
+    """Renderings are whitespace-normalised so they can be compared with
+    display names; GitHub normalises neither the template nor the value it
+    substitutes. A leg carrying interior double spaces therefore renders, after
+    normalisation, a string GitHub NEVER emits — and the required check that
+    does spell it has some other producer, one this scan has not looked at."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  build:
+    name: build ${{ matrix.t }}
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        t: ["e2e  chrome"]
+    steps:
+      - run: make test
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["build e2e chrome"]),
+                 _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+
+
+def test_a_literal_word_before_the_placeholder_still_loses_to_a_caller(tmp_path):
+    """The hazard is that a reusable caller ALSO claims this context — never
+    that the placeholder happens to sit first. Keying the refusal on position
+    let one literal word walk past it: `Nightly ${{ matrix.variant }} / build`
+    renders `Nightly Suite / build`, the name a `Nightly Suite` caller's
+    invocation produces, and the foreign `always()` job certified a check whose
+    real producer carries a condition. Position was only ever a proxy; the
+    competing claim is the thing."""
+    caller = """\
+name: release
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  Nightly Suite:
+    if: github.event.pull_request.draft == false
+    uses: ./.github/workflows/reusable.yml
+"""
+    foreign = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  make:
+    name: Nightly ${{ matrix.variant }} / build
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        variant: [Suite, Other]
+    steps:
+      - run: make build
+"""
+    f = _outcome(
+        _facts_with(tmp_path, {"release.yml": caller, "ci.yml": foreign},
+                    ["Nightly Suite / build"]),
+        _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+    assert "ci.yml" not in f["evidence"], f["evidence"]
+
+
+def test_an_exclude_naming_an_undeclared_axis_is_not_read_as_a_no_op(tmp_path):
+    """An `exclude:` key that matches no declared axis is not a rule this scan
+    understood and applied — it is a rule it could not read. Treating it as a
+    no-op keeps every combination, and EXTRA combinations are the dangerous
+    direction: they manufacture renderings GitHub never emits, any one of which
+    can certify a required check."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  build:
+    name: build ${{ matrix.os }}
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu, macos]
+        exclude:
+          - arch: x86
+    steps:
+      - run: make build
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["build ubuntu"]),
+                 _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+
+
+def test_an_exclude_with_a_computed_value_is_not_compared_literally(tmp_path):
+    """Axis VALUES refuse an expression because what they render to is not
+    knowable; an exclude value is the same evidence and got no such guard, so
+    it was compared as the literal text `${{ … }}`, matched nothing, and
+    removed no combination the run would really remove."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  build:
+    name: build ${{ matrix.os }}
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu, macos]
+        exclude:
+          - os: ${{ github.event_name }}
+    steps:
+      - run: make build
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["build ubuntu"]),
+                 _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+
+
+def test_interior_whitespace_in_a_templated_name_does_not_bind(tmp_path):
+    """Display names are whitespace-collapsed so they can be compared; GitHub
+    collapses nothing. A `name:` carrying interior double spaces therefore
+    renders a string GitHub never emits, and the required check that does spell
+    it belongs to some other producer this scan has not looked at."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  build:
+    name: "build  shard ${{ matrix.shard }}"
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1]
+    steps:
+      - run: make test
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["build shard 1"]),
+                 _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+
+
+def test_a_nested_matrix_value_leaves_a_templated_name_untraced(tmp_path):
+    """Pins the documented refusal for a non-scalar leg. A mapping leg carries
+    sub-properties GitHub can reference (`matrix.platform.target`), and what
+    the name renders to is not knowable from the list alone."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  build:
+    name: build ${{ matrix.platform }}
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - target: linux
+          - target: darwin
+    steps:
+      - run: make build
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["build linux"]),
+                 _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+
+
+def test_a_name_referencing_an_undeclared_axis_stays_untraced(tmp_path):
+    """Pins the documented refusal for an axis the name uses but the matrix
+    does not declare. The value comes from somewhere this scan cannot see, so
+    the rendering is a guess — and a guess that matched would certify a
+    required check against a job that never reports it."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  build:
+    name: build ${{ matrix.shard }} on ${{ matrix.os }}
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1, 2]
+    steps:
+      - run: make test
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["build 1 on ubuntu"]),
+                 _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+
+
 def test_a_needs_cycle_terminates_and_is_not_an_all_clear(tmp_path):
     """Two jobs that `needs:` each other is a shape GitHub rejects but a
     scanner still meets in a work-in-progress branch. The claim the code makes

--- a/skills/ci-secure/tests/test_config_facts.py
+++ b/skills/ci-secure/tests/test_config_facts.py
@@ -2181,6 +2181,252 @@ jobs:
     assert "no job in these workflows reports it" in f["evidence"], f["evidence"]
 
 
+# --- a TEMPLATED job name over an ENUMERABLE matrix -------------------------
+#
+# The literal templated text is still not a context anything reports (the test
+# above), but the names that template RENDERS are. Sharding a required job is
+# the ordinary case: one job named `build shard ${{ matrix.shard }}/4` over
+# `shard: [1, 2, 3, 4]` produces the four contexts the branch requires. Read
+# as "not knowable", all four went untraced and the fact went UNMEASURED — so
+# a repository that shards a required job lost a security fact its own YAML
+# answers outright.
+
+_TEMPLATED_SHARD_MATRIX = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  build:
+    name: build shard ${{ matrix.shard }}/4
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - run: make test SHARD=${{ matrix.shard }}
+"""
+
+
+def test_a_templated_name_over_a_literal_matrix_resolves_to_its_job(tmp_path):
+    """`build shard ${{ matrix.shard }}/4` over `shard: [1, 2, 3, 4]` renders
+    exactly four names, and every one of them is a context this job produces.
+    Nothing about that is a guess: the legs are literals sitting in the YAML,
+    the same evidence the `(…)` expansion already reads. Leaving it unresolved
+    reported a knowable required check as untraceable and dropped the whole
+    fact to unmeasured."""
+    f = _outcome(
+        _facts_with(tmp_path, {"ci.yml": _TEMPLATED_SHARD_MATRIX},
+                    ["build shard 1/4", "build shard 2/4",
+                     "build shard 3/4", "build shard 4/4"]),
+        _FACT)
+    assert f["outcome"] == "pass", f["evidence"]
+    assert "all 4 required check(s)" in f["evidence"], f["evidence"]
+
+
+def test_a_templated_name_producer_that_can_skip_still_fails(tmp_path):
+    """Resolution is not absolution. Once the leg is traced to its job, the
+    ordinary skip analysis applies to it — a conditional producer of a
+    rendered leg is the same bypass as a conditional producer of a plain
+    context, and must read as one."""
+    body = _TEMPLATED_SHARD_MATRIX.replace(
+        "    if: always()\n",
+        "    if: github.actor != 'dependabot[bot]'\n")
+    f = _outcome(
+        _facts_with(tmp_path, {"ci.yml": body}, ["build shard 1/4"]), _FACT)
+    assert f["outcome"] == "fail", f["evidence"]
+    assert "build shard 1/4" in f["evidence"], f["evidence"]
+
+
+def test_a_templated_name_only_produces_the_legs_its_matrix_can_run(tmp_path):
+    """The neighbouring leg that the matrix cannot render is not this job's
+    context. A template that resolved to anything shaped like it would alibi
+    a required check no job emits — the same false green the flattened-value
+    matrix match once produced."""
+    f = _outcome(
+        _facts_with(tmp_path, {"ci.yml": _TEMPLATED_SHARD_MATRIX},
+                    ["build shard 5/4"]),
+        _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+    assert "no job in these workflows reports it" in f["evidence"], f["evidence"]
+
+
+def test_a_templated_name_over_a_computed_matrix_stays_untraced(tmp_path):
+    """`fromJSON()` legs are not enumerable from the YAML, so what the name
+    renders to is unknown — and an unknown must never render as a known
+    negative. The fact stays UNMEASURED with the gap disclosed, which is the
+    honest answer; certifying or failing the check would both be inventions."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  build:
+    name: build shard ${{ matrix.shard }}/4
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: ${{ fromJSON(needs.plan.outputs.shards) }}
+    steps:
+      - run: make test
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["build shard 1/4"]),
+                 _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+    assert "no job in these workflows reports it" in f["evidence"], f["evidence"]
+
+
+def test_a_templated_name_over_an_include_matrix_stays_untraced(tmp_path):
+    """`include:` can add combinations, rename axes and extend existing ones,
+    so the rendered set is not the product of the declared axes. The same
+    refusal the `(…)` expansion already makes applies to the rendered name."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  build:
+    name: build shard ${{ matrix.shard }}/4
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1, 2]
+        include:
+          - shard: 3
+    steps:
+      - run: make test
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["build shard 1/4"]),
+                 _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+
+
+def test_a_name_template_over_a_non_matrix_context_stays_untraced(tmp_path):
+    """Only a matrix reference is enumerable. `${{ github.ref_name }}` renders
+    from the run, not the file, so a name built from one is unknowable here
+    however literal the rest of the line is."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  build:
+    name: build ${{ github.ref_name }}
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1, 2]
+    steps:
+      - run: make test
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["build main"]), _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+
+
+def test_a_degenerate_name_template_is_not_a_producer(tmp_path):
+    """A `name:` that is nothing but a placeholder carries no literal text to
+    anchor it, so whatever it renders is indistinguishable from a check some
+    external app happens to name the same. A security fact that certifies a
+    check on a coincidence is the worse of the two failures available: an
+    unresolved check is merely unmeasured."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  build:
+    name: ${{ matrix.target }}
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [Header rules, Redirect rules]
+    steps:
+      - run: make build
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["Header rules"]),
+                 _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+
+
+def test_a_leading_placeholder_template_does_not_steal_a_reusable_check(tmp_path):
+    """A reusable invocation's leaf check is named `<caller job> / <child>`.
+    A foreign `${{ matrix.variant }} / build` can render exactly that string,
+    and binding it would certify the caller's check against a job in another
+    file that never reports it. When a genuine reusable caller competes for
+    the name, the template loses."""
+    caller = """\
+name: release
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  Suite:
+    if: github.event.pull_request.draft == false
+    uses: ./.github/workflows/reusable.yml
+"""
+    foreign = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  make:
+    name: ${{ matrix.variant }} / build
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        variant: [Suite, Other]
+    steps:
+      - run: make build
+"""
+    f = _outcome(
+        _facts_with(tmp_path, {"release.yml": caller, "ci.yml": foreign},
+                    ["Suite / build"]),
+        _FACT)
+    # Whose check this is stays unresolved — which is the honest answer, and
+    # the one this scan is entitled to. What must NEVER happen is the green:
+    # the foreign `always()` matrix job certifying a check produced in another
+    # file by a caller carrying a real condition.
+    assert f["outcome"] == "unmeasured", f["evidence"]
+    assert "ci.yml" not in f["evidence"], f["evidence"]
+
+
+def test_a_leading_placeholder_template_still_binds_its_own_leg(tmp_path):
+    """The other side of that refusal, and the reason it is scoped rather than
+    blanket: with no reusable caller competing, the leading-placeholder job IS
+    the sole real producer of `linux / build`, and refusing it would report a
+    traceable required check as fileless."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  make:
+    name: ${{ matrix.variant }} / build
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        variant: [linux, darwin]
+    steps:
+      - run: make build
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["linux / build"]),
+                 _FACT)
+    assert f["outcome"] == "pass", f["evidence"]
+
+
 def test_a_needs_cycle_terminates_and_is_not_an_all_clear(tmp_path):
     """Two jobs that `needs:` each other is a shape GitHub rejects but a
     scanner still meets in a work-in-progress branch. The claim the code makes

--- a/skills/ci-secure/tests/test_config_facts.py
+++ b/skills/ci-secure/tests/test_config_facts.py
@@ -2256,8 +2256,14 @@ def test_a_templated_name_over_a_computed_matrix_stays_untraced(tmp_path):
     """`fromJSON()` legs are not enumerable from the YAML, so what the name
     renders to is unknown — and an unknown must never render as a known
     negative. The fact stays UNMEASURED with the gap disclosed, which is the
-    honest answer; certifying or failing the check would both be inventions."""
-    body = """\
+    honest answer; certifying or failing the check would both be inventions.
+
+    Both spellings are exercised. A whole-node `${{ fromJSON(…) }}` is a
+    STRING, so it exits at the not-a-list guard and never reaches the
+    expression check on values — leaving that check unpinned here despite the
+    docstring crediting it. The computed LEG alongside a literal one reaches
+    it."""
+    whole = """\
 name: ci
 on: [pull_request]
 permissions:
@@ -2273,10 +2279,16 @@ jobs:
     steps:
       - run: make test
 """
-    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["build shard 1/4"]),
-                 _FACT)
-    assert f["outcome"] == "unmeasured", f["evidence"]
-    assert "no job in these workflows reports it" in f["evidence"], f["evidence"]
+    leg = whole.replace(
+        "        shard: ${{ fromJSON(needs.plan.outputs.shards) }}\n",
+        '        shard: [1, "${{ fromJSON(needs.plan.outputs.extra)[0] }}"]\n')
+    for n, body in enumerate((whole, leg)):
+        f = _outcome(
+            _facts_with(tmp_path / str(n), {"ci.yml": body},
+                        ["build shard 1/4"]), _FACT)
+        assert f["outcome"] == "unmeasured", f["evidence"]
+        assert "no job in these workflows reports it" in f["evidence"], \
+            f["evidence"]
 
 
 def test_a_templated_name_over_an_include_matrix_stays_untraced(tmp_path):
@@ -2357,12 +2369,16 @@ jobs:
     assert f["outcome"] == "unmeasured", f["evidence"]
 
 
-def test_a_leading_placeholder_template_does_not_steal_a_reusable_check(tmp_path):
+def test_a_template_loses_a_check_a_reusable_caller_claims(tmp_path):
     """A reusable invocation's leaf check is named `<caller job> / <child>`.
     A foreign `${{ matrix.variant }} / build` can render exactly that string,
     and binding it would certify the caller's check against a job in another
     file that never reports it. When a genuine reusable caller competes for
-    the name, the template loses."""
+    the name, the template loses.
+
+    Where the placeholder SITS in the template has nothing to do with it —
+    position was once a proxy for this hazard, and one literal word in front
+    walked past it. The competing claim is the whole rule."""
     caller = """\
 name: release
 on: [pull_request]
@@ -2398,14 +2414,18 @@ jobs:
     # the foreign `always()` matrix job certifying a check produced in another
     # file by a caller carrying a real condition.
     assert f["outcome"] == "unmeasured", f["evidence"]
-    assert "ci.yml" not in f["evidence"], f["evidence"]
+    # The foreign job must never be CREDITED as a producer — the `←` is how
+    # this evidence spells credit. Naming the file is fine, and is now how the
+    # reader learns the two jobs compete; asserting the bare filename absent
+    # confused "not credited" with "not mentioned".
+    assert "← .github/workflows/ci.yml" not in f["evidence"], f["evidence"]
 
 
-def test_a_leading_placeholder_template_still_binds_its_own_leg(tmp_path):
+def test_a_template_binds_its_own_leg_when_no_caller_competes(tmp_path):
     """The other side of that refusal, and the reason it is scoped rather than
-    blanket: with no reusable caller competing, the leading-placeholder job IS
-    the sole real producer of `linux / build`, and refusing it would report a
-    traceable required check as fileless."""
+    blanket: with no reusable caller competing, this job IS the sole real
+    producer of `linux / build`, and refusing it would report a traceable
+    required check as fileless."""
     body = """\
 name: ci
 on: [pull_request]
@@ -2470,7 +2490,11 @@ jobs:
                     ["Suite / build"]),
         _FACT)
     assert f["outcome"] == "unmeasured", f["evidence"]
-    assert "ci.yml" not in f["evidence"], f["evidence"]
+    # The foreign job must never be CREDITED as a producer — the `←` is how
+    # this evidence spells credit. Naming the file is fine, and is now how the
+    # reader learns the two jobs compete; asserting the bare filename absent
+    # confused "not credited" with "not mentioned".
+    assert "← .github/workflows/ci.yml" not in f["evidence"], f["evidence"]
 
 
 def test_punctuation_is_not_literal_text_anchoring_a_template(tmp_path):
@@ -2640,7 +2664,11 @@ jobs:
                     ["Nightly Suite / build"]),
         _FACT)
     assert f["outcome"] == "unmeasured", f["evidence"]
-    assert "ci.yml" not in f["evidence"], f["evidence"]
+    # The foreign job must never be CREDITED as a producer — the `←` is how
+    # this evidence spells credit. Naming the file is fine, and is now how the
+    # reader learns the two jobs compete; asserting the bare filename absent
+    # confused "not credited" with "not mentioned".
+    assert "← .github/workflows/ci.yml" not in f["evidence"], f["evidence"]
 
 
 def test_an_exclude_naming_an_undeclared_axis_is_not_read_as_a_no_op(tmp_path):
@@ -2729,7 +2757,12 @@ jobs:
 def test_a_nested_matrix_value_leaves_a_templated_name_untraced(tmp_path):
     """Pins the documented refusal for a non-scalar leg. A mapping leg carries
     sub-properties GitHub can reference (`matrix.platform.target`), and what
-    the name renders to is not knowable from the list alone."""
+    the name renders to is not knowable from the list alone.
+
+    The required context asserted on is the string a dropped refusal would
+    actually render — the leg's own text. Asserting on `build linux` left this
+    test green with the refusal deleted, because a mapping's text never equals
+    `linux`: the mismatch was doing the work the refusal is credited with."""
     body = """\
 name: ci
 on: [pull_request]
@@ -2748,9 +2781,10 @@ jobs:
     steps:
       - run: make build
 """
-    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["build linux"]),
-                 _FACT)
-    assert f["outcome"] == "unmeasured", f["evidence"]
+    for n, context in enumerate(("build linux", "build {'target': 'linux'}")):
+        f = _outcome(
+            _facts_with(tmp_path / str(n), {"ci.yml": body}, [context]), _FACT)
+        assert f["outcome"] == "unmeasured", (context, f["evidence"])
 
 
 def test_a_name_referencing_an_undeclared_axis_stays_untraced(tmp_path):
@@ -2777,6 +2811,635 @@ jobs:
     f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["build 1 on ubuntu"]),
                  _FACT)
     assert f["outcome"] == "unmeasured", f["evidence"]
+
+
+# --- what counts as literal text ANCHORING a template ----------------------
+#
+# The degenerate refusal asks whether the name carries literal text that
+# discriminates. `\w` was the wrong test for that: it spells `[A-Za-z0-9_]`,
+# so an UNDERSCORE anchored — and `${{ matrix.os }}_${{ matrix.arch }}` is a
+# far more ordinary job name than the `security/snyk` shape the refusal was
+# written for. Every discriminating character still came from a matrix value.
+
+
+def test_an_underscore_between_placeholders_does_not_anchor_a_template(tmp_path):
+    """`${{ matrix.a }}_${{ matrix.b }}` over `[security]` and `[snyk]` renders
+    `security_snyk`. An underscore discriminates exactly as much as the `/`
+    already refused beside it — nothing — so the rendering equalling an
+    external app's check name is the same coincidence, and certifying the
+    check on it is the same scored silent PASS."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  scan:
+    name: ${{ matrix.a }}_${{ matrix.b }}
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        a: [security]
+        b: [snyk]
+    steps:
+      - run: make scan
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["security_snyk"]),
+                 _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+
+
+def test_a_digit_between_placeholders_does_not_anchor_a_template(tmp_path):
+    """A digit is not a literal WORD either. `${{ matrix.t }} 2` renders
+    `Header rules 2`, and a required check spelled that way is as likely to be
+    an external app's second-generation check as this job's leg."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  scan:
+    name: ${{ matrix.t }} 2
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        t: [Header rules]
+    steps:
+      - run: make scan
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["Header rules 2"]),
+                 _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+
+
+def test_a_single_literal_letter_still_anchors_a_template(tmp_path):
+    """The other side of that tightening, so it stays a rule about letters and
+    does not become a rule about length: `v${{ matrix.n }}` is a real and
+    ordinary name, its `v` is literal text a matrix value cannot supply, and
+    refusing it would report a traceable required check as fileless."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  build:
+    name: v${{ matrix.n }}
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        n: [1, 2]
+    steps:
+      - run: make build
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["v1"]), _FACT)
+    assert f["outcome"] == "pass", f["evidence"]
+
+
+# --- matrix legs render the way GITHUB renders them ------------------------
+#
+# Legs reached both readings through `str(entry)`, which is Python's spelling,
+# not GitHub's: a YAML `true` leg became `True` and a `null` leg became
+# `None`. The first silently lost the resolution this fact exists to make; the
+# second walked past the empty-leg refusal, because the string `"None"` is
+# truthy where the empty string GitHub actually substitutes is not.
+
+
+def test_a_boolean_matrix_leg_renders_lowercase_like_github(tmp_path):
+    """GitHub substitutes a YAML `true` leg as `true`. Rendered as Python's
+    `True`, the leg matched nothing and a repository with a boolean axis kept
+    losing the fact this PR set out to give it back."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  test:
+    name: cov ${{ matrix.flag }}
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        flag: [true, false]
+    steps:
+      - run: make test
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["cov true"]), _FACT)
+    assert f["outcome"] == "pass", f["evidence"]
+
+
+def test_a_boolean_leg_also_renders_the_appended_suffix(tmp_path):
+    """The same leg text feeds the `(…)` suffix reading, which is the older of
+    the two: a literal `name:` over `flag: [true]` emits `test (true)`, and
+    `test (True)` is a context GitHub never spells."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  test:
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        flag: [true]
+    steps:
+      - run: make test
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["test (true)"]),
+                 _FACT)
+    assert f["outcome"] == "pass", f["evidence"]
+
+
+def test_a_null_matrix_leg_is_refused_like_the_empty_leg_it_renders(tmp_path):
+    """A `null` leg substitutes as NOTHING, exactly like `''` — so
+    `${{ matrix.p }}deploy` renders the bare `deploy` another job owns, and the
+    empty-leg refusal must fire. Rendered as Python's `None` the leg was
+    non-empty, the refusal did not fire, and the decoy certified a check whose
+    real producer carries a condition."""
+    real = """\
+name: deploy
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  real:
+    name: deploy
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - run: make deploy
+"""
+    decoy = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  j:
+    name: ${{ matrix.p }}deploy
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        p: [~]
+    steps:
+      - run: make build
+"""
+    f = _outcome(
+        _facts_with(tmp_path, {"deploy.yml": real, "ci.yml": decoy},
+                    ["deploy"]),
+        _FACT)
+    assert f["outcome"] == "fail", f["evidence"]
+
+
+# --- refusals that are not about UNKNOWABILITY --------------------------
+
+
+def test_an_unterminated_expression_does_not_match_a_matrix_bare_name(tmp_path):
+    """A `name:` carrying `${{` with no closing `}}` is not a templated name —
+    it has no placeholder to resolve — but it took the templated branch, where
+    every combination rendered the raw text unchanged and the single rendering
+    equalled the bare display name. That reinstated exactly what the literal
+    branch refuses: a MATRIX job standing in for a context GitHub never emits
+    for it, since GitHub always appends the combination."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  build:
+    name: "build ${{ matrix.s"
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        s: [1, 2]
+    steps:
+      - run: make build
+"""
+    f = _outcome(
+        _facts_with(tmp_path, {"ci.yml": body}, ["build ${{ matrix.s"]), _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+
+
+def test_a_non_scalar_exclude_value_is_not_read_as_a_no_op(tmp_path):
+    """An `exclude:` whose VALUE is a list or a mapping is a rule this scan
+    cannot read, and the refusal beside it already says an unreadable exclude
+    is not one it may ignore. Stringified to `"[1]"` it matched no assignment,
+    removed nothing, and left EXTRA renderings standing — the dangerous
+    direction, since any one of them can certify a required check."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  build:
+    name: build ${{ matrix.s }}
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        s: [1, 2]
+        exclude:
+          - s: [1]
+    steps:
+      - run: make build
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["build 1"]), _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+
+
+def test_a_scalar_matrix_axis_leaves_a_templated_name_untraced(tmp_path):
+    """`node: 18` — a scalar where GitHub wants a list — is a matrix this scan
+    cannot enumerate. Skipping the unreadable axis instead of refusing the
+    matrix would let the REST of the axes render a partial name and bind it."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  build:
+    name: build ${{ matrix.os }}
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu]
+        node: 18
+    steps:
+      - run: make build
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["build ubuntu"]),
+                 _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+
+
+# --- which reusable callers actually COMPETE for a name --------------------
+#
+# "A caller this scan cannot rule out claims the name" is the right rule, and
+# it was applied to callers it CAN rule out: any unrenderable caller claimed
+# every context in every file, so one `deploy ${{ matrix.env }}` over a
+# computed matrix — the ordinary deploy-per-environment shape — switched the
+# whole fix off repository-wide.
+
+
+def test_an_unrelated_unrenderable_caller_does_not_suppress_a_traceable_check(tmp_path):
+    """The caller's own literal text rules it out: `deploy ${{ matrix.env }}`
+    cannot render `build shard 1/4` whatever its matrix turns out to hold, so
+    it is not a competitor and the sharded job in another file is still the
+    sole producer."""
+    caller = """\
+name: cd
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  deploy:
+    name: deploy ${{ matrix.env }}
+    strategy:
+      matrix:
+        env: ${{ fromJSON(needs.plan.outputs.envs) }}
+    uses: ./.github/workflows/reusable.yml
+"""
+    f = _outcome(
+        _facts_with(tmp_path,
+                    {"ci.yml": _TEMPLATED_SHARD_MATRIX, "cd.yml": caller},
+                    ["build shard 1/4"]),
+        _FACT)
+    assert f["outcome"] == "pass", f["evidence"]
+
+
+def test_an_unrenderable_caller_that_could_render_the_name_still_claims_it(tmp_path):
+    """The other side: when the caller's literal text COULD produce this
+    context — `build shard ${{ matrix.n }}` against `build shard 1/4` — an
+    unenumerable matrix leaves it a competitor this scan cannot rule out, and
+    the foreign job must not certify the check."""
+    caller = """\
+name: cd
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  shards:
+    name: build shard ${{ matrix.n }}
+    if: github.event.pull_request.draft == false
+    strategy:
+      matrix:
+        n: ${{ fromJSON(needs.plan.outputs.shards) }}
+    uses: ./.github/workflows/reusable.yml
+"""
+    f = _outcome(
+        _facts_with(tmp_path,
+                    {"ci.yml": _TEMPLATED_SHARD_MATRIX, "cd.yml": caller},
+                    ["build shard 1/4"]),
+        _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+
+
+def test_an_unrenderable_caller_claims_the_leaf_of_its_own_invocation(tmp_path):
+    """A reusable call's check is named `<caller> / <child>`, and the child
+    half names a job in the called file this scan does not read. Spelling the
+    leaf as a bare `" / "` suffix demanded the context END there, which no
+    real leaf does — so the leaf half of the claim rule never fired, and a
+    foreign always-running template could certify `Suite / build` while the
+    caller that really produces it carries a condition."""
+    caller = """\
+name: cd
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  suite:
+    name: ${{ matrix.tier }}uite
+    if: github.event.pull_request.draft == false
+    strategy:
+      matrix:
+        tier: ${{ fromJSON(needs.plan.outputs.tiers) }}
+    uses: ./.github/workflows/reusable.yml
+"""
+    foreign = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  make:
+    name: ${{ matrix.v }} / build
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        v: [Suite, Other]
+    steps:
+      - run: make build
+"""
+    f = _outcome(
+        _facts_with(tmp_path, {"cd.yml": caller, "ci.yml": foreign},
+                    ["Suite / build"]),
+        _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+    assert "← .github/workflows/ci.yml" not in f["evidence"], f["evidence"]
+
+
+def test_a_null_matrix_leg_renders_the_empty_suffix_github_renders(tmp_path):
+    """The `(…)` suffix reading shows the leg text directly, so it is where a
+    leg spelled Python's way is visible: GitHub substitutes a `null` leg as
+    nothing and emits `test ()`, while `str(None)` emits `test (None)` — a
+    context GitHub never spells, leaving the real one untraced."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  test:
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [~]
+    steps:
+      - run: make test
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["test ()"]), _FACT)
+    assert f["outcome"] == "pass", f["evidence"]
+
+
+def test_a_caller_whose_rendering_does_not_match_does_not_suppress(tmp_path):
+    """A renderable caller that simply does not produce this context is not a
+    competitor at all. Nothing pinned this branch, so tightening the claim
+    rule to "any templated caller blocks" would have gone unnoticed — and it
+    moves a SCORED fact out of the denominator on every repository that calls
+    a reusable workflow over a matrix."""
+    caller = """\
+name: cd
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  tier:
+    name: ${{ matrix.tier }} suite
+    strategy:
+      matrix:
+        tier: [Alpha, Beta]
+    uses: ./.github/workflows/reusable.yml
+"""
+    f = _outcome(
+        _facts_with(tmp_path,
+                    {"ci.yml": _TEMPLATED_SHARD_MATRIX, "cd.yml": caller},
+                    ["build shard 1/4"]),
+        _FACT)
+    assert f["outcome"] == "pass", f["evidence"]
+
+
+def test_a_literal_callers_own_exact_name_is_still_a_competing_claim(tmp_path):
+    """The claim rule has two halves — the caller's own name, and the
+    `<caller> / <child>` leaf — and only the leaf was pinned. With the exact
+    half dropped, a foreign `always()` template rendering `Suite` joins the
+    real producer, and ANY always-running producer settles the context: the
+    conditional reusable call's FAIL turns into a PASS."""
+    caller = """\
+name: release
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  Suite:
+    if: github.event.pull_request.draft == false
+    uses: ./.github/workflows/reusable.yml
+"""
+    foreign = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  make:
+    name: ${{ matrix.a }}uite
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        a: [S]
+    steps:
+      - run: make build
+"""
+    f = _outcome(
+        _facts_with(tmp_path, {"release.yml": caller, "ci.yml": foreign},
+                    ["Suite"]),
+        _FACT)
+    assert f["outcome"] == "fail", f["evidence"]
+    assert "release.yml" in f["evidence"], f["evidence"]
+    # The foreign job must never be CREDITED as a producer — the `←` is how
+    # this evidence spells credit. Naming the file is fine, and is now how the
+    # reader learns the two jobs compete; asserting the bare filename absent
+    # confused "not credited" with "not mentioned".
+    assert "← .github/workflows/ci.yml" not in f["evidence"], f["evidence"]
+
+
+def test_a_templated_reusable_caller_is_not_its_own_competitor(tmp_path):
+    """The competitor walk has to skip the job it is deciding about. A job
+    carrying both `uses:` and a templated `name:` rendered the context, found
+    ITSELF in the walk, claimed the name against itself and could never
+    resolve — while the identical job with a literal name resolves. The two
+    readings of one job must not disagree."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  build:
+    name: build ${{ matrix.s }}
+    if: always()
+    strategy:
+      matrix:
+        s: [1, 2]
+    uses: ./.github/workflows/reusable.yml
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["build 1"]), _FACT)
+    assert f["outcome"] == "pass", f["evidence"]
+
+
+# --- the evidence names the CAUSE it actually found ------------------------
+#
+# Six distinct refusals shared one sentence — "a job name templated over a
+# matrix this scan cannot enumerate" — which is false for five of them. The
+# reader whose axis name has a typo was sent hunting for an external app that
+# does not exist, on the surface whose whole purpose is telling them how to
+# get a lost security grade back.
+
+
+def test_the_evidence_names_an_axis_the_matrix_does_not_declare(tmp_path):
+    """A one-character typo in an axis name is invisible in the generic
+    sentence and obvious in a specific one."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  build:
+    name: build ${{ matrix.shrd }}
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1, 2]
+    steps:
+      - run: make build
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["build 1"]), _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+    assert "`matrix.shrd`" in f["evidence"], f["evidence"]
+    assert "ci.yml" in f["evidence"], f["evidence"]
+    assert "cannot enumerate" not in f["evidence"], f["evidence"]
+
+
+def test_the_evidence_does_not_blame_the_matrix_for_a_degenerate_name(tmp_path):
+    """The matrix here enumerates perfectly. What this scan refused is the
+    ANCHORING, and saying "cannot enumerate" points the reader at a matrix
+    that is not the problem."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  scan:
+    name: ${{ matrix.target }}
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [Header rules]
+    steps:
+      - run: make build
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["Header rules"]),
+                 _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+    assert "cannot enumerate" not in f["evidence"], f["evidence"]
+    assert "`scan`" in f["evidence"], f["evidence"]
+
+
+def test_the_evidence_names_the_reusable_caller_that_took_the_name(tmp_path):
+    """When a competing reusable call is what suppressed the match, the job
+    the reader can see in front of them IS a producer-shaped job — telling
+    them nothing in these workflows reports the check sends them looking for
+    an external app instead of at the ambiguity."""
+    caller = """\
+name: release
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  Suite:
+    if: github.event.pull_request.draft == false
+    uses: ./.github/workflows/reusable.yml
+"""
+    foreign = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  make:
+    name: Nightly ${{ matrix.variant }} / build
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        variant: [Suite, Other]
+    steps:
+      - run: make build
+"""
+    body = foreign.replace("Nightly ${{ matrix.variant }} / build",
+                           "${{ matrix.variant }} / build")
+    f = _outcome(
+        _facts_with(tmp_path, {"release.yml": caller, "ci.yml": body},
+                    ["Suite / build"]),
+        _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+    assert "release.yml" in f["evidence"], f["evidence"]
+    assert "`Suite`" in f["evidence"], f["evidence"]
+
+
+def test_an_unrelated_templated_job_is_not_named_as_the_cause(tmp_path):
+    """The specific note is a HINT, and a hint that names a job which could
+    not have produced the context is worse than the generic sentence. A job
+    whose literal text cannot render this check is not the reason it is
+    unresolved."""
+    body = """\
+name: ci
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  build:
+    name: build ${{ matrix.shrd }}
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1, 2]
+    steps:
+      - run: make build
+"""
+    f = _outcome(_facts_with(tmp_path, {"ci.yml": body}, ["Codecov"]), _FACT)
+    assert f["outcome"] == "unmeasured", f["evidence"]
+    assert "`build`" not in f["evidence"], f["evidence"]
+    assert "external app check" in f["evidence"], f["evidence"]
 
 
 def test_a_needs_cycle_terminates_and_is_not_an_all_clear(tmp_path):


### PR DESCRIPTION
## TL;DR

A repository that splits a required check across several parallel runs was quietly losing one of its security grades. Because the check names are built from a template rather than typed out, the scan could not tell which job produced them, so it reported them as coming from nowhere and declined to grade the fact at all — even though the answer was sitting in the workflow file the whole time. This teaches the scan to read those names, so sharding a required job no longer costs a repository a security fact it could have been graded on. Splitting a suite into shards is one of the most common things a busy repository does, so this was not a rare shape.

## The defect

`sec.required-checks.skippable` asks whether every status check the default branch requires is produced by a job that always runs — GitHub counts a SKIPPED required check as a pass, so a check only a conditional job reports can be satisfied by never running it.

To answer that, the fact has to map each required check name back to the job that declares it. It matched a job's display name only when the name was literal. A templated one was dropped outright:

```yaml
build:
  name: build shard ${{ matrix.shard }}/4
  strategy:
    matrix:
      shard: [1, 2, 3, 4]
```

That job produces exactly four checks — `build shard 1/4` through `build shard 4/4` — and every value needed to say so is a literal in the file. The resolver reported all four as untraceable ("no job in these workflows reports it — an external app check, a reusable-workflow job, a templated job name, or a stale entry") and, because a PASS is a claim about EVERY required check, the whole fact went UNMEASURED. Its own evidence string named the cause.

```
before:  build shard 1/4 ─┐
         build shard 2/4 ─┤
         build shard 3/4 ─┼─→ (no literal job name matches) ─→ UNTRACED ─→ fact UNMEASURED
         build shard 4/4 ─┘

after:   matrix shard: [1,2,3,4]
              │  rendered through the same enumeration that
              ▼  produces the `(…)` suffixes
         {build shard 1/4, 2/4, 3/4, 4/4}  ─→ the `build` job ─→ skip analysis ─→ PASS or FAIL
```

## The fix

`_matrix_expansions` is refactored onto a new `_matrix_combinations`, which returns the axis assignments the matrix can actually run. Both readings of a matrix job's contexts now come from that one enumeration — the appended `(value, …)` suffix of a literal `name:`, and the rendering of a templated one — so the two cannot disagree about the same matrix, and a refusal added for one is a refusal for both.

Matrix legs are read the way GitHub substitutes them rather than the way Python prints them, so a `true` leg renders `true` and a `null` leg renders nothing at all.

Rendering is EXACT: a rendering is a concrete string that either is the required context or is not. Wildcards appear only to rule a template OUT — deciding which reusable calls compete for a name, and which job the evidence may name — never to rule one in, so a rendered leg cannot stand in for a check that merely looks like it.

## What still does NOT resolve, and why

A fix that resolves everything would be worse than the bug: this fact is scored, and a check certified on a coincidence is a silent pass, while an unresolved check is merely unmeasured. Each of these has its own test:

| Shape | Outcome |
|---|---|
| Matrix with `fromJSON()` or any computed value | UNTRACED → fact UNMEASURED |
| Matrix with `include:` (can add combinations, rename axes) | UNTRACED |
| Nested, non-list or scalar matrix values | UNTRACED |
| An `exclude:` this scan cannot read — undeclared key, computed value, non-scalar value | UNTRACED |
| A placeholder that is not a plain `matrix.<axis>` (`${{ github.ref_name }}`) | UNTRACED |
| A `${{` that is never closed — not a templated name at all | UNTRACED |
| An axis the name references but the matrix does not declare | UNTRACED |
| DEGENERATE template — no literal LETTER anchors it | refused |
| An EMPTY leg, or interior whitespace in a leg or in the `name:` | refused |
| A rendering a genuine reusable caller in these files also claims | refused |

The unknowable shapes are the same rule this project keeps relearning: an unknown must never render as a known negative, and unmeasured beats a confident wrong answer. The last three are anti-coincidence rules.

A degenerate template has no literal text anchoring it, so a rendering that equals an external app's check name proves nothing. The anchor is a LETTER: punctuation, underscores and digits are all supplied by a matrix value for free, and reading them as anchoring text let `${{ matrix.a }}/${{ matrix.b }}` certify `security/snyk` and `${{ matrix.os }}_${{ matrix.arch }}` certify `ubuntu_x64`. One literal letter is enough, so `v${{ matrix.n }}` still binds.

An empty leg renders exactly what GitHub renders, and that is the problem: `${{ matrix.p }}lint` over `p: ['']` collapses to the bare `lint` another job owns, taking the anchoring with it. Interior whitespace is the opposite case, where the comparison string diverges from what GitHub emits.

The competing-claim rule turns on the claim, never on where the placeholder sits: position was only ever a proxy, and one literal word in front of it walked straight past. Its counterpart is tested too — with no reusable caller competing, the job IS the sole real producer of `linux / build` and still binds — and a caller this scan cannot render competes only for the names its own literal text could produce, so one `deploy ${{ matrix.env }}` over a computed matrix no longer switches the resolution off across the repository.

## Blast radius — this changes published scores

`sec.required-checks.skippable` is a SCORED security fact, so `security_score` changes on any repository whose required checks come from a matrix-templated job name. The fact now enters the scored denominator where it used to sit out:

- **PASS** where the newly traced producers always run — the repository gains a fact it is graded on, and (if it was passing the rest) the score is unchanged while the coverage caveat disappears.
- **FAIL, lowering the score**, where a newly traced producer can in fact skip. That case was previously invisible: a real bypass, sitting behind a check nothing could trace.

Reading matrix legs GitHub's way moves the same fact for a second group: a repository whose required checks come from a BOOLEAN matrix axis was resolving nothing, because the leg was compared as `True` against a check GitHub spells `true`. That applies to the older `(value, …)` suffix reading as well as to templated names.

Repositories with no matrix-templated required checks are unaffected. The fixture suite covers both directions.

## Red proof

The regression tests were written and run against the unfixed resolver first:

```
AssertionError: unmeasured: none of the 4 required check(s) could be traced to
a job in these workflows, so whether every required check on branch `main`
protection survives a skipped job was not established. Not judged:
`build shard 1/4` (no job in these workflows reports it — an external app
check, a reusable-workflow job, a templated job name, or a stale entry); ...
assert 'unmeasured' == 'pass'
```

and, for a conditional producer of a rendered leg, `assert 'unmeasured' == 'fail'`.

Review then found one shape that resolved when it must not — an underscore counted as anchoring text, so a required `ubuntu_x64` produced by nothing in the files came back a scored PASS — and four that lost coverage or misled the reader. Those fixes carry their own red proof against the commit before them:

```
test_an_underscore_between_placeholders_does_not_anchor_a_template
AssertionError: all 1 required check(s) on branch `main` protection have
a producer that runs whatever else happens.
assert 'pass' == 'unmeasured'
```

Twelve of the added tests are red there. Every refusal is also mutation-tested: reverting it in place kills a named test. Two earlier tests that could not fail were repaired — one asserted a context its refusal never affected, the other exited at a different guard than its docstring credited.

## Evidence names the cause it actually found

Six distinct refusals shared one sentence — "templated over a matrix this scan cannot enumerate" — which is false for five of them, since a degenerate name, a whitespace rewrite, a misspelled axis and a competing reusable call all enumerate perfectly well. This is the surface a reader uses to win back a security grade, and it was sending anyone with a one-character axis typo off to hunt for an external app that does not exist. The evidence now names the job that nearly produced the check and the reason it did not, and names only a job whose literal text could have produced that context.

## Code sharing

The repo already keeps matrix-leg expansion logic in `skills/ci-speedup/scripts/collect_runs.py`. It is not imported here: each skill ships self-contained (the CLI copies `skills/<name>/` recursively and nothing resolves a sibling at runtime), and `gh_utils.py`'s verbatim-copy invariant is this repo's established pattern for logic two skills both need. The implementation is ci-secure's own, in its exact-enumeration house style.

## Tests

`uv run --python 3.12 --with pytest --with pyyaml python -m pytest -q` from the repo root: **4575 passed, 14 skipped**. Nine new tests in `skills/ci-secure/tests/test_config_facts.py`. A per-skill CHANGELOG entry is included.


