### PR TITLE
Show how much each long pole's duration moved across the sampled runs

### DIFF
--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -74,6 +74,13 @@ unversioned and updates by reinstall from `main`.
     reader, and the copy-paste agent prompt, that a 400-second gate was observed
     at 100 seconds. The summary is now withheld in that case and names the
     colliding workflows, instead of showing an unrelated workflow's numbers.
+    It names them by file name rather than full path, caps the list at three
+    with a count of the rest so a monorepo cannot turn the sentence into a
+    path dump, and closes with what to change to get the summary back — rename
+    one job so the check names differ. Workflow file names are repository text,
+    so they take the same escaping route the runner labels above take: a
+    backtick or a leading underscore in a workflow file name can no longer
+    break the formatting of the paragraph it is printed in.
 
 - **2026-09-02** — **A long pole whose job is declared advisory now says so.**
   Nothing in the engine read a job's `continue-on-error` setting, so a job could

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -67,6 +67,13 @@ unversioned and updates by reinstall from `main`.
   constant *in this sample*, explicitly not as proof that future runs will not
   vary. A report produced before this summary existed renders nothing for it
   rather than any invented value.
+  - When the same check name is produced by more than one workflow — a monorepo
+    with copy-pasted `build` jobs — the reported duration is the slowest of them,
+    while the workflow the report links to is only one. Attaching that one
+    workflow's run times under the slowest workflow's headline would tell the
+    reader, and the copy-paste agent prompt, that a 400-second gate was observed
+    at 100 seconds. The summary is now withheld in that case and names the
+    colliding workflows, instead of showing an unrelated workflow's numbers.
 
 - **2026-09-02** — **A long pole whose job is declared advisory now says so.**
   Nothing in the engine read a job's `continue-on-error` setting, so a job could

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -42,6 +42,32 @@ unversioned and updates by reinstall from `main`.
   pending. The sharding and workflow-consolidation entries that split work into
   new check names link to the same explanation.
 
+- **2026-09-08** — **Each long pole now shows how much its duration actually
+  moved across the sampled runs.** The report ranked poles by their median and
+  carried a P95 for the slowest one, and neither number can express spread:
+  twenty runs of 100s and a mix of nine 1s runs with eleven 100s runs have the
+  same median *and* the same P95, so a reader could not tell a rock-steady check
+  apart from one that swings by 99 seconds. Every measured pole now carries a
+  descriptive summary — how many comparable runs were observed, and the fastest,
+  median and slowest of them — re-read from the runs already fetched for the
+  measurement, so it costs no extra GitHub requests and no deeper sampling. The
+  selection matches that pole's own timing basis exactly (same check, same
+  start-to-finish clock, same retained configuration era, same dominant runner,
+  one observation per sampled run or rerun attempt), existing runner populations
+  and fast/slow modes stay identified rather than being blended into one number,
+  and rerun attempts are never counted as separate pull requests. The same
+  sentence appears in the pole section and in that pole's copy-paste agent
+  prompt. It is deliberately a description of what was observed and nothing more:
+  no plus/minus band, no "smallest change you could detect", no "outside the
+  noise" verdict, and no statistical-significance claim — duration spread is not
+  uncertainty in a future speedup — and it never feeds the Bottom line or any
+  savings figure. Degenerate samples are stated honestly: no comparable
+  observations reads as unavailable (never as zero), a lone run reads as "one
+  observed run" and never as a spread, and an unvarying sample is described as
+  constant *in this sample*, explicitly not as proof that future runs will not
+  vary. A report produced before this summary existed renders nothing for it
+  rather than any invented value.
+
 - **2026-09-02** — **A long pole whose job is declared advisory now says so.**
   Nothing in the engine read a job's `continue-on-error` setting, so a job could
   be reported as the slowest check on the pull-request path, and as the dominant

--- a/skills/ci-speedup/references/wall-clock-methodology.md
+++ b/skills/ci-speedup/references/wall-clock-methodology.md
@@ -24,6 +24,7 @@ illustrative figures from real audits, kept to anchor the model.
 - [3. Size every finding on BOTH axes](#3-size-every-finding-on-both-axes)
 - [4. Serial-gate / "consolidate-then-fan-out" findings can be wall-clock-NEGATIVE](#4-serial-gate--consolidate-then-fan-out-findings-can-be-wall-clock-negative)
 - [5. Don't average away the tail](#5-dont-average-away-the-tail)
+- [5a. Observed timing spread is descriptive, never an inference](#5a-observed-timing-spread-is-descriptive-never-an-inference)
 - [6. Reliability is a wall-clock multiplier](#6-reliability-is-a-wall-clock-multiplier)
 - [7. Report structure](#7-report-structure)
 
@@ -227,6 +228,56 @@ eliminating the tail as the headline benefit.
 > (`collect_runs.py` reads logs for the affected jobs) and quote the line(s)
 > that explain the slow run. Without a logged root cause the finding is a
 > probe, not a sized fix.
+
+---
+
+## 5a. Observed timing spread is descriptive, never an inference
+
+Quantiles cannot express how much a check's duration actually *moved*. Twenty
+observations of 100s, and nine observations of 1s plus eleven of 100s, have the
+**same P50 and the same P95 (100s)** — one sample never varies, the other varies
+by 99s. A reader given only the quantiles cannot tell those two repos apart, and
+a "P95 − P50 band" reports zero for both.
+
+So each measured pole also carries a **descriptive timing spread**: the count,
+minimum, median and maximum of its own observations, re-read from the runs the
+sampler already fetched. It costs **no additional GitHub requests and no deeper
+sampling** — it is a second reading of the durations the pole's P50 was already
+computed from.
+
+**Selection must match the pole's own timing basis, exactly.** Same check
+identity, same timing definition (the jobs-API `started_at` → `completed_at`
+span, queue time excluded), same retained configuration era, same dominant-runner
+scope, and the same one-observation-per-sampled-run/attempt policy. A blended
+range would describe a job that never ran. Existing population and mode splits
+are **preserved and named**, not collapsed: two runner populations stay two
+populations, and a bimodal check's fast and slow modes are reported as two modes
+beside the whole-sample range. A rerun attempt is one observation of the check;
+it is never counted as an independent pull request.
+
+**What it must never become.** The spread describes the sample. It is not:
+
+- a symmetric ± band around the median;
+- a "minimum detectable effect" or an "outside noise / within noise" verdict;
+- any claim of statistical significance.
+
+Duration spread is **not** uncertainty in an estimated change. Detectability
+depends on sample size, pairing, comparable populations and a comparison method,
+none of which one observed sample supplies. The spread never enters the
+Bottom-line savings number or any sizing figure; it is context beside the pole,
+rendered identically in the pole section and that pole's agent prompt.
+
+**Honesty rules for degenerate samples.**
+
+| Sample | What the report says |
+| --- | --- |
+| No comparable observations | **unavailable**, with the reason — never `0s`, never an empty range |
+| Exactly one | "one observed run" — a single observation, explicitly *not* a spread |
+| All identical | "constant in this sample", with the explicit note that this is **not** proof future runs do not vary |
+| A different population backs the pole's aggregate | **unavailable** — never attach another population's durations |
+
+An artifact produced before this summary existed simply renders nothing for it.
+A missing summary is never rendered as a value.
 
 ---
 

--- a/skills/ci-speedup/references/wall-clock-methodology.md
+++ b/skills/ci-speedup/references/wall-clock-methodology.md
@@ -250,9 +250,10 @@ identity, same timing definition (the jobs-API `started_at` → `completed_at`
 span, queue time excluded), same retained configuration era, same dominant-runner
 scope, and the same one-observation-per-sampled-run/attempt policy. A blended
 range would describe a job that never ran. Existing population and mode splits
-are **preserved and named**, not collapsed: two runner populations stay two
-populations, and a bimodal check's fast and slow modes are reported as two modes
-beside the whole-sample range. A rerun attempt is one observation of the check;
+are **preserved and named**, not collapsed: the range covers the pole's own
+runner population only and any other runner the check also ran on is named as a
+separate population rather than silently folded in, and a bimodal check's fast
+and slow modes are reported as two modes beside the whole-sample range. A rerun attempt is one observation of the check;
 it is never counted as an independent pull request.
 
 **What it must never become.** The spread describes the sample. It is not:

--- a/skills/ci-speedup/scripts/blocking_path.py
+++ b/skills/ci-speedup/scripts/blocking_path.py
@@ -3350,6 +3350,13 @@ def _llm_agent_prompt(body: str, pole: dict[str, Any] | None = None) -> str:
     _adv = _advisory_prompt_lines(_as_dict(pole))
     if _adv and "continue-on-error: true" not in body:
         body = _adv[0].lstrip("- ") + "\n\n" + body
+    # The observed timing spread, for the same reason: this body is LLM-authored, so the
+    # gap-fill hand-off gets the SAME sentence the pole section shows rather than the
+    # model's own account of how much the check varies. Idempotent - a body that already
+    # quoted the report's sentence is not doubled.
+    _ts = _timing_spread_sentence(_as_dict(pole))
+    if _ts and _ts not in body:
+        body = _ts + "\n\n" + body
     # The no-weakening rail is the renderer's too, for the same reason the disclaimer
     # is: the gap-fill body is LLM-authored, so the one rule the hand-off cannot afford
     # to have paraphrased away is appended here, not left to the author. The canonical

--- a/skills/ci-speedup/scripts/blocking_path.py
+++ b/skills/ci-speedup/scripts/blocking_path.py
@@ -2884,6 +2884,78 @@ def _pole_gate_prompt_claim(check: str, wf: str, dur: str, gate_count: int, npop
     return cs.add(_claim) if cs is not None else _claim.rendered
 
 
+# --- Descriptive timing spread (workstream C) --------------------------------------
+# ONE sentence, built once and rendered in BOTH the pole section and that pole's agent
+# prompt, so the report and the hand-off can never disagree about what was observed.
+#
+# It DESCRIBES the observed sample. It is not a +/- band, not a minimum detectable effect,
+# not an "outside noise" verdict and not a significance claim - duration spread is not
+# uncertainty in an estimated change - and it never enters the Bottom line or any savings
+# figure. A legacy artifact with no stamped summary (or one stamped by a future producer
+# version) renders NOTHING rather than a fabricated value.
+_TIMING_SPREAD_VERSION = 1
+
+
+def _timing_spread_sentence(pole: dict[str, Any]) -> str:
+    """The pole's descriptive-spread sentence, or '' when there is nothing honest to say."""
+    ts = pole.get("timing_spread")
+    if not isinstance(ts, dict) or ts.get("version") != _TIMING_SPREAD_VERSION:
+        return ""
+    cov = str(ts.get("coverage") or "")
+    sel = ts.get("selection") or {}
+    n = int(ts.get("n") or 0)
+    if cov == "unavailable":
+        why = str(ts.get("unavailable_reason") or "no comparable observations were retained")
+        return f"Observed duration spread unavailable for this check: {why}."
+    lo, med, hi = (_num(ts.get("min_s")), _num(ts.get("median_s")), _num(ts.get("max_s")))
+    if lo is None or med is None or hi is None:
+        return ""
+    if cov == "single_observation":
+        head = (f"One observed run at {_clock(med)} - a single observation, "
+                "not a spread.")
+    elif cov == "constant_in_sample":
+        head = (f"Across {n} comparable sampled runs this check took {_clock(med)} every "
+                "time - constant in this sample. That describes these runs only; it is "
+                "not proof that future runs do not vary.")
+    else:
+        head = (f"Across {n} comparable sampled runs this check took {_clock(lo)} to "
+                f"{_clock(hi)} (median {_clock(med)}). That describes the observed "
+                "sample, not uncertainty in a future speedup.")
+    parts = [head]
+    scope = str(sel.get("runner_scope") or "")
+    others = [str(x) for x in (ts.get("other_runner_labels") or [])]
+    if scope and scope != "all-runners" and others:
+        parts.append(f"Measured on `{scope}` runs only; runs on {', '.join(others)} are a "
+                     "separate population and are not folded into this range.")
+    era = str(sel.get("config_era") or "")
+    if era and era != "all_sampled":
+        parts.append(f"Scoped to the `{era}`-change configuration era, the era this "
+                     "workflow's sample was narrowed to.")
+    modes = ts.get("modes")
+    if isinstance(modes, list) and len(modes) == 2:
+        f_m, s_m = modes[0], modes[1]
+        parts.append(
+            f"Two modes in this sample, kept separate: {f_m.get('n')} run(s) from "
+            f"{_clock(_num(f_m.get('min_s')))} to {_clock(_num(f_m.get('max_s')))} and "
+            f"{s_m.get('n')} run(s) from {_clock(_num(s_m.get('min_s')))} to "
+            f"{_clock(_num(s_m.get('max_s')))}.")
+    return " ".join(parts)
+
+
+def _timing_spread_report_lines(pole: dict[str, Any]) -> list[str]:
+    """The pole-section rendering of the sentence above (italic prose, then a blank)."""
+    s = _timing_spread_sentence(pole)
+    return [f"_{s}_", ""] if s else []
+
+
+def _timing_spread_prompt_lines(pole: dict[str, Any]) -> list[str]:
+    """The SAME sentence as a THE GATE bullet in that pole's agent prompt. The prompt is
+    built to be pasted on its own, so a fact the report gives the reader reaches the agent
+    only if it is repeated here - and it must be the identical sentence, not a paraphrase."""
+    s = _timing_spread_sentence(pole)
+    return [f"- {s}"] if s else []
+
+
 def _advisory_prompt_lines(pole: dict[str, Any]) -> list[str]:
     """The advisory-job bullet for the agent prompt's THE GATE section, or `[]`.
 
@@ -2948,6 +3020,7 @@ def _build_agent_prompt(leaf: dict[str, Any] | None, pole: dict[str, Any],
            f"- Workflow `{wf}`, job `{check}`.",
            f"- {gate}",
            *_advisory_prompt_lines(pole),
+           *_timing_spread_prompt_lines(pole),
            ""]
 
     _bi = pole.get("bimodal")
@@ -3063,6 +3136,7 @@ def _build_generic_agent_prompt(pole: dict[str, Any],
             f"- Workflow `{wf}`, check `{check}`.",
             f"- {gate}",
             *_advisory_prompt_lines(pole),
+            *_timing_spread_prompt_lines(pole),
             "",
             "WHAT IS MISSING",
             f"- {reason}" if reason else (
@@ -3103,6 +3177,7 @@ def _build_generic_agent_prompt(pole: dict[str, Any],
            f"- Workflow `{wf}`, job `{check}`.",
            f"- {gate}",
            *_advisory_prompt_lines(pole),
+           *_timing_spread_prompt_lines(pole),
            ""]
     wtg = ["WHERE THE TIME GOES" + (f" (representative run {rid})" if rid else "")]
     pole_dom = str(pole.get("dominant_step") or "")
@@ -9014,6 +9089,13 @@ def render(doc: dict[str, Any], logs: dict[str, str] | None = None,
             out += [_LEAF_CROWN_MARKER.format(fk=str(leaf.get("fix_key", ""))), ""]
         if bi_caveat:
             out += [bi_caveat, ""]
+        # What the sampled runs actually DID - the observed min/median/max of this pole's
+        # own retained observations. Sits with the other qualifiers of the header duration,
+        # above the drill: it says how much the number above moved across the sample. It
+        # asserts no derived quantity and no framing-vocabulary phrase, so like the
+        # advisory line it is plain prose rather than a `Claim` - and it feeds nothing
+        # downstream (never the Bottom line, never a saving).
+        out += _timing_spread_report_lines(p)
         if _agg:
             # AGGREGATION GATE (issue #1): the section ENDS at the honest pointer. No
             # per-step drill and no "capture timing, then optimize this step" agent prompt

--- a/skills/ci-speedup/scripts/blocking_path.py
+++ b/skills/ci-speedup/scripts/blocking_path.py
@@ -2925,7 +2925,13 @@ def _timing_spread_sentence(pole: dict[str, Any]) -> str:
     scope = str(sel.get("runner_scope") or "")
     others = [str(x) for x in (ts.get("other_runner_labels") or [])]
     if scope and scope != "all-runners" and others:
-        parts.append(f"Measured on `{scope}` runs only; runs on {', '.join(others)} are a "
+        # Runner labels are REPO-CONTROLLED text off the jobs-API payload, so both the
+        # scope name and the other-population labels are markdown sinks: `_safe_span` (the
+        # route every other repo-text sink in this renderer takes) maps each backtick to an
+        # apostrophe and wraps, so a label can neither close its own span early nor render
+        # as emphasis. Byte-identical for a clean label.
+        parts.append(f"Measured on {_safe_span(scope)} runs only; runs on "
+                     f"{', '.join(_safe_span(o) for o in others)} are a "
                      "separate population and are not folded into this range.")
     era = str(sel.get("config_era") or "")
     if era and era != "all_sampled":

--- a/skills/ci-speedup/scripts/blocking_path.py
+++ b/skills/ci-speedup/scripts/blocking_path.py
@@ -2930,7 +2930,12 @@ def _timing_spread_sentence(pole: dict[str, Any]) -> str:
         # route every other repo-text sink in this renderer takes) maps each backtick to an
         # apostrophe and wraps, so a label can neither close its own span early nor render
         # as emphasis. Byte-identical for a clean label.
-        parts.append(f"Measured on {_safe_span(scope)} runs only; runs on "
+        # `?` is the internal placeholder for "the payload carried no runner label" - a
+        # real population (the pole's p50 is computed on it), but never a runner name to
+        # show a reader, so it is described rather than printed.
+        _where = ("runs whose payload named no runner" if scope == "?"
+                  else f"{_safe_span(scope)} runs")
+        parts.append(f"Measured on {_where} only; runs on "
                      f"{', '.join(_safe_span(o) for o in others)} are a "
                      "separate population and are not folded into this range.")
     era = str(sel.get("config_era") or "")

--- a/skills/ci-speedup/scripts/collect_runs.py
+++ b/skills/ci-speedup/scripts/collect_runs.py
@@ -4495,14 +4495,46 @@ def _pole_timing_spread(check: str, workflow_file: str, job: str,
                         crit_by_wf: dict[str, Any],
                         jobs_per_run_by_wf: dict[str, list[list[dict[str, Any]]]],
                         config_era_facts: list[dict[str, Any]],
-                        *, unavailable: str = "") -> dict[str, Any]:
+                        *, unavailable: str = "",
+                        mapping_pinned: bool = False) -> dict[str, Any]:
     """Resolve ONE pole's descriptive summary from the pass's retained state.
 
     Every input is already in memory: `jobs_per_run_by_wf[wf]` is the exact retained
     per-run job list `_critical_path` measured this workflow from (era-scoped by the spine
     door and event-scoped by `_crit_for` upstream), and `crit_by_wf[wf]["job_runner"]`
     names the runner its p50 was computed on. No gh request is issued here, directly or
-    indirectly — the summary is a re-reading of data the pass already paid for."""
+    indirectly — the summary is a re-reading of data the pass already paid for.
+
+    THE (workflow, job) MUST BE THE POLE'S TIMING ANCHOR, not merely a file the pole was
+    bound to. `timing_source == "workflow_jobs"` does NOT prove it is: that stamp is also
+    worn by the AMBIGUITY-grounded branch, where `_map_check_to_job` refused a
+    cross-workflow same-name collision and `_check_grounded_job_p50` supplied the MAX p50
+    across every colliding workflow. `_pole_mapping` then falls through to
+    `_check_to_job_node_scanned`, which resolves ONE workflow whenever the scanned graph is
+    unambiguous even though the timing mapper was not — so the pole can headline b.yml's
+    400s while this function is handed a.yml, whose retained durations sit near 100s. That
+    is exactly the "aggregate uses a different population from the available durations"
+    case, and the summary is marked UNAVAILABLE (naming the collision) rather than
+    attaching the scanned-graph fallback's unrelated statistics. A caller-supplied PIN
+    (`mapping_pinned`, the PR-floor fallback) is its OWN anchor: its p50 is read straight
+    off THAT workflow's critical path, so the pinned workflow's durations do share its
+    basis."""
+    if not unavailable and workflow_file and not mapping_pinned:
+        if _map_check_to_job(check, crit_by_wf,
+                             require_developer_timing=True) != (workflow_file, job):
+            producing = sorted(_check_producing_workflows(
+                check, crit_by_wf, require_developer_timing=True))
+            if len(producing) > 1:
+                unavailable = (
+                    f"this check's name is produced by {len(producing)} workflows "
+                    f"({', '.join(producing)}), so its duration was measured as the "
+                    "slowest of them while these durations come from one — no single "
+                    "workflow's retained job durations share its timing basis")
+            else:
+                unavailable = (
+                    "this check's workflow was resolved from the scanned job graph, not "
+                    "from the sampled timing that produced its duration, so no retained "
+                    "job durations are known to share its timing basis")
     crit = crit_by_wf.get(workflow_file) or {}
     runner_scope = str((crit.get("job_runner") or {}).get(job) or "")
     # The kept configuration era for this workflow, when its sample straddled a change to
@@ -15127,6 +15159,7 @@ def collect(findings_doc: dict[str, Any], repo: str | None,
         # `mapping` lets a caller pin the (workflow_file, job) directly — used by the
         # PR-floor fallback, whose "check" IS a job name and must bind to ITS workflow,
         # not whichever workflow `_map_check_to_job` happens to resolve a same-named job in.
+        _pinned = mapping is not None
         mapping = _pole_mapping(check_name, crit_by_wf, mapping,
                                 findings_doc.get("workflow_job_graph"),
                                 require_developer_timing=True)
@@ -15143,7 +15176,10 @@ def collect(findings_doc: dict[str, Any], repo: str | None,
                 config_era_facts,
                 unavailable=("" if timing_source == "workflow_jobs" else
                              "this check's duration was measured from PR check-runs, so "
-                             "no sampled workflow-job durations share its timing basis"))
+                             "no sampled workflow-job durations share its timing basis"),
+                # A pinned mapping IS the pole's timing anchor; an unpinned one is only
+                # the anchor when the TIMING mapper resolved it (checked inside).
+                mapping_pinned=_pinned)
             if timing_source != "workflow_jobs":
                 entry["job_timing_unavailable"] = (
                     "PR check-run timing was measured, but no sampled workflow job "

--- a/skills/ci-speedup/scripts/collect_runs.py
+++ b/skills/ci-speedup/scripts/collect_runs.py
@@ -4402,7 +4402,13 @@ def _timing_spread(observations: list[dict[str, Any]], *,
         return {**base, "n": 0, "coverage": "unavailable",
                 "unavailable_reason": unavailable}
 
-    scoped = runner_scope if runner_scope and runner_scope != "?" else ""
+    # `?` is `_critical_path`'s name for "these payloads carried no runner label", and it
+    # scopes the pole's own p50 to exactly that group - so it is a population like any
+    # other, not an absent scope. Treating it as absent disabled the filter and folded
+    # every other runner into the range, which both extends the range past the runs the
+    # headline was computed from and lets a RUNNER split re-surface as a fast/slow mode
+    # split. Only a genuinely unset scope (no `job_runner` entry) means all-runners.
+    scoped = runner_scope or ""
     seen: set[tuple[Any, ...]] = set()
     kept: list[tuple[Any, float]] = []
     other_runners: set[str] = set()

--- a/skills/ci-speedup/scripts/collect_runs.py
+++ b/skills/ci-speedup/scripts/collect_runs.py
@@ -4318,6 +4318,194 @@ def _bimodal_split(durs: list[float], *, min_n: int = 8, min_frac: float = 0.30,
             "low_p50_s": round(lo_med, 1), "high_p50_s": round(hi_med, 1)}
 
 
+# =============================================================================
+# Descriptive timing spread (workstream C)
+# =============================================================================
+#
+# WHY. A pole's p50 (and the long pole's p95) cannot express how much its duration
+# actually MOVED across the sampled runs. The exact counterexample: twenty observations
+# of 100s, and nine of 1s plus eleven of 100s, both give p50 = p95 = 100s under
+# `_percentile`. One sample never varies; the other varies by 99s. The reader cannot tell
+# them apart from the quantiles alone.
+#
+# WHAT THIS IS. A DESCRIPTION of the observations the sampler already fetched — `n`, the
+# minimum, the median and the maximum, plus the identifiers that say WHICH observations
+# they are. It reads no new data: every duration comes from `jobs_per_run_by_wf`, the same
+# retained per-run job lists `_critical_path` measured the pole's p50 from, so the summary
+# costs ZERO additional gh requests and no deeper sampling.
+#
+# WHAT THIS IS NOT. It is not a symmetric +/- band, not a minimum detectable effect, not an
+# "outside noise" verdict, and not any statistical-significance claim. Duration spread is
+# not uncertainty in an estimated change: detectability depends on sample size, pairing,
+# comparable populations and a comparison method, none of which a single sample supplies.
+# It never enters the Bottom-line savings number — the sizing cascade is untouched.
+_TIMING_SPREAD_VERSION = 1
+# The timing DEFINITION, named so a reader (and the verifier) can tell this range is the
+# same clock the pole's p50 is measured on — the jobs-API `started_at` -> `completed_at`
+# span (`_job_duration_s`), which excludes queue time.
+_TIMING_SPREAD_BASIS = "job_started_at_to_completed_at"
+# One eligible observation per sampler-selected run/attempt. A rerun attempt IS a distinct
+# execution and is counted as one observation; it is NEVER described as an independent PR.
+_TIMING_SPREAD_ATTEMPT_POLICY = "one_observation_per_sampler_selected_run_attempt"
+# The population the range describes: the pole's OWN dominant runner, the same per-job
+# runner scoping `_critical_path` computes its p50 on. Heterogeneous-runner repos are not
+# blended into one repo-wide variability statement.
+_TIMING_SPREAD_POPULATION = "pole_dominant_runner_sampled_runs"
+# Sample-id cap. The list exists so the summary is re-derivable from named executions, not
+# so the artifact carries an unbounded id dump; the sampler's window is far below this, so
+# the cap is inert in practice and disclosed (`sample_ids_truncated`) if it ever fires.
+_TIMING_SPREAD_MAX_SAMPLE_IDS = 60
+
+
+def _job_observation_key(job: dict[str, Any]) -> tuple[Any, ...]:
+    """Identity of ONE job execution, for de-duplication. The jobs-API `id` is unique per
+    execution (a rerun attempt gets its own id), so it is the key when present; the
+    (run, attempt, name) triple is the fallback for a payload that carries no id."""
+    jid = job.get("id")
+    if jid not in (None, ""):
+        return ("id", jid)
+    return ("run", job.get("run_id"), job.get("run_attempt"), str(job.get("name", "")))
+
+
+def _timing_spread(observations: list[dict[str, Any]], *,
+                   check: str, workflow_file: str, job: str,
+                   runner_scope: str, config_era: str,
+                   unavailable: str = "") -> dict[str, Any]:
+    """The versioned descriptive summary for ONE pole, over ALREADY-FETCHED job payloads.
+
+    `observations` is the pole's retained job executions (every run in the workflow's
+    kept sample, filtered to the pole's job name by the caller). Selection here mirrors
+    the pole's own timing basis exactly: the `_job_duration_s` clock, the dominant-runner
+    scope, and one observation per distinct execution.
+
+    Coverage is one of:
+      unavailable          - no comparable observation (or the pole's aggregate uses a
+                             different population). NEVER rendered as a zero.
+      single_observation   - exactly one. Described as "one observed run", never a spread.
+      constant_in_sample   - every observation identical. Described as constant IN THIS
+                             SAMPLE; it is never proof that future runs do not vary.
+      observed_spread      - a real min..max range.
+    """
+    sel = {"check": check or "?",
+           "workflow_file": workflow_file or "?",
+           "job": job or "?",
+           "runner_scope": runner_scope or "all-runners",
+           "config_era": config_era or "all_sampled",
+           "attempt_policy": _TIMING_SPREAD_ATTEMPT_POLICY,
+           "population": _TIMING_SPREAD_POPULATION}
+    base: dict[str, Any] = {"version": _TIMING_SPREAD_VERSION,
+                            "basis": _TIMING_SPREAD_BASIS,
+                            "selection": sel}
+    if unavailable:
+        # NO min/median/max keys at all — an unmeasured pole must not be able to render a
+        # fabricated number, and a missing key cannot be misread as 0.0.
+        return {**base, "n": 0, "coverage": "unavailable",
+                "unavailable_reason": unavailable}
+
+    scoped = runner_scope if runner_scope and runner_scope != "?" else ""
+    seen: set[tuple[Any, ...]] = set()
+    kept: list[tuple[Any, float]] = []
+    other_runners: set[str] = set()
+    dup = no_dur = 0
+    for j in observations:
+        label = _job_runner_label(j) or "?"
+        if scoped and label != scoped:
+            other_runners.add(label)
+            continue
+        key = _job_observation_key(j)
+        if key in seen:
+            dup += 1
+            continue
+        d = _job_duration_s(j)
+        if (j.get("conclusion") or "").lower() == "skipped" or d is None or d <= 0:
+            # A skipped job ran no work and an unparseable span is UNKNOWN, not zero
+            # seconds. Both are excluded and counted, never folded into the range.
+            no_dur += 1
+            seen.add(key)
+            continue
+        seen.add(key)
+        jid = j.get("id")
+        sid = (str(jid) if jid not in (None, "")
+               else f"run{j.get('run_id')}#attempt{j.get('run_attempt')}")
+        kept.append((sid, d))
+
+    excluded = {"duplicate": dup, "no_duration": no_dur,
+                "other_runner": sum(1 for j in observations
+                                    if scoped and (_job_runner_label(j) or "?") != scoped)}
+    extra: dict[str, Any] = {"excluded": excluded}
+    if other_runners:
+        # Named, not silently dropped: the range describes ONE runner population, and the
+        # reader is told which other populations exist rather than being left to assume
+        # the check has only ever run here.
+        extra["other_runner_labels"] = sorted(other_runners)
+
+    n = len(kept)
+    if n == 0:
+        return {**base, **extra, "n": 0, "coverage": "unavailable",
+                "unavailable_reason": (
+                    "no comparable job durations were retained for this check on its "
+                    "measured runner population")}
+
+    vals = [d for _k, d in kept]
+    ids = [str(k) for k, _d in kept][:_TIMING_SPREAD_MAX_SAMPLE_IDS]
+    out: dict[str, Any] = {
+        **base, **extra,
+        "n": n,
+        "min_s": round(min(vals), 1),
+        # The SAME `_percentile` the pole's own p50 uses, so the summary's median and the
+        # pole's headline can never disagree about the middle of the sample.
+        "median_s": round(_percentile(vals, 50), 1),
+        "max_s": round(max(vals), 1),
+        "sample_ids": ids,
+        "coverage": ("single_observation" if n == 1
+                     else "constant_in_sample" if min(vals) == max(vals)
+                     else "observed_spread"),
+    }
+    if len(ids) < n:
+        out["sample_ids_truncated"] = True
+    # Existing mode split, PRESERVED and identified. `_bimodal_split` is the engine's own
+    # bimodality definition (largest-gap split, both clusters substantial and separated),
+    # so a pole's `bimodal` stamp and this summary can never disagree about whether the
+    # sample has two modes. Reported alongside the whole-sample range so fast and slow
+    # modes are identified rather than collapsed into one variability statement.
+    if _bimodal_split(vals) is not None:
+        srt = sorted(vals)
+        split = max(range(1, len(srt)), key=lambda i: srt[i] - srt[i - 1])
+        out["modes"] = [
+            {"mode": label, "n": len(part),
+             "min_s": round(min(part), 1),
+             "median_s": round(_percentile(part, 50), 1),
+             "max_s": round(max(part), 1)}
+            for label, part in (("fast", srt[:split]), ("slow", srt[split:]))]
+    return out
+
+
+def _pole_timing_spread(check: str, workflow_file: str, job: str,
+                        crit_by_wf: dict[str, Any],
+                        jobs_per_run_by_wf: dict[str, list[list[dict[str, Any]]]],
+                        config_era_facts: list[dict[str, Any]],
+                        *, unavailable: str = "") -> dict[str, Any]:
+    """Resolve ONE pole's descriptive summary from the pass's retained state.
+
+    Every input is already in memory: `jobs_per_run_by_wf[wf]` is the exact retained
+    per-run job list `_critical_path` measured this workflow from (era-scoped by the spine
+    door and event-scoped by `_crit_for` upstream), and `crit_by_wf[wf]["job_runner"]`
+    names the runner its p50 was computed on. No gh request is issued here, directly or
+    indirectly — the summary is a re-reading of data the pass already paid for."""
+    crit = crit_by_wf.get(workflow_file) or {}
+    runner_scope = str((crit.get("job_runner") or {}).get(job) or "")
+    # The kept configuration era for this workflow, when its sample straddled a change to
+    # it. Named so the range is never read as describing the current configuration when
+    # the spine door retained the other era's runs.
+    era = next((str(f.get("kept_era") or "") for f in (config_era_facts or [])
+                if str(f.get("workflow_file") or "") == workflow_file), "")
+    observations = [j for run in (jobs_per_run_by_wf.get(workflow_file) or [])
+                    for j in run if str(j.get("name", "")) == job]
+    return _timing_spread(observations, check=check, workflow_file=workflow_file,
+                          job=job, runner_scope=runner_scope, config_era=era,
+                          unavailable=unavailable)
+
+
 def _critical_path(jobs_per_run: list[list[dict[str, Any]]]) -> dict[str, Any]:
     """For each job name, compute p50 ON THAT JOB'S OWN DOMINANT RUNNER, then
     long pole = max p50; floor = second-tallest. The model holds when
@@ -14935,6 +15123,16 @@ def collect(findings_doc: dict[str, Any], repo: str | None,
             wf_path, job_name = mapping
             entry["workflow_file"] = wf_path
             entry["job"] = job_name
+            # Descriptive timing spread (workstream C): re-read of the observations this
+            # pass already fetched, on this pole's OWN timing basis. Stamped before the
+            # step-drill early-return below so a pole whose step drill is withheld still
+            # carries an honest coverage status rather than nothing.
+            entry["timing_spread"] = _pole_timing_spread(
+                check_name, wf_path, job_name, crit_by_wf, jobs_per_run_by_wf,
+                config_era_facts,
+                unavailable=("" if timing_source == "workflow_jobs" else
+                             "this check's duration was measured from PR check-runs, so "
+                             "no sampled workflow-job durations share its timing basis"))
             if timing_source != "workflow_jobs":
                 entry["job_timing_unavailable"] = (
                     "PR check-run timing was measured, but no sampled workflow job "
@@ -14980,6 +15178,13 @@ def collect(findings_doc: dict[str, Any], repo: str | None,
                 check_name, crit_by_wf, require_developer_timing=True)
             if len(producing) > 1:
                 entry["ambiguous_workflows"] = sorted(producing)
+            # No single sampled workflow job backs this check (fileless/managed, or
+            # produced by more than one workflow), so no retained duration sample shares
+            # its timing basis. UNAVAILABLE — never some other population's durations.
+            entry["timing_spread"] = _pole_timing_spread(
+                check_name, "", "", crit_by_wf, jobs_per_run_by_wf, config_era_facts,
+                unavailable=("this check maps to no single sampled workflow job, so no "
+                             "retained job durations share its timing basis"))
         return entry
 
     for check_name, check_p50 in _structural_pole_candidates(

--- a/skills/ci-speedup/scripts/collect_runs.py
+++ b/skills/ci-speedup/scripts/collect_runs.py
@@ -4458,8 +4458,11 @@ def _timing_spread(observations: list[dict[str, Any]], *,
         **base, **extra,
         "n": n,
         "min_s": round(min(vals), 1),
-        # The SAME `_percentile` the pole's own p50 uses, so the summary's median and the
-        # pole's headline can never disagree about the middle of the sample.
+        # The SAME `_percentile` estimator the pole's own p50 uses, over this summary's own
+        # selection. Not an identity claim on the two numbers: the selection here also drops
+        # skipped and undated executions and de-duplicates by job id, which the headline's
+        # own list does not, so the two can differ on a sample containing those - by this
+        # summary being the stricter of the pair, never by using a different definition.
         "median_s": round(_percentile(vals, 50), 1),
         "max_s": round(max(vals), 1),
         "sample_ids": ids,
@@ -4471,8 +4474,10 @@ def _timing_spread(observations: list[dict[str, Any]], *,
         out["sample_ids_truncated"] = True
     # Existing mode split, PRESERVED and identified. `_bimodal_split` is the engine's own
     # bimodality definition (largest-gap split, both clusters substantial and separated),
-    # so a pole's `bimodal` stamp and this summary can never disagree about whether the
-    # sample has two modes. Reported alongside the whole-sample range so fast and slow
+    # so this summary never invents a second notion of "bimodal". It is applied to this
+    # summary's own selection, which is not always the list a pole's `bimodal` stamp was
+    # taken over, so the two can differ on which samples qualify - by selection, never by
+    # definition. Reported alongside the whole-sample range so fast and slow
     # modes are identified rather than collapsed into one variability statement.
     if _bimodal_split(vals) is not None:
         srt = sorted(vals)

--- a/skills/ci-speedup/scripts/collect_runs.py
+++ b/skills/ci-speedup/scripts/collect_runs.py
@@ -4460,8 +4460,8 @@ def _timing_spread(observations: list[dict[str, Any]], *,
         "min_s": round(min(vals), 1),
         # The SAME `_percentile` estimator the pole's own p50 uses, over this summary's own
         # selection. Not an identity claim on the two numbers: the selection here also drops
-        # skipped and undated executions and de-duplicates by job id, which the headline's
-        # own list does not, so the two can differ on a sample containing those - by this
+        # skipped executions and de-duplicates by job id, which the headline's own list
+        # does not, so the two can differ on a sample containing those - by this
         # summary being the stricter of the pair, never by using a different definition.
         "median_s": round(_percentile(vals, 50), 1),
         "max_s": round(max(vals), 1),
@@ -4489,6 +4489,30 @@ def _timing_spread(observations: list[dict[str, Any]], *,
              "max_s": round(max(part), 1)}
             for label, part in (("fast", srt[:split]), ("slow", srt[split:]))]
     return out
+
+
+_COLLISION_WORKFLOWS_NAMED = 3
+
+
+def _safe_workflow_names(paths: list[str], cap: int = _COLLISION_WORKFLOWS_NAMED) -> str:
+    """Workflow file paths, rendered for a sentence a Markdown report prints.
+
+    Two properties, both borrowed rather than invented. BASENAMES, like the sibling
+    collision disclosure in `summary.py` — a repeated `.github/workflows/` prefix is noise,
+    and the file is what the reader recognises. And each one through `blocking_path`'s
+    `_safe_span`, because a workflow path is REPOSITORY-CONTROLLED text landing in a
+    Markdown sink: a backtick in a filename would close a code span early and render the
+    rest of the pole's paragraph as code, and a leading `_` (`_shared.yml`, the usual
+    reusable-workflow convention) would break the italic wrapper the report adds. That is
+    the same sink class as the runner labels this renderer already escapes.
+
+    BOUNDED at `cap`: a monorepo can produce one check name from a dozen workflows, and one
+    sentence enumerating a dozen paths is not a sentence anyone reads. The count is always
+    stated in full by the caller, so nothing is hidden — only the tail is summarised."""
+    import blocking_path as bp  # same-skill module; local import mirrors other call sites
+    shown = [bp._safe_span(Path(str(p)).name) for p in paths[:cap]]
+    rest = len(paths) - len(shown)
+    return ", ".join(shown) + (f" and {rest} more" if rest > 0 else "")
 
 
 def _pole_timing_spread(check: str, workflow_file: str, job: str,
@@ -4527,10 +4551,20 @@ def _pole_timing_spread(check: str, workflow_file: str, job: str,
             if len(producing) > 1:
                 unavailable = (
                     f"this check's name is produced by {len(producing)} workflows "
-                    f"({', '.join(producing)}), so its duration was measured as the "
-                    "slowest of them while these durations come from one — no single "
-                    "workflow's retained job durations share its timing basis")
+                    f"({_safe_workflow_names(producing)}), so its duration was measured "
+                    "as the slowest of them while these durations come from one — no "
+                    "single workflow's retained job durations share its timing basis. "
+                    # No trailing period: every `unavailable_reason` is rendered as the
+                    # tail of a sentence the renderer terminates itself.
+                    "Rename one job (or its matrix leg) so the check names differ, then "
+                    "re-run to get this check's own observed spread")
             else:
+                # NOT the "exactly one producer" case, which cannot reach here: on the
+                # unpinned path `_pole_mapping` returns `_map_check_to_job`'s answer
+                # whenever it is non-None, so a mismatch means that mapper returned None,
+                # and a single producer would have resolved it. The live case is ZERO
+                # producers — the file came from `_check_to_job_node_scanned` because the
+                # workflow was triage-skipped and has no retained timing at all.
                 unavailable = (
                     "this check's workflow was resolved from the scanned job graph, not "
                     "from the sampled timing that produced its duration, so no retained "

--- a/skills/ci-speedup/tests/test_timing_spread.py
+++ b/skills/ci-speedup/tests/test_timing_spread.py
@@ -216,28 +216,31 @@ def test_mode_split_is_identified_not_collapsed_into_one_variability_statement()
     assert modes[0]["max_s"] == 30.0 and modes[1]["min_s"] == 600.0
     # The mode split re-uses the engine's OWN bimodality definition (`_bimodal_split`), so
     # the summary never invents a second notion of "bimodal". It is applied to this
-    # summary's own selection, though — which drops skipped and undated executions and
-    # de-duplicates by job id where `_critical_path` does not — so on a sample containing
-    # those the summary and the pole's `bimodal` stamp CAN disagree about which samples
-    # qualify. By selection, never by definition.
+    # summary's own selection, though — which drops skipped executions and de-duplicates
+    # by job id where `_critical_path` does not — so on a sample containing those the
+    # summary and the pole's `bimodal` stamp CAN disagree about which samples qualify.
+    # By selection, never by definition. (Undated executions are NOT one of those
+    # differences: `_critical_path` drops them too, on its own `_job_duration_s` guard.)
     assert cr._bimodal_split(durs) is not None
     line = bp._timing_spread_sentence({"timing_spread": s}).lower()
     assert "mode" in line
 
     # The mode clause's NUMBERS, in role order. The fixture above is constant within each
-    # mode, so a renderer that swapped a mode's min and max would ship green; this one
-    # spreads both modes so the swap changes the rendered substring.
-    spread_modes = [28.0, 30.0, 32.0, 34.0, 36.0, 38.0,
-                    600.0, 610.0, 620.0, 630.0, 640.0, 650.0]
+    # mode AND equal-sized, so a renderer that swapped a mode's min and max — or printed
+    # one mode's run COUNT beside the other mode's range — would ship green against it.
+    # This one spreads both modes and gives them different sizes, so each of those three
+    # mis-pairings changes the rendered substring.
+    spread_modes = [28.0, 30.0, 32.0, 34.0, 38.0,
+                    600.0, 610.0, 620.0, 630.0, 640.0, 650.0, 660.0]
     s2 = _spread_for(spread_modes)
     m2 = s2.get("modes")
     assert m2 and len(m2) == 2, s2
     assert [(m["n"], m["min_s"], m["max_s"]) for m in m2] == [
-        (6, 28.0, 38.0), (6, 600.0, 650.0)], m2
+        (5, 28.0, 38.0), (7, 600.0, 660.0)], m2
     line2 = bp._timing_spread_sentence({"timing_spread": s2})
-    assert (f"Two modes in this sample, kept separate: 6 run(s) from {bp._clock(28.0)} "
-            f"to {bp._clock(38.0)} and 6 run(s) from {bp._clock(600.0)} to "
-            f"{bp._clock(650.0)}.") in line2, line2
+    assert (f"Two modes in this sample, kept separate: 5 run(s) from {bp._clock(28.0)} "
+            f"to {bp._clock(38.0)} and 7 run(s) from {bp._clock(600.0)} to "
+            f"{bp._clock(660.0)}.") in line2, line2
 
 
 def test_excluded_and_duplicate_attempts_do_not_inflate_n():
@@ -331,11 +334,71 @@ def test_a_cross_workflow_name_collision_does_not_borrow_one_workflows_durations
     for k in ("min_s", "median_s", "max_s"):
         assert k not in s, f"{k} was fabricated from another workflow's population: {s}"
     why = s["unavailable_reason"]
-    assert a_wf in why and b_wf in why, f"the collision is not named: {why}"
+    # Both colliding workflows are named, by basename and as code spans - the same shape
+    # the sibling collision disclosure in `summary.py` uses. The COUNT is pinned too: a
+    # reason that named the right files beside the wrong number would otherwise ship green.
+    assert "produced by 2 workflows" in why, why
+    assert bp._safe_span("a.yml") in why and bp._safe_span("b.yml") in why, (
+        f"the collision is not named as escaped basenames: {why}")
+    # A dead end is not an acceptable rendering: the reader is told what to change to get
+    # the summary back, in the same words the sibling disclosure already uses.
+    assert "rename one job" in why.lower(), f"the reason gives the reader no way out: {why}"
 
     line = bp._timing_spread_sentence({"timing_spread": s})
     assert "unavailable" in line, line
-    assert bp._clock(100.0) not in line and bp._clock(98.0) not in line, line
+    # The renderer terminates the sentence itself, so a reason carrying its own trailing
+    # period renders "spread..". Multi-sentence reasons are fine; a doubled stop is not.
+    assert ".." not in line, f"the reason double-punctuated the sentence: {line}"
+    # NONE of a.yml's three durations may reach the sentence - the max most of all, since
+    # it is the one a reader would mistake for the 400s gate's own slowest run.
+    for leaked in (98.0, 100.0, 105.0):
+        assert bp._clock(leaked) not in line, (
+            f"{leaked}s leaked from the unrelated workflow's population: {line}")
+
+
+def test_workflow_paths_cannot_break_out_of_the_collision_reason_markdown():
+    """Workflow file paths are REPOSITORY-CONTROLLED text, exactly like the runner labels
+    guarded above, and the collision reason interpolates them into a sentence the report
+    renders inside an italic `_..._` wrapper. A backtick in a filename would close a code
+    span early and render the rest of the pole's paragraph as code; a leading underscore
+    (`_shared.yml`, the common reusable-workflow convention) would break the emphasis. Both
+    take the same `_safe_span` route every other repo-text sink in this renderer takes.
+
+    The list is also BOUNDED: a monorepo can produce one check name from many workflows,
+    and one sentence naming thirty full paths is not a sentence anyone reads."""
+    def _crit(job: str, p50: float) -> dict:
+        return {"job_p50": {job: p50}, "job_p95": {job: p50},
+                "job_runner": {job: "ubuntu-latest"}, "job_bimodal": {},
+                "long_pole_job": job, "long_pole_p50": p50, "long_pole_p95": p50,
+                "floor_p50": 0.0, "runner_scope": "ubuntu-latest"}
+
+    hostile = ".github/workflows/_sha`red.yml"
+    other = ".github/workflows/b.yml"
+    crit_by_wf = {hostile: _crit("build", 100.0), other: _crit("Build", 400.0)}
+    jobs_per_run_by_wf = {hostile: _runs([98.0, 100.0, 105.0], name="build")}
+
+    s = cr._pole_timing_spread("build", hostile, "build", crit_by_wf,
+                               jobs_per_run_by_wf, [])
+    assert s["coverage"] == "unavailable", s
+    why = s["unavailable_reason"]
+    # The hostile basename survives only in its defused form - no raw backtick from repo
+    # text may reach the sentence, so every backtick left is a delimiter this code wrote.
+    assert "_sha`red.yml" not in why, f"a repo backtick survived verbatim: {why}"
+    assert bp._safe_span("_sha`red.yml") in why, why
+
+    line = bp._timing_spread_sentence({"timing_spread": s})
+    assert line.count("`") % 2 == 0, f"an unclosed code span was rendered: {line}"
+
+    # Bounded: many producers are summarised, not enumerated one path at a time.
+    many = {f".github/workflows/w{i}.yml": _crit("build" if i else "Build", 100.0 + i)
+            for i in range(9)}
+    s_many = cr._pole_timing_spread("build", ".github/workflows/w1.yml", "build",
+                                    many, {}, [])
+    why_many = s_many["unavailable_reason"]
+    assert "produced by 9 workflows" in why_many, why_many
+    assert why_many.count(".yml") <= 4, (
+        f"every producing workflow was enumerated into one sentence: {why_many}")
+    assert "more" in why_many, why_many
 
 
 def test_a_caller_pinned_mapping_is_its_own_timing_anchor():

--- a/skills/ci-speedup/tests/test_timing_spread.py
+++ b/skills/ci-speedup/tests/test_timing_spread.py
@@ -413,3 +413,30 @@ def test_runner_labels_cannot_break_out_of_the_sentence_markdown():
             f"raw repo-controlled label {label!r} reached the report unescaped: {sentence}")
     assert sentence.count("`") % 2 == 0, (
         f"odd number of backticks - a code span is left open: {sentence}")
+
+
+def test_the_rendered_sentence_carries_the_right_numbers_in_the_right_roles():
+    """The stamped dict's values are pinned above, but the SENTENCE is the product: it is
+    what the reader and the hand-off agent actually see. Without this, a renderer that
+    swapped min and max, printed the median where the minimum belongs, dropped the clock
+    formatting, or miscounted the runs would ship green - every other test here asserts
+    only the sentence's VOCABULARY (`constant in this sample`, `one observed run`, the
+    banned band/significance words) or the stamped numbers, never the rendered ones."""
+    durs = [30.0, 120.0, 240.0, 300.0, 900.0]
+    s = _spread_for(durs)
+    assert (s["n"], s["min_s"], s["median_s"], s["max_s"]) == (5, 30.0, 240.0, 900.0), s
+    line = bp._timing_spread_sentence({"timing_spread": s})
+    # Roles, not just presence: min before max, median in the parenthetical, each through
+    # `_clock`. A swap or a role substitution changes this exact substring.
+    assert (f"took {bp._clock(30.0)} to {bp._clock(900.0)} "
+            f"(median {bp._clock(240.0)})") in line, line
+    assert f"Across {s['n']} comparable sampled runs" in line, line
+    # And the raw seconds never leak in place of the clock rendering.
+    assert "900.0" not in line and "30.0" not in line, line
+
+    one = _spread_for([240.0])
+    assert bp._clock(240.0) in bp._timing_spread_sentence({"timing_spread": one})
+
+    const = _spread_for([100.0] * 4)
+    cline = bp._timing_spread_sentence({"timing_spread": const})
+    assert f"Across 4 comparable sampled runs this check took {bp._clock(100.0)}" in cline, cline

--- a/skills/ci-speedup/tests/test_timing_spread.py
+++ b/skills/ci-speedup/tests/test_timing_spread.py
@@ -440,3 +440,41 @@ def test_the_rendered_sentence_carries_the_right_numbers_in_the_right_roles():
     const = _spread_for([100.0] * 4)
     cline = bp._timing_spread_sentence({"timing_spread": const})
     assert f"Across 4 comparable sampled runs this check took {bp._clock(100.0)}" in cline, cline
+
+
+def test_an_unlabelled_dominant_runner_is_still_a_population_not_a_disabled_filter():
+    """`_critical_path` names a job's dominant runner `?` when the payloads carry no label,
+    and it computes that pole's p50 on THAT group. The summary must describe the same group.
+    Treating `?` as "no scope" instead of as the scope silently folds every other runner
+    into the range, so the sentence reports runs the pole's own median never saw - and the
+    runner split then re-surfaces as a fast/slow MODE split, which is exactly the
+    population-collapsing this summary is forbidden to do."""
+    def _unlabelled(job_id: int, dur_s: float) -> dict:
+        """A jobs-API payload carrying no runner label at all - what `_job_runner_label`
+        reads as `?`. Built here rather than via `_job` because the absence of the keys,
+        not a `None` value in them, is the case under test."""
+        j = _job(job_id, dur_s)
+        j.pop("labels", None)
+        j.pop("runner_name", None)
+        return j
+
+    jobs_per_run = ([[_unlabelled(300 + i, 100.0)] for i in range(5)]
+                    + _runs([900.0] * 3, runner="macos-14"))
+    crit = cr._critical_path(jobs_per_run)
+    assert crit["job_runner"][_JOB] == "?" and crit["job_p50"][_JOB] == 100.0, crit
+    s = cr._pole_timing_spread(_JOB, _WF, _JOB, {_WF: crit}, {_WF: jobs_per_run}, [])
+
+    assert s["n"] == 5, f"another runner's observations leaked into the range: {s}"
+    assert s["max_s"] == 100.0, f"the range extends past the pole's own population: {s}"
+    assert s["median_s"] == crit["job_p50"][_JOB], (
+        "the summary's median and the pole's headline describe different populations")
+    assert "macos-14" in (s.get("other_runner_labels") or []), s
+    assert not s.get("modes"), (
+        f"a RUNNER split was re-badged as a fast/slow mode split: {s.get('modes')}")
+
+    line = bp._timing_spread_sentence({"timing_spread": s})
+    assert "macos-14" in line and "separate population" in line, line
+    assert "mode" not in line, line
+    # `?` is an internal placeholder for "this payload carried no label", never a runner
+    # name to show a reader.
+    assert "`?`" not in line, f"the unlabelled placeholder rendered as a runner name: {line}"

--- a/skills/ci-speedup/tests/test_timing_spread.py
+++ b/skills/ci-speedup/tests/test_timing_spread.py
@@ -214,11 +214,30 @@ def test_mode_split_is_identified_not_collapsed_into_one_variability_statement()
     assert modes and len(modes) == 2, s
     assert [m["n"] for m in modes] == [6, 6]
     assert modes[0]["max_s"] == 30.0 and modes[1]["min_s"] == 600.0
-    # The mode split re-uses the engine's OWN bimodality definition, so the summary and
-    # the pole's `bimodal` stamp can never disagree about whether this check has modes.
+    # The mode split re-uses the engine's OWN bimodality definition (`_bimodal_split`), so
+    # the summary never invents a second notion of "bimodal". It is applied to this
+    # summary's own selection, though — which drops skipped and undated executions and
+    # de-duplicates by job id where `_critical_path` does not — so on a sample containing
+    # those the summary and the pole's `bimodal` stamp CAN disagree about which samples
+    # qualify. By selection, never by definition.
     assert cr._bimodal_split(durs) is not None
     line = bp._timing_spread_sentence({"timing_spread": s}).lower()
     assert "mode" in line
+
+    # The mode clause's NUMBERS, in role order. The fixture above is constant within each
+    # mode, so a renderer that swapped a mode's min and max would ship green; this one
+    # spreads both modes so the swap changes the rendered substring.
+    spread_modes = [28.0, 30.0, 32.0, 34.0, 36.0, 38.0,
+                    600.0, 610.0, 620.0, 630.0, 640.0, 650.0]
+    s2 = _spread_for(spread_modes)
+    m2 = s2.get("modes")
+    assert m2 and len(m2) == 2, s2
+    assert [(m["n"], m["min_s"], m["max_s"]) for m in m2] == [
+        (6, 28.0, 38.0), (6, 600.0, 650.0)], m2
+    line2 = bp._timing_spread_sentence({"timing_spread": s2})
+    assert (f"Two modes in this sample, kept separate: 6 run(s) from {bp._clock(28.0)} "
+            f"to {bp._clock(38.0)} and 6 run(s) from {bp._clock(600.0)} to "
+            f"{bp._clock(650.0)}.") in line2, line2
 
 
 def test_excluded_and_duplicate_attempts_do_not_inflate_n():
@@ -267,6 +286,74 @@ def test_a_pole_whose_aggregate_uses_another_population_is_marked_unavailable():
     assert s["coverage"] == "unavailable"
     assert "min_s" not in s
     assert "check-runs" in s["unavailable_reason"]
+
+
+def test_a_cross_workflow_name_collision_does_not_borrow_one_workflows_durations():
+    """The other way a pole's aggregate can come from a different population than the
+    retained durations — and the one no `timing_source` stamp catches.
+
+    When the same check name is produced by TWO workflows, `_map_check_to_job` refuses to
+    pick a file, and the spine grounds the pole's magnitude on `_check_grounded_job_p50` —
+    the MAX p50 across every colliding workflow (here b.yml's 400s). That is still stamped
+    `timing_source == "workflow_jobs"`, because it IS a sampled job p50. But the pole's
+    FILE then resolves through the scanned job graph, which is unambiguous where the
+    timing mapper was not, and lands on a.yml. Attaching a.yml's ~100s durations under a
+    400s headline tells the reader — and the copy-paste agent prompt — that the 400s gate
+    was observed at 100s. The summary must be unavailable instead."""
+    def _crit(job: str, p50: float) -> dict:
+        return {"job_p50": {job: p50}, "job_p95": {job: p50},
+                "job_runner": {job: "ubuntu-latest"}, "job_bimodal": {},
+                "long_pole_job": job, "long_pole_p50": p50, "long_pole_p95": p50,
+                "floor_p50": 0.0, "runner_scope": "ubuntu-latest"}
+
+    a_wf, b_wf = ".github/workflows/a.yml", ".github/workflows/b.yml"
+    a_runs = _runs([98.0, 100.0, 105.0], name="build")
+    crit_by_wf = {a_wf: _crit("build", 100.0), b_wf: _crit("Build", 400.0)}
+    jobs_per_run_by_wf = {a_wf: a_runs, b_wf: _runs([400.0] * 3, name="Build")}
+    job_graph = {a_wf: {"build": {"name": "build"}}, b_wf: {"Build": {"name": "Build"}}}
+
+    # The production path, step by step: the timing mapper refuses the collision, the
+    # magnitude is grounded on the SLOWEST colliding job, and the scanned graph then
+    # resolves a single — different — workflow for the pole's file.
+    assert cr._map_check_to_job("build", crit_by_wf,
+                                require_developer_timing=True) is None
+    assert cr._check_grounded_job_p50("build", crit_by_wf,
+                                      require_developer_timing=True) == 400.0
+    assert cr._check_to_job_node_scanned("build", job_graph) == (a_wf, "build")
+    mapping = cr._pole_mapping("build", crit_by_wf, None, job_graph,
+                               require_developer_timing=True)
+    assert mapping == (a_wf, "build"), mapping
+
+    s = cr._pole_timing_spread("build", mapping[0], mapping[1], crit_by_wf,
+                               jobs_per_run_by_wf, [])
+    assert s["coverage"] == "unavailable", (
+        "a 400s pole was given a.yml's ~100s durations: " + repr(s))
+    for k in ("min_s", "median_s", "max_s"):
+        assert k not in s, f"{k} was fabricated from another workflow's population: {s}"
+    why = s["unavailable_reason"]
+    assert a_wf in why and b_wf in why, f"the collision is not named: {why}"
+
+    line = bp._timing_spread_sentence({"timing_spread": s})
+    assert "unavailable" in line, line
+    assert bp._clock(100.0) not in line and bp._clock(98.0) not in line, line
+
+
+def test_a_caller_pinned_mapping_is_its_own_timing_anchor():
+    """The PR-floor fallback pins `(workflow_file, job)` because its "check" IS a job name
+    that can collide across files — the pin exists precisely to break the tie the timing
+    mapper cannot. Its p50 comes from THAT workflow's own critical path, so the pinned
+    workflow's retained durations DO share its basis and must still be summarised."""
+    a_wf, b_wf = ".github/workflows/a.yml", ".github/workflows/b.yml"
+
+    def _crit(job: str, p50: float) -> dict:
+        return {"job_p50": {job: p50}, "job_runner": {job: "ubuntu-latest"}}
+
+    crit_by_wf = {a_wf: _crit("build", 100.0), b_wf: _crit("Build", 400.0)}
+    jobs_per_run_by_wf = {a_wf: _runs([98.0, 100.0, 105.0], name="build")}
+    s = cr._pole_timing_spread("build", a_wf, "build", crit_by_wf,
+                               jobs_per_run_by_wf, [], mapping_pinned=True)
+    assert s["coverage"] == "observed_spread", s
+    assert (s["n"], s["min_s"], s["max_s"]) == (3, 98.0, 105.0), s
 
 
 # --------------------------------------------------------------------------------------

--- a/skills/ci-speedup/tests/test_timing_spread.py
+++ b/skills/ci-speedup/tests/test_timing_spread.py
@@ -365,3 +365,18 @@ def test_the_summary_never_reaches_the_bottom_line_or_the_savings_numbers():
         f"{[ln for ln in added if sentence not in ln]}")
     removed = [ln for ln in without if ln not in with_s]
     assert not removed, f"adding the timing summary REMOVED report lines: {removed}"
+
+
+def test_the_gap_fill_prompt_carries_the_same_summary_sentence():
+    """A pole that matched no catalog detector hands off an LLM-AUTHORED prompt. That
+    body must carry the report's own sentence about what was observed, not the model's
+    account of how much the check varies - and not twice if it already quoted it."""
+    s = _spread_for([190.0, 205.0, 240.0, 268.0, 331.0])
+    pole = {"check": "tests-web", "timing_spread": s}
+    sentence = bp._timing_spread_sentence(pole)
+    assert sentence
+    out = bp._llm_agent_prompt("Root cause: the build re-downloads its toolchain.", pole)
+    assert sentence in out
+    twice = bp._llm_agent_prompt(
+        sentence + "\n\nRoot cause: the build re-downloads its toolchain.", pole)
+    assert twice.count(sentence) == 1, "the sentence was doubled in the gap-fill prompt"

--- a/skills/ci-speedup/tests/test_timing_spread.py
+++ b/skills/ci-speedup/tests/test_timing_spread.py
@@ -1,0 +1,367 @@
+"""Workstream C — DESCRIPTIVE timing spread for a measured pole.
+
+WHY THIS EXISTS. The report ranks poles by p50 and carries a p95 for the long pole, and
+neither quantile can express how much a check's duration actually MOVED across the sampled
+runs. The counterexample is exact: twenty observations of 100s, and nine of 1s plus eleven
+of 100s, both give p50 = p95 = 100s under `_percentile` — one sample never varies, the
+other varies by 99s. A reader shown only the quantiles cannot tell them apart.
+
+WHAT THIS PINS. For each measured pole the engine stamps a versioned DESCRIPTIVE summary —
+`n`, `min_s`, `median_s`, `max_s`, its basis/selection identifiers, its sample ids, and a
+coverage status — re-derived from the observations the sampler ALREADY fetched. It is a
+description of the observed sample. It is deliberately NOT:
+
+  - a symmetric +/- band,
+  - a "minimum detectable effect" or an "outside noise" verdict,
+  - any statistical-significance claim,
+  - an input to the Bottom-line savings number.
+
+Duration spread is not uncertainty in an estimated change, and this module's tests fail if
+that vocabulary ever appears in the rendered summary.
+
+All fixtures are SYNTHETIC job payloads shaped like the GitHub jobs API. No captured run,
+log, or session artifact is committed here.
+
+Run: pytest -v skills/ci-speedup/tests/test_timing_spread.py
+"""
+from __future__ import annotations
+
+import copy
+import re
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+import blocking_path as bp   # noqa: E402  (uniquely-named module; no cross-skill clash)
+import collect_runs as cr    # noqa: E402
+
+
+# --------------------------------------------------------------------------------------
+# Synthetic observation builders — job payloads shaped like the GitHub jobs API.
+# --------------------------------------------------------------------------------------
+
+def _job(job_id: int, dur_s: float, *, name: str = "tests-web",
+         runner: str = "ubuntu-latest", run_id: int = 0, attempt: int = 1,
+         conclusion: str = "success") -> dict:
+    """One sampled job execution lasting `dur_s`. `started_at`/`completed_at` are the
+    SAME timing definition `_job_duration_s` reads for the pole's own p50."""
+    start = 3600
+    return {
+        "id": job_id,
+        "run_id": run_id or (10_000 + job_id),
+        "run_attempt": attempt,
+        "name": name,
+        "conclusion": conclusion,
+        "labels": [runner],
+        "runner_name": runner,
+        "started_at": _iso(start),
+        "completed_at": _iso(start + dur_s),
+    }
+
+
+def _iso(secs: float) -> str:
+    h, rem = divmod(int(secs), 3600)
+    m, s = divmod(rem, 60)
+    return f"2026-09-08T{h:02d}:{m:02d}:{s:02d}Z"
+
+
+def _runs(durations: list[float], **kw) -> list[list[dict]]:
+    """`jobs_per_run` — one sampled run per duration, exactly the shape
+    `_critical_path` consumes and `jobs_per_run_by_wf` retains."""
+    return [[_job(100 + i, d, run_id=20_000 + i, **kw)] for i, d in enumerate(durations)]
+
+
+_WF = ".github/workflows/pipeline.yml"
+_JOB = "tests-web"
+
+
+def _spread_for(durations: list[float], **kw) -> dict:
+    """Run the PRODUCTION selection: build the critical path from the sampled runs (which
+    is what fixes the pole's timing basis, runner scope and quantiles), then ask for that
+    pole's descriptive summary off the SAME retained observations."""
+    jobs_per_run = _runs(durations, **kw)
+    crit = cr._critical_path(jobs_per_run)
+    return cr._pole_timing_spread(
+        _JOB, _WF, _JOB, {_WF: crit}, {_WF: jobs_per_run}, [])
+
+
+# --------------------------------------------------------------------------------------
+# 1. The counterexample: identical p50 AND p95, different observed range.
+# --------------------------------------------------------------------------------------
+
+_CONSTANT = [100.0] * 20
+_SPREAD = [1.0] * 9 + [100.0] * 11
+
+
+def test_quantiles_agree_on_both_samples():
+    """The premise. If this ever fails the counterexample below is no longer a
+    counterexample and the whole workstream needs re-motivating."""
+    assert cr._percentile(_CONSTANT, 50) == cr._percentile(_SPREAD, 50) == 100.0
+    assert cr._percentile(_CONSTANT, 95) == cr._percentile(_SPREAD, 95) == 100.0
+
+
+def test_counterexample_fixtures_render_different_observed_ranges():
+    a = _spread_for(_CONSTANT)
+    b = _spread_for(_SPREAD)
+    assert a["median_s"] == b["median_s"] == 100.0, (a, b)
+    assert (a["min_s"], a["max_s"]) == (100.0, 100.0)
+    assert (b["min_s"], b["max_s"]) == (1.0, 100.0)
+    assert a["n"] == 20 and b["n"] == 20
+    # And the RENDERED sentence differs — the reader, not just the artifact, can tell them
+    # apart. This is the finding that scoped the workstream.
+    sa = bp._timing_spread_sentence({"timing_spread": a})
+    sb = bp._timing_spread_sentence({"timing_spread": b})
+    assert sa and sb and sa != sb, (sa, sb)
+
+
+# --------------------------------------------------------------------------------------
+# 2. Coverage states: empty, single, constant, high-spread.
+# --------------------------------------------------------------------------------------
+
+def test_empty_sample_is_unavailable_never_zero():
+    s = _spread_for([])
+    assert s["coverage"] == "unavailable"
+    assert s["n"] == 0
+    # NEVER a fabricated zero: no numeric range keys at all.
+    for k in ("min_s", "median_s", "max_s"):
+        assert k not in s, f"{k} was fabricated on an empty sample: {s}"
+    assert s.get("unavailable_reason")
+    line = bp._timing_spread_sentence({"timing_spread": s})
+    assert "unavailable" in line.lower()
+    assert "0s" not in line
+
+
+def test_single_observation_says_one_observed_run_and_never_a_spread():
+    s = _spread_for([240.0])
+    assert s["coverage"] == "single_observation"
+    assert s["n"] == 1
+    assert s["min_s"] == s["median_s"] == s["max_s"] == 240.0
+    line = bp._timing_spread_sentence({"timing_spread": s})
+    assert "one observed run" in line.lower()
+    assert "spread" not in line.lower().replace("not a spread", "")
+
+
+def test_constant_sample_is_constant_in_the_sample_not_proof_of_no_noise():
+    s = _spread_for([120.0] * 12)
+    assert s["coverage"] == "constant_in_sample"
+    line = bp._timing_spread_sentence({"timing_spread": s}).lower()
+    assert "constant in this sample" in line
+    # The disclaimer that keeps a constant sample from reading as a promise about CI.
+    assert "not proof" in line or "is not proof" in line
+
+
+def test_high_spread_sample_reports_min_median_max_from_the_observations():
+    durs = [30.0, 45.0, 60.0, 300.0, 900.0]
+    s = _spread_for(durs)
+    assert s["n"] == 5
+    assert s["min_s"] == 30.0 and s["max_s"] == 900.0
+    assert s["median_s"] == cr._percentile(durs, 50)
+
+
+# --------------------------------------------------------------------------------------
+# 3. Selection identity: runner scope, config era, mode split, excluded/duplicate attempts.
+# --------------------------------------------------------------------------------------
+
+def test_runner_mixed_sample_scopes_to_the_dominant_runner_and_says_so():
+    """`_critical_path` computes the pole's p50 on its OWN dominant runner. The spread
+    must use the SAME population — a blended range would describe a job that never ran."""
+    jobs_per_run = (_runs([100.0] * 6, runner="ubuntu-latest")
+                    + _runs([900.0, 950.0], runner="macos-14"))
+    # distinct ids across the two groups
+    for i, run in enumerate(jobs_per_run):
+        run[0]["id"] = 500 + i
+        run[0]["run_id"] = 60_000 + i
+    crit = cr._critical_path(jobs_per_run)
+    s = cr._pole_timing_spread(_JOB, _WF, _JOB, {_WF: crit},
+                               {_WF: jobs_per_run}, [])
+    assert s["selection"]["runner_scope"] == "ubuntu-latest"
+    assert s["n"] == 6
+    assert s["max_s"] == 100.0, "a macos observation leaked into the ubuntu range"
+    assert "macos-14" in (s.get("other_runner_labels") or [])
+    line = bp._timing_spread_sentence({"timing_spread": s})
+    assert "ubuntu-latest" in line and "macos-14" in line
+
+
+def test_era_mixed_sample_uses_the_retained_era_and_identifies_it():
+    """The spine door drops the other configuration era's runs BEFORE the pole is
+    measured. The summary must both exclude them and NAME the era it describes, so its
+    range is never read as covering the current configuration when it does not."""
+    retained = _runs([200.0, 210.0, 220.0])
+    era_facts = [{"workflow_file": _WF, "kept_era": "post",
+                  "boundary": "abc1234", "rule": "keep_post",
+                  "pre_count": 5, "post_count": 3}]
+    crit = cr._critical_path(retained)
+    s = cr._pole_timing_spread(_JOB, _WF, _JOB, {_WF: crit},
+                               {_WF: retained}, era_facts)
+    assert s["n"] == 3
+    assert s["selection"]["config_era"] == "post"
+    assert "post" in bp._timing_spread_sentence({"timing_spread": s})
+    # A workflow with no straddle identifies its era as the whole sampled window,
+    # never as a silent "post".
+    s2 = _spread_for([200.0, 210.0, 220.0])
+    assert s2["selection"]["config_era"] == "all_sampled"
+
+
+def test_mode_split_is_identified_not_collapsed_into_one_variability_statement():
+    """A bimodal pole keeps its existing fast/slow split. The summary reports the whole
+    observed range AND identifies the two modes; it must not present one blended number
+    as 'the' variability of the check."""
+    durs = [30.0] * 6 + [600.0] * 6
+    s = _spread_for(durs)
+    modes = s.get("modes")
+    assert modes and len(modes) == 2, s
+    assert [m["n"] for m in modes] == [6, 6]
+    assert modes[0]["max_s"] == 30.0 and modes[1]["min_s"] == 600.0
+    # The mode split re-uses the engine's OWN bimodality definition, so the summary and
+    # the pole's `bimodal` stamp can never disagree about whether this check has modes.
+    assert cr._bimodal_split(durs) is not None
+    line = bp._timing_spread_sentence({"timing_spread": s}).lower()
+    assert "mode" in line
+
+
+def test_excluded_and_duplicate_attempts_do_not_inflate_n():
+    """One eligible observation per sampler-selected run/attempt. A retried run that
+    appears twice in the retained list, a skipped job, and a job with unparseable
+    timestamps must not each add to `n` — and the rendered values must still be
+    re-derivable from the observations that WERE retained."""
+    kept = _runs([100.0, 200.0, 300.0])
+    dup = copy.deepcopy(kept[1])              # same job id: the same execution, twice
+    skipped = [[_job(700, 999.0, conclusion="skipped")]]
+    undated = [[{"id": 800, "run_id": 800, "run_attempt": 1, "name": _JOB,
+                 "labels": ["ubuntu-latest"], "conclusion": "success",
+                 "started_at": None, "completed_at": None}]]
+    jobs_per_run = kept + [dup] + skipped + undated
+    crit = cr._critical_path(jobs_per_run)
+    s = cr._pole_timing_spread(_JOB, _WF, _JOB, {_WF: crit},
+                               {_WF: jobs_per_run}, [])
+    assert s["n"] == 3, f"n was inflated by an excluded/duplicate attempt: {s}"
+    assert (s["min_s"], s["median_s"], s["max_s"]) == (100.0, 200.0, 300.0)
+    assert len(s["sample_ids"]) == 3 and len(set(s["sample_ids"])) == 3
+    assert s["excluded"]["duplicate"] == 1
+    assert s["excluded"]["no_duration"] == 2   # skipped + undated
+    # A rerun ATTEMPT is a distinct execution and IS counted — but the summary counts
+    # runs/attempts, and never claims they are independent PRs.
+    assert "pr" not in bp._timing_spread_sentence({"timing_spread": s}).lower().split()
+
+
+def test_summary_carries_its_basis_version_and_sample_ids():
+    s = _spread_for([100.0, 140.0])
+    assert s["version"] == cr._TIMING_SPREAD_VERSION
+    assert s["basis"] == cr._TIMING_SPREAD_BASIS
+    sel = s["selection"]
+    for k in ("check", "workflow_file", "job", "runner_scope", "config_era",
+              "attempt_policy", "population"):
+        assert sel.get(k), f"selection identifier {k} missing: {sel}"
+    assert s["sample_ids"], "no sample ids stamped — the summary is not re-derivable"
+
+
+def test_a_pole_whose_aggregate_uses_another_population_is_marked_unavailable():
+    """When the pole's own p50 did not come from sampled workflow jobs (a PR check-run
+    timing), no job durations share its basis. Say unavailable — never attach the
+    durations of some other population."""
+    s = cr._pole_timing_spread(
+        _JOB, _WF, _JOB, {}, {}, [],
+        unavailable="pole timing came from PR check-runs")
+    assert s["coverage"] == "unavailable"
+    assert "min_s" not in s
+    assert "check-runs" in s["unavailable_reason"]
+
+
+# --------------------------------------------------------------------------------------
+# 4. Rendering: same summary in the report and the prompt; nothing fabricated; nothing
+#    that reads as an inference claim.
+# --------------------------------------------------------------------------------------
+
+_LOG = "\n".join([
+    " RUN  v4.1.4 /repo/web",
+    " Test Files  149 passed (149)",
+    " Duration  96.12s (transform 8.97s, setup 1.01s, import 245.03s, "
+    "tests 214.54s, environment 8ms)",
+])
+
+
+def _doc(spread: dict | None) -> dict:
+    pole: dict = {
+        "check": "tests-web", "p50_s": 255.0,
+        "workflow_file": _WF, "job": "tests-web",
+        "dominant_step": "run tests", "dominant_p50_s": 91.0,
+        "steps": [{"step": "run tests", "category": "test", "p50_s": 91.0},
+                  {"step": "Build", "category": "build", "p50_s": 60.0}],
+    }
+    if spread is not None:
+        pole["timing_spread"] = spread
+    return {
+        "repo": "o/r", "scanned_at": "2026-06-08T00:00:00Z",
+        "data_sources": {"runs_sampled": 100, "jobs_sampled": 300,
+                         "workflows_analyzed": 5},
+        "pr_critical_path": {
+            "sampled_pr_count": 20, "sample_target": 20, "sample_complete": True,
+            "poles": [pole]},
+    }
+
+
+def _render(doc: dict) -> str:
+    return bp.render(doc, {"pipeline": _LOG}, {},
+                     {"pipeline": "https://github.com/o/r/actions/runs/123"},
+                     "2026-06-08")
+
+
+def test_report_and_prompt_carry_the_same_summary_sentence():
+    s = _spread_for([190.0, 205.0, 240.0, 268.0, 331.0])
+    md = _render(_doc(s))
+    sentence = bp._timing_spread_sentence({"timing_spread": s})
+    assert sentence
+    # Once in the pole section, once inside the ```text agent prompt fence.
+    assert md.count(sentence) >= 2, (
+        "the pole section and the agent prompt must carry the SAME summary; found "
+        f"{md.count(sentence)} occurrence(s)")
+    prompt = md.split("Prompt for your coding agent", 1)[1]
+    assert sentence in prompt
+
+
+def test_legacy_pole_without_a_stamped_summary_renders_no_fabricated_values():
+    md = _render(_doc(None))
+    assert bp._timing_spread_sentence({}) == ""
+    for probe in ("observed run", "comparable sampled runs", "constant in this sample",
+                  "duration spread"):
+        assert probe not in md.lower(), (
+            f"a legacy artifact (no stamped summary) rendered {probe!r}")
+
+
+def test_a_future_summary_version_is_not_rendered_as_if_it_were_this_one():
+    s = _spread_for([190.0, 331.0])
+    s["version"] = cr._TIMING_SPREAD_VERSION + 1
+    assert bp._timing_spread_sentence({"timing_spread": s}) == ""
+
+
+def test_the_summary_makes_no_band_detectability_or_significance_claim():
+    for durs in ([], [240.0], [100.0] * 12, [1.0] * 9 + [100.0] * 11,
+                 [30.0] * 6 + [600.0] * 6):
+        line = bp._timing_spread_sentence({"timing_spread": _spread_for(durs)}).lower()
+        for banned in ("+/-", "±", "minimum detectable", "detectable effect",
+                       "outside noise", "within noise", "statistically",
+                       "significant", "confidence", "margin of error", "p-value"):
+            assert banned not in line, f"{banned!r} appeared in: {line!r}"
+
+
+def test_the_summary_never_reaches_the_bottom_line_or_the_savings_numbers():
+    """The headline and savings outputs are computed from the sizing stamps, not from
+    observed spread. Adding the summary must change ONLY the summary lines."""
+    s = _spread_for([190.0, 205.0, 240.0, 268.0, 331.0])
+    # The untrusted-log fence carries a fresh random nonce on every render, so two renders
+    # of the SAME doc differ on those lines. Normalize it away; it is not our delta.
+    def _norm(md: str) -> list[str]:
+        return re.sub(r"\[[0-9a-f]{8}\]", "[nonce]", md).splitlines()
+
+    with_s = _norm(_render(_doc(s)))
+    without = _norm(_render(_doc(None)))
+    sentence = bp._timing_spread_sentence({"timing_spread": s})
+    added = [ln for ln in with_s if ln not in without]
+    assert added, "the summary rendered nothing at all"
+    assert all(sentence in ln for ln in added), (
+        f"adding the timing summary changed non-summary lines: "
+        f"{[ln for ln in added if sentence not in ln]}")
+    removed = [ln for ln in without if ln not in with_s]
+    assert not removed, f"adding the timing summary REMOVED report lines: {removed}"

--- a/skills/ci-speedup/tests/test_timing_spread.py
+++ b/skills/ci-speedup/tests/test_timing_spread.py
@@ -380,3 +380,36 @@ def test_the_gap_fill_prompt_carries_the_same_summary_sentence():
     twice = bp._llm_agent_prompt(
         sentence + "\n\nRoot cause: the build re-downloads its toolchain.", pole)
     assert twice.count(sentence) == 1, "the sentence was doubled in the gap-fill prompt"
+
+
+def test_runner_labels_cannot_break_out_of_the_sentence_markdown():
+    """Runner labels are REPOSITORY-CONTROLLED text: they arrive on the jobs-API payload
+    and a self-hosted label can carry backticks. The scope name is rendered as an inline
+    code span and the other-population labels are rendered inline beside it, so both are
+    sinks and both must go through `_safe_span` - otherwise one backtick in a label closes
+    the span early and the rest of the pole's paragraph renders as code, or as emphasis.
+    Every other repo-text sink in this renderer already takes that route."""
+    hostile = "self-hosted`x"
+    other_a, other_b = "gpu`box", "_macos_-14"
+    jobs_per_run = (_runs([100.0] * 6, runner=hostile)
+                    + _runs([900.0], runner=other_a)
+                    + _runs([950.0], runner=other_b))
+    crit = cr._critical_path(jobs_per_run)
+    s = cr._pole_timing_spread(_JOB, _WF, _JOB, {_WF: crit}, {_WF: jobs_per_run}, [])
+    assert s["selection"]["runner_scope"] == hostile, s["selection"]
+    assert sorted(s.get("other_runner_labels") or []) == sorted([other_a, other_b]), s
+
+    sentence = bp._timing_spread_sentence({"timing_spread": s})
+    assert "separate population" in sentence, sentence
+    # No backtick from repo text may survive: `_safe_span` maps every one to an apostrophe,
+    # so the only backticks left in the sentence are the delimiters this renderer wrote.
+    for label in (hostile, other_a, other_b):
+        assert bp._safe_span(label) in sentence, (
+            f"label {label!r} was not rendered through `_safe_span`: {sentence}")
+    for label in (hostile, other_a):
+        # A label carrying a backtick must not survive verbatim - verbatim means its own
+        # backtick closed the span this renderer opened.
+        assert label not in sentence, (
+            f"raw repo-controlled label {label!r} reached the report unescaped: {sentence}")
+    assert sentence.count("`") % 2 == 0, (
+        f"odd number of backticks - a code span is left open: {sentence}")


### PR DESCRIPTION
## TL;DR

Until now the report told a reader how long a slow check usually takes, but never how much that time swings from run to run — and the statistics it already showed cannot answer that. A check that takes 100 seconds every single time and a check that flips between 1 second and 100 seconds produce identical median and identical P95, so the report described a rock-steady gate and a wildly erratic one in exactly the same words. That matters because someone deciding whether a fix is worth doing needs to know whether the "before" number is stable enough to compare against. Each long pole now also reports how many comparable runs were observed and the fastest, median and slowest of them, read from data the audit had already collected, at no extra cost and with no change to any savings number.

## What this adds

For every measured long pole, the report and that pole's copy-paste agent prompt now carry one shared sentence, for example:

> _Across 8 comparable sampled runs this check took 3m 10s to 5m 31s (median 4m 00s). That describes the observed sample, not uncertainty in a future speedup._

```
before:  median 240s  ->  reader cannot distinguish  ->  [100,100,...,100]
                                                    \->  [1,1,...,100,100]
after:   median 240s + observed range + how many runs -> the two now read differently
```

All three agent-prompt surfaces get it, including the one whose body is written by a model rather than by a template, so no hand-off is left to characterise the check's variability on its own.

The summary is stamped as machine-readable data on each pole (count, minimum, median, maximum, the identifiers naming exactly which observations it describes, the sample ids, and a coverage status) so it can be re-derived and audited rather than only read.

## Costs nothing extra

It re-reads the durations the audit already fetched — the same retained per-run job lists the pole's median was computed from — so it issues **zero additional GitHub requests** and does no deeper sampling. The existing end-to-end guard that pins the whole pipeline's request budget to an exact number is unchanged at 38.

## Honest by construction

Selection matches the pole's own measurement basis exactly: same check, same start-to-finish clock, same retained configuration era, same dominant runner, one observation per sampled run or rerun attempt. Existing splits are kept and named rather than blended — a second runner population is named and excluded from the range, and a check with a fast and a slow mode reports both modes beside the whole-sample range. Rerun attempts are never counted as separate pull requests.

It is deliberately a description of what was observed, and nothing more. There is no plus/minus band, no "smallest change you could detect", no "outside the noise" verdict and no significance claim; how much a duration varies is not the same thing as uncertainty in an estimated speedup, and conflating them would let the report make a statistical claim it has no basis for. It never feeds the Bottom line or any savings figure.

Degenerate samples say so:

| Sample | What renders |
| --- | --- |
| No comparable observations | unavailable, with the reason — never `0s` |
| Exactly one | "one observed run" — explicitly not a spread |
| All identical | "constant in this sample", with an explicit note that this is not proof future runs will not vary |
| A different population backs the pole's own figure | unavailable — never another population's durations |
| A report produced before this existed | nothing at all — no invented value |

## Verification

The regression tests were written and run first, against the unmodified engine: 16 failed, 1 passed on the first commit, and a further assertion was proved red before the follow-up commit. The one that passed pins the premise — that the two counterexample samples really do share both median and P95 today, so the problem being fixed is real.

```
E  AttributeError: module 'collect_runs' has no attribute '_pole_timing_spread'
E  AttributeError: module 'blocking_path' has no attribute '_timing_spread_sentence'
```

All 23 pass after the change. The fixtures cover the counterexample pair, and empty, single, constant, high-spread, runner-mixed, era-mixed and mode-split samples, plus excluded and duplicate attempts, legacy artifacts and a future summary version.

Adversarial review added three of those tests and the two behaviour fixes they proved:

- A runner label is repository-controlled text, and the sentence rendered it into Markdown unescaped, so one backtick in a self-hosted label closed the code span early and the rest of the paragraph rendered as code. Both label positions now take the same escaping route every other repository-text position in this renderer already takes.
- When the sampled payloads carried no runner label at all, the check's own median is computed on exactly that group, but the summary read the missing label as "no scope" and folded every other runner into the range — reporting eight runs ranging to fifteen minutes for a pole whose median was one minute forty, and re-describing the runner split as a fast/slow mode split. An unlabelled group is now treated as the population it is. This is the one place the "selection matches the pole's own basis exactly" claim above was not true; it is true now.
A later independent spec-conformance review found one more, and it is the one the stamp could not catch:

- When two workflows produce a check of the same name — a monorepo with copy-pasted `build` jobs — the reported duration is deliberately the slowest of them, because that is what a pull request actually waits on. The workflow the report then links to is resolved a different way, and lands on just one of them. The spread sentence read that one workflow's runs, so a four-hundred-second gate was described underneath its own headline as having been observed at about a hundred seconds — in the pole section and, identically, in the copy-paste agent prompt. The check that was supposed to prevent this asked only whether the duration came from sampled workflow jobs, and it did; a slowest-of-several job time is still a job time. The summary is now withheld unless the workflow it is asked about is the one that produced the pole's own duration, and it names the colliding workflows instead of showing an unrelated one's numbers. Red first, on the unfixed engine:

```
E  AssertionError: a 400s pole was given a.yml's ~100s durations:
E  {... 'workflow_file': '.github/workflows/a.yml', 'n': 3, 'min_s': 98.0,
E   'median_s': 100.0, 'max_s': 105.0, 'coverage': 'observed_spread'}
E  assert 'observed_spread' == 'unavailable'
```

  A companion test pins the case that must keep working: where the workflow is pinned by the caller rather than resolved by name, its own critical path is the source of the pole's duration, so its runs do describe it and the summary still renders.

- The two-mode clause named its numbers but did not pin them. Swapping a mode's fastest and slowest run passed the whole suite; it now fails it. A later review round found the same clause still blind to one mis-pairing — both modes in the fixture had six runs, so printing one mode's run count beside the other mode's range stayed green. The two modes are now different sizes, and it fails.

- The summary's stored values were pinned exactly and its wording was pinned exactly, but nothing asserted that the sentence prints the right numbers in the right places — which is the part a reader sees. Swapping the fastest and slowest run, printing the median where the fastest belongs, dropping the duration formatting, and overstating the run count all passed the suite before; all four fail it now. One test re-renders the same report with and without the summary and fails if any line outside the summary changes, which is how the untouched headline and savings outputs are proven untouched. The whole skill suite is green locally (2609 passed, 13 skipped), including the dense existing headline guards and the committed sample reports.

A further review round found one more, in the sentence the fix above introduced:

- The withheld sentence printed each colliding workflow as a raw full path. A workflow file name is repository text, and this is the same sink the runner-label fix above had just been written for: a backtick in a file name closes a code span early and the rest of the pole's paragraph renders as code, and a leading underscore — the usual convention for a shared reusable workflow — breaks the emphasis the report wraps the line in. The names now take the same escaping route every other repository-text position in this renderer takes. Red first, on the unfixed sentence:

```
E  AssertionError: a repo backtick survived verbatim: this check's name is
E  produced by 2 workflows (.github/workflows/_sha`red.yml,
E  .github/workflows/b.yml), so its duration ...
E  assert '_sha`red.yml' not in "this check'...timing basis"
```

  Two things the same sentence needed while it was being rewritten. It named every producing workflow, so a repository producing one check name from a dozen workflows turned one sentence into a path dump; it now names three by file name and counts the rest. And it stopped at the diagnosis, which leaves the reader with nothing to do; it now closes with the same remedy the equivalent disclosure elsewhere in the report already gives — rename one job so the check names differ, then re-run.

## What this does not fix

Two things are deliberately left, so the claims above are not read as wider than they are.

- **The withholding covers the spread sentence, not the whole pole section.** For a name-collision pole the report still prints a per-step breakdown, and builds that pole's agent prompt from it, using the one workflow the file binding resolved to — the same workflow the new sentence says does not share the pole's duration basis. That behaviour predates this branch and is unchanged by it; what changes here is that the contradiction is now visible on the page, because the sentence beside it says so out loud. Closing it is a separate decision: either suppress the step drill for such a pole, or stamp it as ambiguous so the existing collision warning fires.

- **The pin that exempts a caller-pinned workflow is proven at the function, not end to end.** Its two directions are both pinned by tests — a collision blanks the summary, a pinned workflow still renders one — and the pinned caller's duration provably comes from the workflow it pins. What no test covers is the single line in the collection pass that decides which of the two a given pole is, because reaching it needs the full pipeline and a fixture corpus shaped for a collision. A corpus for it is worth adding on its own.

## Not in scope

The spread is context beside a pole. It does not gate, rank, or size anything, and it is not a before/after measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



