### PR TITLE
chore: enable Dependabot version updates (ENG-533)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      pip-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Enables Dependabot **version updates** so dependencies stay current, alongside the vulnerability alerts and security updates already enabled org-wide (ENG-533).

**Ecosystems covered:** `pip,github-actions`

**Volume control:** minor and patch bumps are grouped into a single PR per ecosystem, run weekly on Mondays, capped at 5 open PRs per ecosystem. Major bumps still arrive individually, since those need real review.

Note that `main` now requires an approving review (ENG-534), so Dependabot PRs will need a human approval to land.

https://claude.ai/code/session_019ZZ7DtLN4RyYVktaub3Rrv