### PR TITLE
Post-fix verification reports what the evidence supports, not one "less work" verdict

### DIFF
--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -218,7 +218,31 @@ unversioned and updates by reinstall from `main`.
 
 ### Changed
 
-- **2026-08-20** — **The storage boundary is stated instead of implied.**
+- **2026-09-08** — **The planned before/after check can no longer claim a
+  speedup it did not measure.** The approved (still unimplemented) post-fix
+  verification methodology told the future implementation to stamp one universal
+  "less work run" label whenever the branch's CI workload differed from the
+  baseline's — a verdict that asserts a direction the evidence usually does not
+  support, and that says nothing at all when a branch does *more* work. The
+  methodology now carries five evidence-backed workload states — same, reduced,
+  increased, changed, unknown — with unknown as the default and a direction
+  claimed only where workload identity evidence exists (equal job counts do not
+  prove equal work; re-sharding a suite does not prove coverage was cut). Only
+  the same state permits a clean "same work, faster" attribution; the others are
+  reported together with the confound, and an added-work run is explicitly never
+  reported as proof that the fix is worth *at least* the measured delta. The
+  methodology also now fixes when the check may start (an authorized push bound
+  to an exact remote commit, resumed on a later invocation from saved scratch
+  context — never a background daemon), forbids spending a second set of reruns
+  to re-answer the same commit, discards in-flight samples when the branch head
+  moves, requires the reported number to describe whichever check gates the
+  merge *now* rather than a former slow check that has been overtaken, and
+  states that the first automatic branch run supplies sample one. No skill
+  behavior changes: this is the contract a later implementation follows, and all
+  six locked design decisions — two samples adaptive to four, the 20% variance
+  threshold, sequential reruns with no empty commits, automatic with disclosed
+  cost, environment-level configuration, wall-clock only — are unchanged and
+  continue to govern wherever an amendment touches them.
   `references/savings-methodology.md` sizes every finding on two axes — runner
   minutes and wall clock — and said nothing about artifact and cache storage,
   which is a separate line on the GitHub bill governed by `retention-days` and

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -218,7 +218,7 @@ unversioned and updates by reinstall from `main`.
 
 ### Changed
 
-- **2026-09-08** — **The planned before/after check can no longer claim a
+- **2026-09-09** — **The planned before/after check can no longer claim a
   speedup it did not measure.** The approved (still unimplemented) post-fix
   verification methodology told the future implementation to stamp one universal
   "less work run" label whenever the branch's CI workload differed from the

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -237,8 +237,11 @@ unversioned and updates by reinstall from `main`.
   to re-answer the same commit, discards in-flight samples when the branch head
   moves, requires the reported number to describe whichever check gates the
   merge *now* rather than a former slow check that has been overtaken, and
-  states that the first automatic branch run supplies sample one. No skill
-  behavior changes: this is the contract a later implementation follows, and all
+  states that the first automatic branch run supplies sample one. Where a
+  descriptive spread over the baseline's own observations is available, it may
+  now be shown as historical context beside the before figure — never as a
+  significance test, and never in place of the locked adaptive threshold. No
+  skill behavior changes: this is the contract a later implementation follows, and all
   six locked design decisions — two samples adaptive to four, the 20% variance
   threshold, sequential reruns with no empty commits, automatic with disclosed
   cost, environment-level configuration, wall-clock only — are unchanged and

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -242,7 +242,12 @@ unversioned and updates by reinstall from `main`.
   six locked design decisions — two samples adaptive to four, the 20% variance
   threshold, sequential reruns with no empty commits, automatic with disclosed
   cost, environment-level configuration, wall-clock only — are unchanged and
-  continue to govern wherever an amendment touches them. (#95)
+  continue to govern wherever an amendment touches them. Two rules the amendment
+  itself needed are stated with it: sampling by workflow dispatch targets a
+  branch ref rather than a commit, so a dispatched run's head is checked against
+  the bound fix commit and discarded on a mismatch; and the documented
+  `CI_SPEEDUP_VERIFY_RUNS=0` escape hatch turns the phase off outright, so a
+  saved verdict is not re-rendered either. (#95)
 
 - **2026-08-20** — **The storage boundary is stated instead of implied.**
   `references/savings-methodology.md` sizes every finding on two axes — runner

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -242,7 +242,9 @@ unversioned and updates by reinstall from `main`.
   six locked design decisions — two samples adaptive to four, the 20% variance
   threshold, sequential reruns with no empty commits, automatic with disclosed
   cost, environment-level configuration, wall-clock only — are unchanged and
-  continue to govern wherever an amendment touches them.
+  continue to govern wherever an amendment touches them. (#95)
+
+- **2026-08-20** — **The storage boundary is stated instead of implied.**
   `references/savings-methodology.md` sizes every finding on two axes — runner
   minutes and wall clock — and said nothing about artifact and cache storage,
   which is a separate line on the GitHub bill governed by `retention-days` and

--- a/skills/ci-speedup/references/before-after-verification-spec.md
+++ b/skills/ci-speedup/references/before-after-verification-spec.md
@@ -6,8 +6,9 @@ This becomes the methodology doc for a new, lightweight, **built-in** ci-speedup
 phase once the implementation lands in a follow-up PR.
 
 **Amended 2026-09-08** with the workload-state vocabulary, the confounded-workload
-reporting rule, the trigger/resume contract, the gate-migration rule, and the
-bootstrap clarification. Those amendments narrow what may be *claimed* and define
+reporting rule, the trigger/resume contract, the gate-migration rule, the
+bootstrap clarification, and the optional descriptive baseline spread (historical
+context only — it never replaces the locked adaptive threshold). Those amendments narrow what may be *claimed* and define
 *when* the phase runs. **They change none of the six locked decisions**; where an
 amendment and a locked decision could be read as interacting, the locked decision
 governs.

--- a/skills/ci-speedup/references/before-after-verification-spec.md
+++ b/skills/ci-speedup/references/before-after-verification-spec.md
@@ -5,6 +5,13 @@
 This becomes the methodology doc for a new, lightweight, **built-in** ci-speedup
 phase once the implementation lands in a follow-up PR.
 
+**Amended 2026-09-08** with the workload-state vocabulary, the confounded-workload
+reporting rule, the trigger/resume contract, the gate-migration rule, and the
+bootstrap clarification. Those amendments narrow what may be *claimed* and define
+*when* the phase runs. **They change none of the six locked decisions**; where an
+amendment and a locked decision could be read as interacting, the locked decision
+governs.
+
 ## Problem
 
 ci-speedup is a *speedup* tool, but today it never tells the user how much
@@ -42,8 +49,9 @@ pauses before committing / opening a PR. Phase 7 presupposes the user then
 7. Verify the speedup (NEW)  ← branch CI has run → measure after → report before/after
 ```
 
-Trigger condition: the fix branch exists on the remote AND the gating workflow
-has completed at least the minimum number of runs on it (see "Sampling"). Until a
+Trigger condition: the fix is bound to an exact remote head SHA AND that head's
+gating-workflow run has completed (see "Sampling", and "Trigger and resume
+contract" for the precise eligibility, binding, and resume rules). Until a
 push-to-branch step exists in the skill (phase 6 today ends at applying the fix,
 not pushing it), phase 7 is gated on that landing.
 
@@ -108,7 +116,10 @@ measurement and a misleading one:
    is **not** a same-window controlled experiment.
 3. **CI-only-scope precondition (guarded, see below)** — the delta is
    attributable to the CI change *only if* the branch changes nothing but CI
-   config. If it touches product code, the timing conflates the two.
+   config. If it touches product code, the timing conflates the two. The
+   **workload state** (`same` / `reduced` / `increased` / `changed` / `unknown` —
+   see "Workload state" below) is stated too; only `same` supports a clean
+   "same work, faster" claim, and any other state is reported with its confound.
 4. **Variance** — the range is shown; if runs disagree beyond the threshold even
    after the cap, say the result is noisy and give the range, not a point.
 5. **Cache state** — whether the "after" reflects warm or cold caches, and that
@@ -132,20 +143,95 @@ branch:
    implementation and make it configurable.)
 2. **The same work ran.** A pure-workflow edit can still change *what* runs — path
    filters, `if:` skips, test sharding, or a reduced matrix (all fixes ci-speedup
-   itself produces) make the "after" faster because **less CI executed**, not
-   because the same CI got faster. If the after runs a different job/test set than
-   the before (fewer jobs, filtered, sharded, reduced matrix), label the delta
-   **"less work run,"** not "same work faster," and do not headline a clean
-   speedup.
+   itself produces) can make the "after" faster because **different CI executed**,
+   not because the same CI got faster. Classify the workload with the states
+   below and do not headline a clean speedup unless the state is `same`.
 
 These establish that no *product code* changed and the *same work* ran — they do
 not neutralize the cache/commit/event asymmetries above, so "cleanly attributable"
 means "attributable to the CI change," not "controlled."
 
+### Workload state — evidence-backed, not one universal label
+
+*(2026-09-08 amendment. This replaces the earlier universal "less work run"
+label, which asserted a direction — less — that the evidence often does not
+support. It narrows what may be claimed; it changes none of the six locked
+decisions.)*
+
+Compare the after run's workload identity against the before's and record exactly
+one state:
+
+- **`same`** — the same jobs/checks and the same units of work are identified in
+  both. Only this state permits a clean "same work, faster" attribution.
+- **`reduced`** — positive evidence that work present before is absent after (a
+  named job/check/test target no longer executed, a matrix leg dropped, a path
+  filter that demonstrably skipped identified work).
+- **`increased`** — positive evidence of work present after that was not present
+  before (added jobs, added matrix legs, added steps).
+- **`changed`** — the workload differs in identity without a defensible net
+  direction: work both appeared and disappeared, or was redistributed (the same
+  tests re-split across a different number of shards, work relocated between
+  jobs).
+- **`unknown`** — the evidence needed to compare workload identity is missing,
+  ambiguous, or not retained. `unknown` is the default; a state is only asserted
+  when its evidence exists.
+
+Classify a direction **only when workload identity/count evidence supports it**.
+Two rules the classifier must obey, because both mistakes are easy:
+
+- **Equal job counts alone do not prove equal work.** The same number of jobs can
+  run a different matrix, a different test selection, or a different filtered set.
+  Equal counts with no identity evidence is `unknown`, not `same`.
+- **Sharding alone does not prove coverage reduction.** Re-sharding a suite
+  changes how work is divided, not necessarily how much of it runs: re-splitting
+  the same suite across more or fewer shards moves the job count while coverage
+  is unchanged. Absent evidence about the work each shard actually ran, that is
+  `changed`, not `reduced`.
+
+The conservative same-work attribution gate is preserved exactly as written
+above: it is `same` that unlocks a clean attribution, and every other state
+withholds it.
+
+### Reporting a confounded workload
+
+For **`increased`**, **`changed`**, or **`unknown`**, report the observed timing
+change *together with the confound*, in the same breath, and stop there.
+Specifically:
+
+- State the measured delta as observed, and state what about the workload
+  differed (or that it could not be established).
+- **The observed delta is never a lower bound on the fix's benefit** when the
+  workload is `increased`, `changed`, or `unknown`; do not claim that added or
+  altered work makes it one. "It got faster even though it did more work, so the real win is
+  at least this big" is not supported: the added work may be cheap, concurrent,
+  off the critical path, or cache-warming, and the altered work may have moved
+  time rather than removed it. There is no floor to quote.
+- `reduced` is likewise not a clean speedup: the delta includes work that simply
+  did not run.
+- Product-code changes continue to disallow clean CI-only attribution regardless
+  of workload state; guard 1 and guard 2 are independent and both must pass.
+
+### Optional descriptive baseline context
+
+Where a descriptive spread over the baseline's own observations is available
+(minimum/median/maximum and sample count of the before-side observations), it MAY
+be shown as historical context alongside the before figure. It **must not replace
+the locked adaptive threshold**, must **not become a significance test** or an
+"outside the noise" verdict, and must not alter sample selection or the adaptive
+sampling decision — where the two could interact, **the locked decision governs**
+(Decisions 1 and 2). Its absence never blocks this phase.
+
 ## Triggering the runs (Decision 3)
 
 - The fix is pushed to a branch; its `pull_request`/`push` CI runs once
-  automatically. That's sample 1 (cold cache).
+  automatically. That's sample 1 (cold cache). **Bootstrap (2026-09-08
+  amendment):** that completed automatic branch run **supplies the first sample** — this
+  phase then collects only the remaining attempts up to N. Requiring two
+  pre-existing samples before the component responsible for obtaining sample two
+  may start would **deadlock**, since nothing else produces sample two. The
+  locked default (N = 2, adaptive to 4, Decision 1) counts the automatic run
+  among the N; the amendment names where sample one comes from, it does not raise
+  or lower N.
 - For samples 2..N, **`gh run rerun <run-id>` is the primary mechanism** — it
   re-runs the existing gating run on the same branch head, works for ANY workflow
   (no config needed), pollutes no history, and re-uses the identical commit so it
@@ -163,6 +249,89 @@ means "attributable to the CI change," not "controlled."
   for parallel sampling when available, otherwise accept serial reruns.
 - **Never re-push** (empty commits pollute history) — explicitly rejected.
 - Guard: only the gating workflow needs sampling — don't fan out every workflow.
+
+## Trigger and resume contract (2026-09-08 amendment)
+
+This section makes "once the fix is on a branch" precise. It defines *when* the
+phase may start, *what* it is bound to, and *what happens when it is invoked
+again*. It changes none of the six locked decisions — sampling defaults, the
+variance threshold, the rerun mechanism, automatic-with-disclosed-cost, the env
+knobs, and wall-clock-only all continue to govern once the phase is eligible.
+
+### Eligibility
+
+Phase 6 still stops at a verified, **uncommitted** change and the existing user
+checkpoint before commit / PR. Nothing here authorizes bypassing that
+checkpoint — this work **does not authorize bypassing that checkpoint**, and no
+commit, push, or branch creation happens on the user's behalf to make
+verification possible.
+
+Phase 7 becomes eligible when all of the following hold:
+
+1. The **authorized commit/push** has occurred — the user took the phase-6
+   checkpoint decision and the fix reached the remote.
+2. The fix is bound to an **exact remote head SHA**, not a branch name. A branch
+   name is a moving target; the comparison is about one commit.
+3. That head's initial relevant CI run has **completed** (it is sample one — see
+   Bootstrap above).
+
+During an ongoing authorized fix session, continue automatically when those facts
+become available — that is Decision 4's automatic behavior, with the cost line.
+
+### Resume after the session ends
+
+If the session ends before verification completes, a **later invocation can
+resume from the saved scratch context** and finish the comparison. This is a
+resume-on-next-invocation, **not a background daemon**: nothing keeps running,
+polls, or spends runner minutes between sessions, and the output must never
+imply that something is watching in the background. If no one invokes the skill
+again, no further samples are ever collected.
+
+Runtime context is persisted beside the run's scratch artifacts, outside tracked
+and installable content.
+
+### Context binding
+
+Bind the saved context to all of:
+
+- repository,
+- the baseline artifact the "before" came from,
+- the **fix head SHA**,
+- workflow / check identity being sampled,
+- the run and attempt IDs already collected.
+
+### Repeat invocation
+
+Repeated invocation reuses completed samples and an existing verdict for that
+head. It **must not spend another set of reruns** to re-answer a question already
+answered for the same head — the disclosed cost is paid once, not once per
+invocation.
+
+**A changed head invalidates in-flight comparison.** If the remote head moved
+(amended commit, force-push, new commits on the branch), samples collected
+against the old head are not mixed with the new one: the in-flight comparison is
+discarded and a fresh after-sample set is collected against the new head, under
+the same locked N and threshold.
+
+### Gate migration — the after metric must describe the current gate
+
+**The after metric must describe the current merge gate.** A fix that speeds up
+or removes the former pole often hands the gate to whatever check is now slowest.
+Reporting the former pole's improvement as a merge-wait improvement would then
+describe a check that no longer decides when the user can merge.
+
+- Within the sampled workflow, **re-evaluate the gate/chain** on the after head
+  and report merge-wait against whatever now gates.
+- Never report a former pole's improvement as merge-wait improvement after
+  another check has taken over. Report the check-level improvement as a
+  check-level fact, and state that the gate moved.
+- If relevant competing workflows or external checks cannot be compared on the
+  same after head, report the measured check-level result and mark the
+  repository **merge-wait change unavailable**. Unavailable is an honest answer;
+  a number that describes the wrong check is not.
+- **Do not expand sampling to unrelated workflows** to manufacture that number.
+  The sampling guard above (only the gating workflow is sampled) still holds, and
+  widening the fan-out would spend cost the locked disclosure did not price.
 
 ## Fetching + computing "after"
 
@@ -191,8 +360,12 @@ Speedup (measured): the test check now merges in ~6m10s, down from ~8m36s — ab
   • CI timing varies run-to-run, on whatever runner tier/concurrency you use; this is one branch's runs vs recent history, not a controlled test.
 ```
 
-If the guard trips (non-CI files changed), or variance stays high, or CI failed
-on the branch, the block says so plainly instead of quoting a clean number.
+That example is the `same`-workload case. If the guard trips (non-CI files
+changed), or the workload state is anything but `same`, or the gate moved to
+another check, or variance stays high, or CI failed on the branch, the block says
+so plainly instead of quoting a clean number — e.g. *"the branch also added a job,
+so this timing change and that extra work can't be separated"* rather than any
+claim that the fix is worth at least the measured delta.
 
 ## Cost, automation, and configuration (Decisions 4 & 5)
 
@@ -224,7 +397,10 @@ collapses it to ≈ one run); billing is N × one run's runner-minutes regardles
   fabricate a number.
 - **Fix didn't change the gating check's identity** → normal case, compare.
 - **Fix changed which check gates** (e.g. removed the pole) → report that the
-  former gate is gone and what the new merge-wait is.
+  former gate is gone and what the new merge-wait is, per "Gate migration" above.
+  The former pole's own improvement is a check-level fact, never the merge-wait
+  delta once another check gates; if the new gate cannot be compared on the same
+  after head, mark the repository merge-wait change unavailable.
 - **Only 1 run available** (dispatch unsupported, or user won't spend N) → report
   it as a single cold sample with a loud "one run, treat as indicative" caveat.
 - **High variance past the cap** → range only, explicitly "noisy."
@@ -278,7 +454,14 @@ All six resolved; these are the contract the implementation follows.
   billing cost).
 - Tests: the median/range math over all runs, the variance-adaptive-N logic, the
   cold(1)+warm(N−1) composition at the default N = 2, the CI-only-scope guard
-  (product code → conflated; a coverage-reducing workflow edit → "less work run"),
-  and the "CI failed / 1 run / high variance" degradations — all offline with
+  (product code → conflated; each workload state reached only on its own
+  evidence, with equal job counts and a pure re-shard NOT classified as
+  `reduced`; `increased`/`changed`/`unknown` never headlining a clean
+  attribution or a lower bound), the trigger/resume contract (no reruns before a
+  remote fix head exists; the automatic run counted as sample one; repeat
+  invocation collecting no duplicate samples; a moved head discarding in-flight
+  samples), the gate-migration rule (a new gate or an uncomparable competing
+  workflow cannot be reported as the old check's merge-wait delta), and the
+  "CI failed / 1 run / high variance" degradations — all offline with
   synthesized run timings.
 - CHANGELOG entry.

--- a/skills/ci-speedup/references/before-after-verification-spec.md
+++ b/skills/ci-speedup/references/before-after-verification-spec.md
@@ -8,8 +8,8 @@ phase once the implementation lands in a follow-up PR.
 **Amended 2026-09-08** with the workload-state vocabulary, the confounded-workload
 reporting rule, the trigger/resume contract, the gate-migration rule, the
 bootstrap clarification, and the optional descriptive baseline spread (historical
-context only — it never replaces the locked adaptive threshold). Those amendments narrow what may be *claimed* and define
-*when* the phase runs. **They change none of the six locked decisions**; where an
+context only — it never replaces the locked adaptive threshold). Those amendments
+narrow what may be *claimed* and define *when* the phase runs. **They change none of the six locked decisions**; where an
 amendment and a locked decision could be read as interacting, the locked decision
 governs.
 

--- a/skills/ci-speedup/references/before-after-verification-spec.md
+++ b/skills/ci-speedup/references/before-after-verification-spec.md
@@ -51,10 +51,13 @@ pauses before committing / opening a PR. Phase 7 presupposes the user then
 ```
 
 Trigger condition: the fix is bound to an exact remote head SHA AND that head's
-gating-workflow run has completed (see "Sampling", and "Trigger and resume
-contract" for the precise eligibility, binding, and resume rules). Until a
-push-to-branch step exists in the skill (phase 6 today ends at applying the fix,
-not pushing it), phase 7 is gated on that landing.
+initial relevant CI run has completed (see "Sampling", and "Trigger and resume
+contract" for the precise eligibility, binding, and resume rules). Those rules
+describe the phase once it exists; they do not make it live. Phase 6 today ends
+at applying the fix, so until the skill gains a push-to-branch step, **nothing
+reaches eligibility and phase 7 never runs** — the eligibility rules are what the
+implementation must satisfy on the day that step lands, not a claim that the
+phase is reachable now.
 
 ## Measurement design
 
@@ -248,6 +251,13 @@ sampling decision — where the two could interact, **the locked decision govern
   parallel** (≈ one run of wall-clock). But many workflows are `push`/`pull_request`
   only (the website's `ci.yml` is), so dispatch cannot be the primary path; use it
   for parallel sampling when available, otherwise accept serial reruns.
+  **Dispatch takes a ref, not a SHA, so it does not satisfy the exact-head
+  binding on its own:** a dispatched run builds whatever the ref points at when
+  it starts, so a follow-up commit silently swaps the commit under the sample.
+  Check each dispatched run's `head_sha` against the bound fix head and **discard
+  any sample that does not match** (the changed-head rule below then applies). A
+  rerun cannot drift this way — it re-uses the identical commit by construction —
+  which is the second reason it is the primary path.
 - **Never re-push** (empty commits pollute history) — explicitly rejected.
 - Guard: only the gating workflow needs sampling — don't fan out every workflow.
 
@@ -305,7 +315,9 @@ Bind the saved context to all of:
 Repeated invocation reuses completed samples and an existing verdict for that
 head. It **must not spend another set of reruns** to re-answer a question already
 answered for the same head — the disclosed cost is paid once, not once per
-invocation.
+invocation. Reuse is still subject to Decision 5's escape hatch:
+`CI_SPEEDUP_VERIFY_RUNS=0` disables phase 7 outright, so a saved verdict is not
+rendered either — the knob turns the phase off, not merely its spending.
 
 **A changed head invalidates in-flight comparison.** If the remote head moved
 (amended commit, force-push, new commits on the branch), samples collected

--- a/skills/ci-speedup/references/before-after-verification-spec.md
+++ b/skills/ci-speedup/references/before-after-verification-spec.md
@@ -261,10 +261,9 @@ knobs, and wall-clock-only all continue to govern once the phase is eligible.
 ### Eligibility
 
 Phase 6 still stops at a verified, **uncommitted** change and the existing user
-checkpoint before commit / PR. Nothing here authorizes bypassing that
-checkpoint — this work **does not authorize bypassing that checkpoint**, and no
-commit, push, or branch creation happens on the user's behalf to make
-verification possible.
+checkpoint before commit / PR. This work **does not authorize bypassing that
+checkpoint**: no commit, push, or branch creation happens on the user's behalf
+to make verification possible.
 
 Phase 7 becomes eligible when all of the following hold:
 

--- a/skills/ci-speedup/tests/test_before_after_verification_contract.py
+++ b/skills/ci-speedup/tests/test_before_after_verification_contract.py
@@ -27,6 +27,20 @@ Pins are section-scoped wherever a phrase also occurs elsewhere in the doc, and
 rules that carry a scope condition are pinned against the scope, not the phrase:
 a rule stated as one sentence can be inverted by appending an exception to it,
 which leaves every substring pin intact.
+
+Where a rule is pinned by meaning rather than by phrasing, the check is
+**closed-world**: it finds every sentence in the doc that touches the rule and
+requires each one to state or withhold it. The open-world shape — listing the
+verbs or sentence templates a violation might use — was tried first and loses to
+the first wording nobody listed ("the delta serves as a floor", "`reduced` also
+qualifies for the headline", "only after the user approves"). Closed-world costs
+a false positive when the doc says something true in a shape the sweep does not
+recognise; that is the trade, and it is the safe direction for a contract pin.
+A known one: a prohibition opening with a bare "No ..." ("No reader can treat the
+delta as a lower bound") reads to the sweep as a sentence about a floor that does
+not refuse one. Widening the refusal words to a bare "no" was tried and rejected
+— it exempts "With no confound present, the delta is a floor", which is the
+inversion itself. Reword the doc rather than loosen the sweep.
 """
 from __future__ import annotations
 
@@ -54,6 +68,77 @@ def _decisions() -> str:
 #: Every workload-state token, as the doc writes them.
 _STATES = ("`same`", "`reduced`", "`increased`", "`changed`", "`unknown`")
 
+#: The doc with fenced code blocks blanked out. Section slicing counts markdown
+#: headings, and a ``# `` line inside a fence is not one — it would truncate a
+#: section early and leave its pins reading a prefix of the text they name.
+_SPEC_NO_FENCES = re.sub(
+    r"^```.*?^```", lambda m: "\n" * m.group(0).count("\n"), _SPEC,
+    flags=re.MULTILINE | re.DOTALL,
+)
+
+#: Words that turn a sentence about a rule into a statement WITHHOLDING it.
+#: The prose pins below are closed-world — every sentence that touches a rule
+#: must either restate it or refuse it — so this is the list that decides which.
+#: Matched on WORD boundaries. Substring matching reads "whenever" as "never"
+#: and quietly exempts the sentence it was meant to catch.
+_WITHHOLDING = re.compile(
+    r"(?i)\b(never|not|cannot|no floor|no lower bound|disallow\w*|withhold\w*|"
+    r"refuse\w*|denied|unsupported)\b|n't\b"
+)
+
+
+def _sentences(text: str) -> list[str]:
+    """The text's sentences, each flattened to one line.
+
+    Pass RAW text (`_SPEC`, `_raw_section`), never `_section`: the markdown line
+    structure is what separates a bullet, a table and a heading from the prose
+    after them, and `_section` has already flattened it away.
+
+    Prose rules live in sentences, so a sentence is the unit a pin can hold. A
+    doc-wide substring search cannot tell "never a floor" from "a floor";
+    splitting first and then asking what each sentence does is what makes the
+    checks below closed-world rather than a list of forbidden phrasings.
+    """
+    # Split on markdown block starts BEFORE splitting on punctuation. A table
+    # row or a bullet often carries no sentence-final punctuation at all, so
+    # flattening first glues it to the next block — and if that block happens to
+    # be a withholding sentence, the glued unit inherits its "not"/"disallow"
+    # and the sweep reads a grant as a refusal.
+    units: list[str] = []
+    for line in text.splitlines():
+        is_row = line.lstrip().startswith("|")
+        # A table is one unit. Row-per-unit would let "| clean attribution |" and
+        # "| `reduced` | yes |" sit in different units, so neither one names both
+        # the rule and the state it grants it to.
+        if is_row and units and units[-1].lstrip().startswith("|"):
+            units[-1] += " " + line.strip()
+        elif re.match(r"\s*([-*+]\s|\d+\.\s|\||#{1,6}\s|>)", line) or not units:
+            units.append(line)
+        elif not line.strip():
+            units.append("")
+        else:
+            units[-1] += " " + line
+    out: list[str] = []
+    for unit in units:
+        flat = re.sub(r"\s+", " ", unit).strip()
+        if not flat:
+            continue
+        out += [s.strip() for s in re.split(r"(?<=[.:;])\s+(?=[A-Z`\"*(-])", flat) if s.strip()]
+    return out
+
+
+#: Phrases by which the doc states a rule's EXCLUSIVITY rather than refusing it
+#: ("only `same` supports a clean claim, and any other state is reported with
+#: its confound"). Such a sentence names every state and grants to none of them,
+#: so it is as compliant as a withholding one.
+_EXCLUSIVE = re.compile(
+    r"(?i)only `same`|any other state|every other state|and no other"
+)
+
+
+def _withholds(sentence: str) -> bool:
+    return bool(_WITHHOLDING.search(sentence) or _EXCLUSIVE.search(sentence))
+
 
 def _raw_section(heading: str) -> str:
     """The doc text under `heading`, up to the next heading of the same or a
@@ -65,10 +150,20 @@ def _raw_section(heading: str) -> str:
     whole file can be satisfied by an unrelated occurrence elsewhere — which is
     exactly how "exact remote head SHA" survives rewriting eligibility item 2.
     """
-    m = re.search(rf"^{re.escape(heading)}.*$", _SPEC, re.MULTILINE)
-    assert m is not None, f"no heading starts with {heading!r}"
+    body = _SPEC_NO_FENCES
+    hits = re.findall(rf"^{re.escape(heading)}.*$", body, re.MULTILINE)
+    assert hits, f"no heading starts with {heading!r}"
+    # Exactly one, or the slice is forgeable: `re.search` takes the FIRST
+    # prefix match, so planting an earlier "### Eligibility (superseded)" that
+    # carries the pinned wording captures every section-scoped pin and frees the
+    # real section to be rewritten. Ambiguity is the bug, so it is the failure.
+    assert len(hits) == 1, (
+        f"heading {heading!r} matches {len(hits)} headings ({hits!r}); a "
+        "section-scoped pin cannot say which one it is reading"
+    )
+    m = re.search(rf"^{re.escape(heading)}.*$", body, re.MULTILINE)
     level = len(heading) - len(heading.lstrip("#"))
-    rest = _SPEC[m.end() :]
+    rest = body[m.end() :]
     nxt = re.search(rf"\n#{{1,{level}}} ", rest)
     return m.group(0) + (rest[: nxt.start()] if nxt else rest)
 
@@ -175,21 +270,30 @@ def test_confounded_workload_is_never_a_lower_bound():
         f"the three confounded ones: {rule!r}"
     )
 
-    # ...and nowhere may the doc GRANT a floor, however the grant is phrased.
-    # This catches the rewrite by meaning rather than by substring: any clause
-    # that permits a delta to be read as a lower bound / floor is out of
-    # contract, whatever verb it uses.
-    granted = [
-        m.group(0)
-        for m in re.finditer(
-            r"(?i)\b(may|can|could|might|is permitted|is allowed|permissible|"
-            r"acceptable)\b[^.;]{0,140}?\b(lower bound|floor)\b",
-            _FLAT,
-        )
+    # ...and nowhere may the doc GRANT a floor. Listing the verbs a grant might
+    # use is an open-world check and loses: "the delta serves as a floor",
+    # "treat the delta as a minimum", "the fix is worth at least the delta" name
+    # no modal verb at all and would each walk through such a list. Invert it —
+    # find every sentence that talks about a floor AT ALL and require each one
+    # to be withholding one. A new sentence granting a floor has to be written
+    # as a grant, so it arrives without a withholding word and reddens; and the
+    # inversion also stops the old check's false positive, where the correct
+    # sentence "the delta may NOT be reported as a floor" read as a permission.
+    floor_talk = [
+        s
+        for s in _sentences(_SPEC)
+        if re.search(r"(?i)\b(lower bound|floor|worth at least|at least this "
+                     r"big|as a minimum|bounds? the [a-z ]+ from below)\b", s)
     ]
-    assert not granted, (
-        f"the doc now permits quoting a floor under the fix's benefit: {granted!r}"
+    assert floor_talk, (
+        "the doc no longer says anything about a floor under the fix's "
+        "benefit; the prohibition has been deleted rather than weakened"
     )
+    for sentence in floor_talk:
+        assert _withholds(sentence), (
+            "a sentence lets the observed delta stand as a floor under the "
+            f"fix's benefit: {sentence!r}"
+        )
 
     # Pin the actual confound sentence. A `.*`/DOTALL search over the flattened
     # doc for the three state names in order proves nothing: the definition list
@@ -231,13 +335,46 @@ def test_the_same_work_attribution_gate_is_preserved():
     # in any clause that grants the clean attribution, however that clause is
     # worded or wherever in the doc it is added.
     granting = re.findall(r"unless the state is ([^.]{0,160})\.", _FLAT)
-    granting += re.findall(r"([^.]{0,80})\bunlocks\b", _FLAT)
     assert granting, "no attribution-granting clause found to check for exclusivity"
     for clause in granting:
+        # A clause naming NO state is left to the doc-wide sweep below; demanding
+        # every `unlocks` clause name `same` reddens on a correct sentence like
+        # "the gate unlocks the headline claim". What is out of contract is a
+        # clause that names a state OTHER than `same`.
         named = {s for s in _STATES if s in clause}
-        assert named == {"`same`"}, (
+        assert named <= {"`same`"}, (
             "a state other than `same` appears in an attribution-granting "
             f"clause: {clause!r} names {sorted(named)}"
+        )
+
+    # The two shapes above are the doc's current wording, so pinning only those
+    # enumerates two ways to grant the headline and misses every other: a new
+    # bullet, a new sentence, or a table row saying `reduced` qualifies is
+    # invisible to them. Sweep the whole doc instead — any sentence that talks
+    # about the clean attribution and names a state other than `same` must be
+    # WITHHOLDING it, which is what "`same`, and no other" means as a rule.
+    attribution_talk = [
+        s
+        for s in _sentences(_SPEC)
+        if re.search(r"(?i)(clean speedup|clean attribution|clean ci-only "
+                     r"attribution|same work, faster|headline)", s)
+    ]
+    assert attribution_talk, "the doc no longer states the clean-attribution rule"
+    # ...and the exclusivity phrasing that exempts a sentence from the sweep may
+    # not itself be widened: "only `same` and `reduced`" reads as exclusive to
+    # the sweep while granting to two states.
+    widened = re.findall(r"only `same`[^.]{0,40}", _FLAT)
+    for clause in widened:
+        assert not ({s for s in _STATES if s in clause} - {"`same`"}), (
+            f"the `same`-only exclusivity has been widened: {clause!r}"
+        )
+    for sentence in attribution_talk:
+        named = {s for s in _STATES if s in sentence}
+        if named <= {"`same`"}:
+            continue
+        assert _withholds(sentence), (
+            "a sentence grants the clean same-work attribution to a state "
+            f"other than `same`: {sentence!r} names {sorted(named)}"
         )
 
 
@@ -250,15 +387,33 @@ def test_eligibility_binds_to_an_exact_remote_head_sha():
     assert "exact remote head SHA" in _FLAT
     assert "authorized commit/push" in _FLAT
 
-    # Both phrases above occur elsewhere in the doc (the phase-7 placement
-    # section states the trigger condition too), so they survive rewriting the
-    # eligibility item itself to bind to a branch name. Pin the item where it
-    # lives, together with the reason it is a SHA.
+    # "exact remote head SHA" occurs twice (the phase-7 placement section states
+    # the trigger condition too), so the flat pin above survives rewriting the
+    # eligibility item itself to bind to a branch name. "authorized commit/push"
+    # happens to occur once today, which pins item 1 only by luck — a second
+    # occurrence anywhere would unpin it. So pin BOTH items where they live.
     eligibility = _section("### Eligibility")
+    assert "The **authorized commit/push** has occurred" in eligibility, (
+        "eligibility item 1 no longer requires the authorized commit/push"
+    )
     assert "bound to an **exact remote head SHA**, not a branch name" in eligibility, (
         "eligibility item 2 no longer binds the fix to an exact remote head SHA"
     )
     assert "A branch name is a moving target" in eligibility
+    # Closed-world: the two sentences above are the ONLY places eligibility may
+    # mention a branch name. An exception appended to the item ("where a SHA is
+    # unavailable, the branch name is an acceptable substitute") leaves both
+    # phrases intact and undoes the rule they state.
+    stray = [
+        s
+        for s in _sentences(_raw_section("### Eligibility"))
+        if "branch name" in s
+        and "**exact remote head SHA**, not a branch name" not in s
+        and "A branch name is a moving target" not in s
+    ]
+    assert not stray, (
+        f"eligibility mentions a branch name outside the binding rule: {stray!r}"
+    )
 
 
 def test_resume_is_scratch_context_not_a_daemon():
@@ -316,8 +471,11 @@ def test_phase_six_checkpoint_is_not_bypassed():
 
 def test_locked_decisions_are_pinned_where_the_amendments_implement_them():
     """`test_locked_decisions_are_unchanged` scans only the Decisions section,
-    so it cannot see a decision moved by amended text elsewhere. These are the
-    two places the amendments implement a locked decision in their own words.
+    so it cannot see a decision moved by amended text elsewhere. Pinned here are
+    the amendment sentences that carry a locked NUMBER or a locked automatic/
+    manual choice in their own words — the ones where a rewrite changes spend or
+    changes who starts the phase. Other restatements defer to the decisions
+    generically and are covered by `test_amendments_defer_to_the_locked_decisions`.
 
     Decision 4 (automatic, with the cost line disclosed) lives in the trigger
     contract as "continue automatically"; rewriting that to "ask the user to
@@ -331,10 +489,41 @@ def test_locked_decisions_are_pinned_where_the_amendments_implement_them():
         "the trigger contract no longer starts phase 7 automatically (Decision 4)"
     )
     assert "that is Decision 4's automatic behavior" in trigger
-    for gate in ("ask the user", "confirm before", "await confirmation", "prompt the user"):
-        assert gate not in trigger.lower(), (
-            f"the trigger contract now gates the automatic start on {gate!r} "
-            "(Decision 4 is automatic-with-disclosed-cost)"
+    # Naming four gating phrases enumerates four ways to gate the start, and a
+    # fifth wording ("only after the user approves", "requires an explicit
+    # re-invocation", "user sign-off") inverts Decision 4 with the pin green.
+    # Pin the pairing instead: no sentence in this section may put a user's
+    # permission in the way of the phase starting, however that is worded.
+    starts = re.compile(
+        r"(?i)\b(start|starts|starting|begin|begins|continue|continuing|"
+        r"proceed|proceeds|dispatch|dispatched|sampl\w+|phase 7|the runs)\b"
+    )
+    gating = re.compile(
+        r"(?i)(\bask\w*\b|\bconfirm\w*|\bapprov\w*|\bconsent\w*|"
+        r"\bprompt\w*|\bpermission\b|\bawait\w*|\bsign-?off\b|"
+        r"\bgo-?ahead\b|\bmanual\w*|\bre-?invocation\b|\bre-?invoke\w*)"
+    )
+    gated = [
+        s
+        for s in _sentences(_raw_section("## Trigger and resume contract"))
+        if starts.search(s) and gating.search(s)
+    ]
+    assert not gated, (
+        "the trigger contract now gates phase 7's start on a user action "
+        f"(Decision 4 is automatic-with-disclosed-cost): {gated!r}"
+    )
+
+    # Decision-adjacent: the doc's evidence rule is that equal job counts do not
+    # prove equal work. A sentence that classifies `same` from job counts alone
+    # reinstates the universal label this whole amendment removed, and it can be
+    # added far from any pinned phrase — so every sentence about job counts must
+    # be a withholding one.
+    for sentence in _sentences(_SPEC):
+        if not re.search(r"(?i)\bjob counts?\b", sentence):
+            continue
+        assert _withholds(sentence), (
+            "a sentence infers a workload state from job counts, which the doc "
+            f"elsewhere says does not prove equal work: {sentence!r}"
         )
 
     triggering = _section("## Triggering the runs (Decision 3)")
@@ -343,6 +532,14 @@ def test_locked_decisions_are_pinned_where_the_amendments_implement_them():
         "N, which raises the sampling spend Decision 1 locked"
     )
     assert "it does not raise or lower N" in triggering
+
+    # Decision 1 + 2 again, in the clause that governs a resample after the head
+    # moves: re-scoping THAT to its own N or its own threshold is a spend change
+    # the Decisions section would still read as locked.
+    assert "under the same locked N and threshold" in _FLAT, (
+        "a resample after the head moves no longer runs under the locked N and "
+        "variance threshold (Decisions 1 and 2)"
+    )
 
 
 # --------------------------------------------------------------------------

--- a/skills/ci-speedup/tests/test_before_after_verification_contract.py
+++ b/skills/ci-speedup/tests/test_before_after_verification_contract.py
@@ -1,0 +1,146 @@
+"""Contract pins for the phase-7 before/after verification methodology doc.
+
+`references/before-after-verification-spec.md` is an approved *plan*: it is the
+contract a later implementation follows, so its wording is the only thing that
+can regress before any code exists. These are content checks over that doc — the
+prose-change form of a regression test (proposal §9: contract/content checks
+where meaningful, no blanket doc exemption).
+
+Two things are pinned:
+
+1. The 2026-09-08 methodology amendments — the evidence-backed workload states
+   that replace the old universal "less work run" label, the confound rule for
+   increased/changed/unknown workload, the trigger/resume contract, the
+   gate-migration rule, and the bootstrap clarification.
+2. That those amendments did NOT quietly rewrite any of the six locked
+   decisions. The amendments narrow disclosure; they never move the sampling
+   defaults, the variance threshold, the trigger mechanism, or v1's scope.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_SPEC = (
+    Path(__file__).resolve().parents[1]
+    / "references"
+    / "before-after-verification-spec.md"
+).read_text()
+
+# Markdown hard-wraps prose, so a pinned phrase can straddle a newline. Assert
+# against a whitespace-flattened copy; only the per-line scan below needs lines.
+_FLAT = re.sub(r"\s+", " ", _SPEC)
+
+
+def _decisions() -> str:
+    """The locked "Decisions" section, to the next top-level heading."""
+    start = _SPEC.index("## Decisions (locked)")
+    end = _SPEC.index("\n## ", start + 1)
+    return _SPEC[start:end]
+
+
+# --------------------------------------------------------------------------
+# 1. The amendments
+# --------------------------------------------------------------------------
+
+
+def test_workload_states_replace_the_universal_less_work_label():
+    """Direction is classified only where evidence supports it, across five
+    named states — not collapsed into one "less work run" verdict."""
+    for state in ("`same`", "`reduced`", "`increased`", "`changed`", "`unknown`"):
+        assert state in _FLAT, f"workload state {state} missing from the methodology"
+
+    # The old label may only survive where the doc says it is being replaced.
+    for line in _SPEC.splitlines():
+        if "less work run" in line:
+            assert "replace" in line.lower(), (
+                "the universal 'less work run' label is still used as a verdict: " + line
+            )
+
+
+def test_equal_job_counts_and_sharding_do_not_prove_a_direction():
+    assert "Equal job counts alone do not prove equal work" in _FLAT
+    assert "sharding alone does not prove coverage reduction" in _FLAT.lower()
+
+
+def test_confounded_workload_is_never_a_lower_bound():
+    """Added or unknown work makes the delta ambiguous in BOTH directions; it
+    must never be sold as a floor under the fix's benefit."""
+    assert "never a lower bound on the fix's benefit" in _FLAT
+    assert re.search(
+        r"increased.*changed.*unknown", _FLAT, re.IGNORECASE | re.DOTALL
+    ), "the confounded-workload states are not named together"
+
+
+def test_the_same_work_attribution_gate_is_preserved():
+    assert "The same work ran" in _FLAT
+    assert "conservative same-work attribution gate" in _FLAT
+
+
+# --------------------------------------------------------------------------
+# 2. Trigger and resume
+# --------------------------------------------------------------------------
+
+
+def test_eligibility_binds_to_an_exact_remote_head_sha():
+    assert "exact remote head SHA" in _FLAT
+    assert "authorized commit/push" in _FLAT
+
+
+def test_resume_is_scratch_context_not_a_daemon():
+    assert "not a background daemon" in _FLAT
+    assert "saved scratch context" in _FLAT
+
+
+def test_repeat_invocation_does_not_resample():
+    assert "must not spend another set of reruns" in _FLAT
+    assert "A changed head invalidates in-flight comparison" in _FLAT
+
+
+def test_phase_six_checkpoint_is_not_bypassed():
+    assert "does not authorize bypassing that checkpoint" in _FLAT
+
+
+# --------------------------------------------------------------------------
+# 3. Gate migration
+# --------------------------------------------------------------------------
+
+
+def test_after_metric_describes_the_current_gate():
+    assert "The after metric must describe the current merge gate" in _FLAT
+    assert "merge-wait change unavailable" in _FLAT
+    assert "Do not expand sampling to unrelated workflows" in _FLAT
+
+
+# --------------------------------------------------------------------------
+# 4. Bootstrap
+# --------------------------------------------------------------------------
+
+
+def test_bootstrap_does_not_deadlock():
+    assert "deadlock" in _FLAT
+    assert "supplies the first sample" in _FLAT
+
+
+# --------------------------------------------------------------------------
+# 5. The six locked decisions survive the amendments
+# --------------------------------------------------------------------------
+
+
+def test_locked_decisions_are_unchanged():
+    d = re.sub(r"\s+", " ", _decisions())
+    assert "**Default N = 2, adaptive up to 4.**" in d
+    assert "**Variance threshold = 20%**" in d
+    assert "`CI_SPEEDUP_VERIFY_VARIANCE_PCT`" in d
+    assert "never re-push" in d
+    assert "not gated" in d
+    assert "Env-configurable, out of user-facing SKILL.md" in d
+    assert "Wall-clock only in v1" in d
+
+
+def test_amendments_defer_to_the_locked_decisions():
+    """Where an amendment touches a locked decision, the doc must say the
+    locked decision governs — the amendments are disclosure-only."""
+    assert "the locked decision governs" in _FLAT
+    assert "must not replace the locked adaptive threshold" in _FLAT
+    assert "not become a significance test" in _FLAT

--- a/skills/ci-speedup/tests/test_before_after_verification_contract.py
+++ b/skills/ci-speedup/tests/test_before_after_verification_contract.py
@@ -19,6 +19,14 @@ Two things are pinned:
    elsewhere in the file — a term redefined, a precondition added — which is why
    the amendment sections carry their own pins above and why the doc states that
    the locked decision governs wherever the two could be read as interacting.
+   Where an amendment restates a locked decision in its own words (Decision 4's
+   "continue automatically", Decision 1's "counts the automatic run among the
+   N"), that sentence is pinned in the section it lives in as well.
+
+Pins are section-scoped wherever a phrase also occurs elsewhere in the doc, and
+rules that carry a scope condition are pinned against the scope, not the phrase:
+a rule stated as one sentence can be inverted by appending an exception to it,
+which leaves every substring pin intact.
 """
 from __future__ import annotations
 
@@ -41,6 +49,57 @@ def _decisions() -> str:
     start = _SPEC.index("## Decisions (locked)")
     end = _SPEC.index("\n## ", start + 1)
     return _SPEC[start:end]
+
+
+#: Every workload-state token, as the doc writes them.
+_STATES = ("`same`", "`reduced`", "`increased`", "`changed`", "`unknown`")
+
+
+def _raw_section(heading: str) -> str:
+    """The doc text under `heading`, up to the next heading of the same or a
+    higher level (so a `##` section carries its `###` subsections with it).
+    `heading` is matched as a line prefix, so a section is addressable without
+    pinning the date its heading carries.
+
+    Section scoping is what makes a pin local. A phrase asserted against the
+    whole file can be satisfied by an unrelated occurrence elsewhere — which is
+    exactly how "exact remote head SHA" survives rewriting eligibility item 2.
+    """
+    m = re.search(rf"^{re.escape(heading)}.*$", _SPEC, re.MULTILINE)
+    assert m is not None, f"no heading starts with {heading!r}"
+    level = len(heading) - len(heading.lstrip("#"))
+    rest = _SPEC[m.end() :]
+    nxt = re.search(rf"\n#{{1,{level}}} ", rest)
+    return m.group(0) + (rest[: nxt.start()] if nxt else rest)
+
+
+def _section(heading: str) -> str:
+    """`_raw_section`, whitespace-flattened for phrase matching."""
+    return re.sub(r"\s+", " ", _raw_section(heading))
+
+
+def _bullets(heading: str) -> list[str]:
+    """The section's markdown bullets, each flattened to a single line.
+
+    Rules that live in one bullet are pinned against that bullet, not the whole
+    doc: a scope condition appended to a rule ("...when the workload is X")
+    stays inside its bullet, so the bullet is the unit that can prove the rule
+    still binds to what it is supposed to bind to.
+    """
+    body = _raw_section(heading)
+    bullets: list[str] = []
+    in_bullet = False
+    for line in body.splitlines():
+        if re.match(r"\s*[-*] ", line):
+            bullets.append(line.strip()[2:])
+            in_bullet = True
+        elif not line.strip():
+            in_bullet = False
+        elif in_bullet and line.startswith((" ", "\t")):
+            bullets[-1] += " " + line.strip()
+        else:
+            in_bullet = False
+    return [re.sub(r"\s+", " ", b) for b in bullets]
 
 
 # --------------------------------------------------------------------------
@@ -93,6 +152,45 @@ def test_confounded_workload_is_never_a_lower_bound():
     must never be sold as a floor under the fix's benefit."""
     assert "never a lower bound on the fix's benefit" in _FLAT
 
+    # The phrase alone pins nothing about WHICH states the rule binds to: the
+    # rule can be inverted by appending a scope condition to the very sentence
+    # that states it ("...never a lower bound on the fix's benefit when the
+    # workload is `reduced`; for `increased`, `changed`, or `unknown` the delta
+    # MAY be reported as a floor under the fix's benefit"). So pin the rule's
+    # scope, in its own bullet: it binds to the three confounded states, and to
+    # no other.
+    rule = [
+        b
+        for b in _bullets("### Reporting a confounded workload")
+        if "never a lower bound on the fix's benefit" in b
+    ]
+    assert len(rule) == 1, "the never-a-lower-bound rule is not stated in exactly one bullet"
+    (rule,) = rule
+    for state in ("`increased`", "`changed`", "`unknown`"):
+        assert state in rule, (
+            f"the never-a-lower-bound rule no longer binds to {state}: {rule!r}"
+        )
+    assert "`same`" not in rule and "`reduced`" not in rule, (
+        "the never-a-lower-bound rule has been re-scoped to a state other than "
+        f"the three confounded ones: {rule!r}"
+    )
+
+    # ...and nowhere may the doc GRANT a floor, however the grant is phrased.
+    # This catches the rewrite by meaning rather than by substring: any clause
+    # that permits a delta to be read as a lower bound / floor is out of
+    # contract, whatever verb it uses.
+    granted = [
+        m.group(0)
+        for m in re.finditer(
+            r"(?i)\b(may|can|could|might|is permitted|is allowed|permissible|"
+            r"acceptable)\b[^.;]{0,140}?\b(lower bound|floor)\b",
+            _FLAT,
+        )
+    ]
+    assert not granted, (
+        f"the doc now permits quoting a floor under the fix's benefit: {granted!r}"
+    )
+
     # Pin the actual confound sentence. A `.*`/DOTALL search over the flattened
     # doc for the three state names in order proves nothing: the definition list
     # already names them in that order, so it passed even with the whole
@@ -124,7 +222,23 @@ def test_the_same_work_attribution_gate_is_preserved():
         "it is `same` that unlocks a clean attribution, and every other state "
         "withholds it"
     ) in _FLAT
-    assert "do not headline a clean speedup unless the state is `same`" in _FLAT
+    # Anchored to the end of the sentence: an un-anchored prefix match is
+    # satisfied by "unless the state is `same` or `reduced`", which grants the
+    # clean headline to exactly the state the gate exists to withhold it from.
+    assert "do not headline a clean speedup unless the state is `same`." in _FLAT
+
+    # Independently of the sentence above: no state other than `same` may appear
+    # in any clause that grants the clean attribution, however that clause is
+    # worded or wherever in the doc it is added.
+    granting = re.findall(r"unless the state is ([^.]{0,160})\.", _FLAT)
+    granting += re.findall(r"([^.]{0,80})\bunlocks\b", _FLAT)
+    assert granting, "no attribution-granting clause found to check for exclusivity"
+    for clause in granting:
+        named = {s for s in _STATES if s in clause}
+        assert named == {"`same`"}, (
+            "a state other than `same` appears in an attribution-granting "
+            f"clause: {clause!r} names {sorted(named)}"
+        )
 
 
 # --------------------------------------------------------------------------
@@ -135,6 +249,16 @@ def test_the_same_work_attribution_gate_is_preserved():
 def test_eligibility_binds_to_an_exact_remote_head_sha():
     assert "exact remote head SHA" in _FLAT
     assert "authorized commit/push" in _FLAT
+
+    # Both phrases above occur elsewhere in the doc (the phase-7 placement
+    # section states the trigger condition too), so they survive rewriting the
+    # eligibility item itself to bind to a branch name. Pin the item where it
+    # lives, together with the reason it is a SHA.
+    eligibility = _section("### Eligibility")
+    assert "bound to an **exact remote head SHA**, not a branch name" in eligibility, (
+        "eligibility item 2 no longer binds the fix to an exact remote head SHA"
+    )
+    assert "A branch name is a moving target" in eligibility
 
 
 def test_resume_is_scratch_context_not_a_daemon():
@@ -188,6 +312,37 @@ def test_dispatch_sampling_cannot_drift_off_the_bound_head():
 
 def test_phase_six_checkpoint_is_not_bypassed():
     assert "does not authorize bypassing that checkpoint" in _FLAT
+
+
+def test_locked_decisions_are_pinned_where_the_amendments_implement_them():
+    """`test_locked_decisions_are_unchanged` scans only the Decisions section,
+    so it cannot see a decision moved by amended text elsewhere. These are the
+    two places the amendments implement a locked decision in their own words.
+
+    Decision 4 (automatic, with the cost line disclosed) lives in the trigger
+    contract as "continue automatically"; rewriting that to "ask the user to
+    confirm before continuing" turns an automatic phase into a gated one while
+    the Decisions section still reads as written. Decision 1 (N = 2, adaptive to
+    4) lives in the bootstrap clause as "counts the automatic run among the N";
+    dropping that turns N into N + 1 runs of spend.
+    """
+    trigger = _section("## Trigger and resume contract")
+    assert "continue automatically when those facts become available" in trigger, (
+        "the trigger contract no longer starts phase 7 automatically (Decision 4)"
+    )
+    assert "that is Decision 4's automatic behavior" in trigger
+    for gate in ("ask the user", "confirm before", "await confirmation", "prompt the user"):
+        assert gate not in trigger.lower(), (
+            f"the trigger contract now gates the automatic start on {gate!r} "
+            "(Decision 4 is automatic-with-disclosed-cost)"
+        )
+
+    triggering = _section("## Triggering the runs (Decision 3)")
+    assert "counts the automatic run among the N" in triggering, (
+        "the bootstrap clause no longer counts the automatic branch run toward "
+        "N, which raises the sampling spend Decision 1 locked"
+    )
+    assert "it does not raise or lower N" in triggering
 
 
 # --------------------------------------------------------------------------

--- a/skills/ci-speedup/tests/test_before_after_verification_contract.py
+++ b/skills/ci-speedup/tests/test_before_after_verification_contract.py
@@ -3,8 +3,9 @@
 `references/before-after-verification-spec.md` is an approved *plan*: it is the
 contract a later implementation follows, so its wording is the only thing that
 can regress before any code exists. These are content checks over that doc — the
-prose-change form of a regression test (proposal §9: contract/content checks
-where meaningful, no blanket doc exemption).
+prose-change form of a regression test: a plan whose only artifact is prose still
+gets contract checks over the load-bearing sentences, rather than a blanket
+"documentation is exempt from tests".
 
 Two things are pinned:
 
@@ -12,9 +13,12 @@ Two things are pinned:
    that replace the old universal "less work run" label, the confound rule for
    increased/changed/unknown workload, the trigger/resume contract, the
    gate-migration rule, and the bootstrap clarification.
-2. That those amendments did NOT quietly rewrite any of the six locked
-   decisions. The amendments narrow disclosure; they never move the sampling
-   defaults, the variance threshold, the trigger mechanism, or v1's scope.
+2. That the six locked decisions are still stated, verbatim, in the Decisions
+   section. Note what that pin does and does not buy: it proves the decisions'
+   own WORDING is intact. It cannot detect a decision moved by amended text
+   elsewhere in the file — a term redefined, a precondition added — which is why
+   the amendment sections carry their own pins above and why the doc states that
+   the locked decision governs wherever the two could be read as interacting.
 """
 from __future__ import annotations
 
@@ -46,16 +50,37 @@ def _decisions() -> str:
 
 def test_workload_states_replace_the_universal_less_work_label():
     """Direction is classified only where evidence supports it, across five
-    named states — not collapsed into one "less work run" verdict."""
-    for state in ("`same`", "`reduced`", "`increased`", "`changed`", "`unknown`"):
-        assert state in _FLAT, f"workload state {state} missing from the methodology"
+    named states — not collapsed into one "less work run" verdict.
 
-    # The old label may only survive where the doc says it is being replaced.
-    for line in _SPEC.splitlines():
-        if "less work run" in line:
-            assert "replace" in line.lower(), (
-                "the universal 'less work run' label is still used as a verdict: " + line
-            )
+    Pin each state's DEFINITION, not just its token. The bare tokens also occur
+    in the disclaimer list and the implementation sketch, so a presence check
+    survives deleting the definitions outright — which is the half of the
+    amendment that carries the meaning.
+    """
+    for state, defining_phrase in (
+        ("`same`", "the same jobs/checks and the same units of work are identified"),
+        ("`reduced`", "positive evidence that work present before is absent after"),
+        ("`increased`", "positive evidence of work present after that was not present"),
+        ("`changed`", "differs in identity without a defensible net direction"),
+        ("`unknown`", "the evidence needed to compare workload identity is missing"),
+    ):
+        assert f"**{state}**" in _FLAT, f"workload state {state} is not defined"
+        assert defining_phrase in _FLAT, (
+            f"workload state {state} lost its definition: {defining_phrase!r}"
+        )
+
+    # `unknown` is the floor, so a classifier that guesses is out of contract.
+    assert "`unknown` is the default; a state is only asserted when its evidence exists" in _FLAT
+
+    # The retired label may appear exactly once, in the sentence that retires it.
+    # An earlier form of this check allowed any line containing "replace", which
+    # a sentence like "replace the state with the less work run label" satisfies.
+    assert _FLAT.count("less work run") == 1, (
+        "the retired 'less work run' label appears "
+        f"{_FLAT.count('less work run')} times; it may appear only where the doc "
+        "records that it was replaced"
+    )
+    assert 'This replaces the earlier universal "less work run" label' in _FLAT
 
 
 def test_equal_job_counts_and_sharding_do_not_prove_a_direction():
@@ -67,14 +92,39 @@ def test_confounded_workload_is_never_a_lower_bound():
     """Added or unknown work makes the delta ambiguous in BOTH directions; it
     must never be sold as a floor under the fix's benefit."""
     assert "never a lower bound on the fix's benefit" in _FLAT
-    assert re.search(
-        r"increased.*changed.*unknown", _FLAT, re.IGNORECASE | re.DOTALL
-    ), "the confounded-workload states are not named together"
+
+    # Pin the actual confound sentence. A `.*`/DOTALL search over the flattened
+    # doc for the three state names in order proves nothing: the definition list
+    # already names them in that order, so it passed even with the whole
+    # confounded-reporting rule rewritten away.
+    assert (
+        "For **`increased`**, **`changed`**, or **`unknown`**, report the observed "
+        "timing change *together with the confound*, in the same breath, and stop there."
+    ) in _FLAT, "the confounded-workload reporting rule no longer names its three states"
+
+    # A reduced workload is not a clean speedup either — the delta includes work
+    # that simply did not run.
+    assert "`reduced` is likewise not a clean speedup" in _FLAT
+
+    # The two guards are independent: product code disqualifies attribution even
+    # when the workload state is `same`.
+    assert "guard 1 and guard 2 are independent and both must pass" in _FLAT
 
 
 def test_the_same_work_attribution_gate_is_preserved():
     assert "The same work ran" in _FLAT
     assert "conservative same-work attribution gate" in _FLAT
+
+    # The load-bearing half of the gate is its EXCLUSIVITY: `same` is the only
+    # state that unlocks a clean claim. Asserting the two phrases above still
+    # passes a doc that let `reduced` headline a clean speedup, so pin both the
+    # positive grant and the withholding of every other state.
+    assert 'Only this state permits a clean "same work, faster" attribution' in _FLAT
+    assert (
+        "it is `same` that unlocks a clean attribution, and every other state "
+        "withholds it"
+    ) in _FLAT
+    assert "do not headline a clean speedup unless the state is `same`" in _FLAT
 
 
 # --------------------------------------------------------------------------
@@ -91,10 +141,49 @@ def test_resume_is_scratch_context_not_a_daemon():
     assert "not a background daemon" in _FLAT
     assert "saved scratch context" in _FLAT
 
+    # "Not a daemon" is only honest if the output says so too, and if a session
+    # that is never re-invoked simply stops rather than accruing samples.
+    assert "the output must never imply that something is watching in the background" in _FLAT
+    assert "If no one invokes the skill again, no further samples are ever collected" in _FLAT
+
+    # Where the resume state lives is install-surface relevant: scratch context
+    # inside tracked or installable content would ship to end users.
+    assert (
+        "Runtime context is persisted beside the run's scratch artifacts, outside "
+        "tracked and installable content"
+    ) in _FLAT
+
+
+def test_resume_context_is_bound_to_the_run_it_describes():
+    """Without the binding list, a resumed session cannot tell whether the saved
+    samples belong to the head it is now looking at."""
+    binding = _FLAT[_FLAT.index("### Context binding"):]
+    binding = binding[: binding.index("###", 3)] if "###" in binding[3:] else binding
+    for item in (
+        "repository",
+        'the baseline artifact the "before" came from',
+        "the **fix head SHA**",
+        "workflow / check identity being sampled",
+    ):
+        assert item in binding, f"context binding no longer includes {item!r}"
+
 
 def test_repeat_invocation_does_not_resample():
     assert "must not spend another set of reruns" in _FLAT
     assert "A changed head invalidates in-flight comparison" in _FLAT
+
+    # Reuse must not outrank the kill switch: `0` turns the phase off, so a
+    # saved verdict is not rendered either.
+    assert "`CI_SPEEDUP_VERIFY_RUNS=0` disables phase 7 outright" in _FLAT
+
+
+def test_dispatch_sampling_cannot_drift_off_the_bound_head():
+    """`workflow_dispatch` takes a ref, so it builds whatever the ref points at
+    when it starts — the one sampling path that can silently swap the commit out
+    from under the exact-head binding."""
+    assert "Dispatch takes a ref, not a SHA" in _FLAT
+    assert "discard any sample that does not match" in _FLAT
+    assert "head_sha" in _FLAT, "no instruction to check the dispatched run's head SHA"
 
 
 def test_phase_six_checkpoint_is_not_bypassed():
@@ -108,8 +197,18 @@ def test_phase_six_checkpoint_is_not_bypassed():
 
 def test_after_metric_describes_the_current_gate():
     assert "The after metric must describe the current merge gate" in _FLAT
-    assert "merge-wait change unavailable" in _FLAT
     assert "Do not expand sampling to unrelated workflows" in _FLAT
+
+    # The prohibition itself, not just the escape hatch. Asserting only the
+    # phrases above left the load-bearing "Never" free to become "Always".
+    assert "Never report a former pole's improvement as merge-wait improvement" in _FLAT
+
+    # "unavailable" is stated in two places (the rule and the degradation table);
+    # pin both, so deleting either one is caught.
+    assert _FLAT.count("merge-wait change unavailable") >= 2, (
+        "the merge-wait-unavailable fallback is no longer stated in both the "
+        "gate-migration rule and the degraded-output list"
+    )
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## TL;DR

The post-fix speedup check that ci-speedup plans to run has an approved methodology, and as written it would have let the tool announce a clean win in cases where the branch simply ran different work — including branches that ran *more* work, where the honest answer is that the timing change cannot be separated from the workload change at all. This rewrites that part of the plan so the check can only claim what its evidence supports, and pins down when the check may start, what it is bound to, and which check its number is allowed to describe. **Nothing ships to users here: this is a plan/contract change with no behavior change**, and every one of the plan's six locked design decisions is left exactly as it was.

## What changed in the methodology

### 1. One "less work run" verdict becomes five evidence-backed workload states

The old rule: if the branch's CI ran a different job/test set than the baseline, label the delta "less work run". That asserts a direction — *less* — that the evidence usually does not establish, and it is silent about a branch that ran more work.

The new rule records exactly one of `same`, `reduced`, `increased`, `changed`, `unknown`, with `unknown` as the default and a direction asserted only where workload identity/count evidence exists. Two named traps: equal job counts alone do not prove equal work, and re-sharding a suite alone does not prove coverage was cut (that is `changed`, not `reduced`). The conservative same-work attribution gate is preserved — only `same` unlocks a clean "same work, faster" claim.

### 2. Confounded workload is reported with its confound, never as a floor

For `increased`, `changed`, or `unknown`, the observed timing change is reported together with what differed about the workload — and explicitly **never as a lower bound on the fix's benefit**. "It got faster even though it did more work, so the real win is at least this big" is not supported: added work may be cheap, concurrent, off the critical path, or cache-warming. Product-code changes continue to disallow clean CI-only attribution independently of workload state.

### 3. Trigger and resume contract

```
phase 6 stops at the user checkpoint (uncommitted)
        |
        v  user authorizes commit/push
fix bound to an exact remote head SHA
        |
        v  that head's first CI run completes  ->  sample 1
phase 7 eligible: collect the remaining samples (N locked at 2, adaptive to 4)
        |
        +-- session ends?  -> resume on a LATER invocation from saved scratch
        |                     context. Not a daemon: nothing polls in between.
        +-- invoked again?  -> reuse completed samples + verdict for that head;
        |                     spend no second set of reruns.
        +-- head moved?     -> in-flight comparison invalidated; fresh samples.
```

Eligibility, context binding (repository, baseline artifact, fix head, check identity, run/attempt IDs), and the explicit statement that the phase-6 checkpoint is not bypassed are all written into the doc.

### 4. Gate migration

The after metric must describe the **current** merge gate. Speeding up or removing the slowest check often hands the gate to whatever is now slowest, and the former pole's improvement is then a check-level fact, not a merge-wait improvement. Where a competing workflow or external check cannot be compared on the same after head, the repository merge-wait change is marked unavailable — and sampling is never widened to unrelated workflows to manufacture a number.

### 5. Bootstrap

The completed automatic branch run supplies sample one. Stated because the alternative reading — requiring two pre-existing samples before the component responsible for obtaining sample two may start — deadlocks.

## The six locked decisions are unchanged

Verbatim from the doc's Decisions section, all still present and now pinned by a test:

1. **Default N = 2, adaptive up to 4.**
2. **Variance threshold = 20%** (of the median), overridable via `CI_SPEEDUP_VERIFY_VARIANCE_PCT`.
3. **Trigger via `gh run rerun` (primary), `workflow_dispatch` where declared, never re-push.**
4. **Automatic, with the runner-minute cost disclosed in the same line — not gated.**
5. **Env-configurable, out of user-facing SKILL.md.**
6. **Wall-clock only in v1**; runner-minute before/after is a documented fast-follow.

Where an amendment could be read as touching one — the optional descriptive baseline spread, and the bootstrap's relationship to N — the doc says explicitly that the locked decision governs. The descriptive spread may be shown as historical context only: it must not replace the locked adaptive threshold, become a significance test, or alter sample selection.

## Tests

`skills/ci-speedup/tests/test_before_after_verification_contract.py` is new: it pins the amended vocabulary and rules, and separately pins that the six locked decisions are still stated. Red-first in its contract form — when it was first written, 11 of its 12 checks failed against the unamended doc (it has since grown to 15 checks as the pins were tightened):

```
assert "The after metric must describe the current merge gate" in _FLAT
E   AssertionError
```

The twelfth check (the locked-decision pin) passed before the change and passes after, which is the point: the amendments must not move it.

## Added during review

Two rules this change introduced were left open and are now closed in the same
doc:

- The new exact-remote-head-SHA binding could not be satisfied by the
  `workflow_dispatch` sampling path, which dispatches against a ref and builds
  whatever that ref points at when the run starts — so a follow-up commit could
  silently swap the commit under a sample. Dispatched samples now have their
  `head_sha` checked against the bound fix head and are discarded on a mismatch.
- Repeat-invocation reuse was phrased as an unconditional obligation, which read
  as outranking Decision 5's `CI_SPEEDUP_VERIFY_RUNS=0` escape hatch. The knob
  now explicitly disables the phase outright rather than only its spending.

The trigger paragraph asserted both that the eligibility rules apply and that
the phase cannot be reached today; it now states plainly that they describe what
the implementation must satisfy on the day a push-to-branch step lands.

The contract test was pinning tokens where the meaning lives in sentences. Ten
mutations of the doc that passed the first version of the test now fail it,
including one that let a `reduced` workload headline a clean speedup — the
same-work gate's meaning is its exclusivity, and two phrase checks did not
capture that. A changelog entry that had overwritten the previous entry's dated
heading was also restored.

A spec-conformance pass then found three rules that could still be inverted with
every pin green, because the pin matched a phrase rather than the rule's scope:
the "never a lower bound" rule could be re-scoped to `reduced` while granting a
floor to the three confounded states; the same-work exclusivity sentence could
take " or `reduced`" on the end, since the pin was an unanchored prefix; and the
sentences that implement two locked decisions outside the Decisions section
(Decision 4's automatic start, Decision 1's counting of the automatic run toward
N) plus the head-SHA binding in eligibility item 2 were unpinned where they live.
Each is now pinned against its scope and its section, and each is proven by a
mutation of the doc that the earlier pins passed and the current ones fail. The
doc is unchanged by that pass; the changelog bullet's date was corrected to the
UTC date the branch's commits carry.

A second review pass then found that those pins still asserted meaning through
lists of the words a violation might use — five modal verbs for a granted floor,
four phrases for a confirmation gate, two sentence templates for the clean
headline. A list like that loses to the first wording nobody put on it, and
twenty-three mutations of the doc walked through: "the observed delta serves as
a floor", a two-row table granting the clean headline to a reduced workload,
"start the runs only after the user approves", and — because a section was
located by the first heading with a matching prefix — a planted "superseded"
section carrying the pinned wording, which freed the real one to be rewritten.
Each check is now a closed-world sweep instead: it finds every sentence in the
doc that touches the rule and requires each one to state it or refuse it, and an
ambiguous section heading is itself a failure. All twenty-three mutations now
fail, and the doc still passes. Two pins that reddened on *correct* doc text — a
prohibition read as a permission, a withholding sentence read as a grant — were
fixed in the same pass, along with a refusal-word check that read "whenever" as
"never". Three rules that were stated in the doc but pinned nowhere are now
pinned. The methodology doc is still unchanged; the changelog entry gained the
one amendment it had omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



