### PR TITLE
Size two concurrent CI fixes together: the measurement contract, and an honest stop

### DIFF
--- a/skills/ci-speedup/ARCHITECTURE.md
+++ b/skills/ci-speedup/ARCHITECTURE.md
@@ -1858,35 +1858,6 @@ a CommonMark fence walk ever ends still inside a fence.
 
 ## 10. Status of the planned bounds
 
-### Joint scenarios for two concurrent checks — contract present, nothing feeds it
-
-`scripts/joint_scenario.py` holds a data contract and a pure calculator for
-sizing **two findings on two different concurrent checks together**. It exists
-because the per-finding stamps cannot answer that question: with checks at 300s
-and 299s, cutting 100s off either alone moves the gate by 1s or 0s while doing
-both moves it by 100s, and `wall_clock_p50_s` is an already-capped merge-wait
-saving rather than a post-fix duration, so subtracting the stamps yields 1s.
-
-**It is imported by nothing.** No stage calls it, it has no `main()`, and no
-report renders a joint block. That is deliberate, not an oversight: the module's
-`MISSING_PRODUCER_EVIDENCE` tuple names the six things a producer would have to
-stamp first (per-observation durations for the whole gating set, stamped
-concurrency validation, per-observation local reductions, affected-step
-identity, stable matrix-leg identity, and a local-runtime-only certificate),
-none of which the engine stamps today. `load_inputs` on a current findings
-artifact returns `contract_inputs_absent` rather than reconstructing a scenario
-out of the aggregate stamps that happen to be present.
-
-The methodology is `references/wall-clock-methodology.md` §8; the tests are
-`tests/test_joint_sizing.py`, which pin the numbers and every rejection code.
-The refusal vocabulary is closed: `REJECTION_CODES` exports it, a rejection
-built with a code outside it raises, and the suite asserts the exported set is
-exactly the set of codes the module can actually produce.
-**The next step that would change this status is a producer**, not more
-calculator: until one exists the module stays inert, and it should be either
-wired or removed rather than left to become archaeology.
-
-
 The cascade extraction (`wall_clock.py`, the `Bound` contract, the monotonic-
 down + no-silent-shrink invariants, and `size_wall_clock` wired into production
 with a rendered derivation) is **done** (§5). Disposition of the four physical
@@ -1931,6 +1902,34 @@ bounds the gaps list originally named - three implemented, one deliberately not:
   always-available core ("is this on the developer's critical path") via
   `run.event`; required-check gating would add a usually-blank, contentious cap
   on top. Left out on purpose rather than shipped hollow.
+
+### Joint scenarios for two concurrent checks — contract present, nothing feeds it
+
+`scripts/joint_scenario.py` holds a data contract and a pure calculator for
+sizing **two findings on two different concurrent checks together**. It exists
+because the per-finding stamps cannot answer that question: with checks at 300s
+and 299s, cutting 100s off either alone moves the gate by 1s or 0s while doing
+both moves it by 100s, and `wall_clock_p50_s` is an already-capped merge-wait
+saving rather than a post-fix duration, so subtracting the stamps yields 1s.
+
+**It is imported by nothing.** No stage calls it, it has no `main()`, and no
+report renders a joint block. That is deliberate, not an oversight: the module's
+`MISSING_PRODUCER_EVIDENCE` tuple names the six things a producer would have to
+stamp first (per-observation durations for the whole gating set, stamped
+concurrency validation, per-observation local reductions, affected-step
+identity, stable matrix-leg identity, and a local-runtime-only certificate),
+none of which the engine stamps today. `load_inputs` on a current findings
+artifact returns `contract_inputs_absent` rather than reconstructing a scenario
+out of the aggregate stamps that happen to be present.
+
+The methodology is `references/wall-clock-methodology.md` §8; the tests are
+`tests/test_joint_sizing.py`, which pin the numbers and every rejection code.
+The refusal vocabulary is closed: `REJECTION_CODES` exports it, a rejection
+built with a code outside it raises, and the suite asserts the exported set is
+exactly the set of codes the module can actually produce.
+**The next step that would change this status is a producer**, not more
+calculator: until one exists the module stays inert, and it should be either
+wired or removed rather than left to become archaeology.
 
 ## 11. The structural / critical-path track
 

--- a/skills/ci-speedup/ARCHITECTURE.md
+++ b/skills/ci-speedup/ARCHITECTURE.md
@@ -1879,6 +1879,9 @@ out of the aggregate stamps that happen to be present.
 
 The methodology is `references/wall-clock-methodology.md` §8; the tests are
 `tests/test_joint_sizing.py`, which pin the numbers and every rejection code.
+The refusal vocabulary is closed: `REJECTION_CODES` exports it, a rejection
+built with a code outside it raises, and the suite asserts the exported set is
+exactly the set of codes the module can actually produce.
 **The next step that would change this status is a producer**, not more
 calculator: until one exists the module stays inert, and it should be either
 wired or removed rather than left to become archaeology.

--- a/skills/ci-speedup/ARCHITECTURE.md
+++ b/skills/ci-speedup/ARCHITECTURE.md
@@ -1858,6 +1858,32 @@ a CommonMark fence walk ever ends still inside a fence.
 
 ## 10. Status of the planned bounds
 
+### Joint scenarios for two concurrent checks — contract present, nothing feeds it
+
+`scripts/joint_scenario.py` holds a data contract and a pure calculator for
+sizing **two findings on two different concurrent checks together**. It exists
+because the per-finding stamps cannot answer that question: with checks at 300s
+and 299s, cutting 100s off either alone moves the gate by 1s or 0s while doing
+both moves it by 100s, and `wall_clock_p50_s` is an already-capped merge-wait
+saving rather than a post-fix duration, so subtracting the stamps yields 1s.
+
+**It is imported by nothing.** No stage calls it, it has no `main()`, and no
+report renders a joint block. That is deliberate, not an oversight: the module's
+`MISSING_PRODUCER_EVIDENCE` tuple names the six things a producer would have to
+stamp first (per-observation durations for the whole gating set, stamped
+concurrency validation, per-observation local reductions, affected-step
+identity, stable matrix-leg identity, and a local-runtime-only certificate),
+none of which the engine stamps today. `load_inputs` on a current findings
+artifact returns `contract_inputs_absent` rather than reconstructing a scenario
+out of the aggregate stamps that happen to be present.
+
+The methodology is `references/wall-clock-methodology.md` §8; the tests are
+`tests/test_joint_sizing.py`, which pin the numbers and every rejection code.
+**The next step that would change this status is a producer**, not more
+calculator: until one exists the module stays inert, and it should be either
+wired or removed rather than left to become archaeology.
+
+
 The cascade extraction (`wall_clock.py`, the `Bound` contract, the monotonic-
 down + no-silent-shrink invariants, and `size_wall_clock` wired into production
 with a rendered derivation) is **done** (§5). Disposition of the four physical

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -110,10 +110,13 @@ unversioned and updates by reinstall from `main`.
   insufficient per-observation evidence all yield an explicit *unsupported*
   verdict rather than a number. The refusal that protects the whole design —
   a reduction declared on top of an already-capped savings stamp — reads what
-  the basis says rather than matching one exact string, so "derived from" that
-  stamp, in any spelling or case, is refused as the bare field name is; and
-  the full refusal vocabulary is a single exported set, so a refusal that is
-  not declared there fails the moment it fires. A joint saving of zero is a supported,
+  the basis says rather than matching one exact string, so a sentence built
+  around that stamp is refused as the bare field name is, in any case,
+  punctuation or camelCase spelling of it; it matches the field name rather
+  than the meaning, so it is defence in depth behind the producer's own
+  declarations rather than a substitute for them. The full refusal vocabulary
+  is a single exported set, so a refusal that is not declared there fails the
+  moment it fires. A joint saving of zero is a supported,
   honest answer, not a failure. **No report renders a joint block today**: the
   engine stamps none of the required inputs, and the specific gaps are recorded
   in the module and in the wall-clock methodology so a later producer has a

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -102,11 +102,18 @@ unversioned and updates by reinstall from `main`.
   two findings each claiming 250s of a 300s check are double-counting whatever
   they call the work, not composing. Two findings touching the same step, a
   `needs:` chain, a required aggregator, a shared serial upstream, an
-  unresolved competitor, an ambiguous matrix identity, an unvalidated
+  unresolved competitor, a competitor an observation timed but the gating set
+  never declared (it would be dropped out of the gate maximum instead of
+  capping the saving), an ambiguous matrix identity, an unvalidated
   concurrent timing span, a missing or repeated finding, workflow, work or
   evidence identity, one check name claimed by two different workflows, or
   insufficient per-observation evidence all yield an explicit *unsupported*
-  verdict rather than a number — and a joint saving of zero is a supported,
+  verdict rather than a number. The refusal that protects the whole design —
+  a reduction declared on top of an already-capped savings stamp — reads what
+  the basis says rather than matching one exact string, so "derived from" that
+  stamp, in any spelling or case, is refused as the bare field name is; and
+  the full refusal vocabulary is a single exported set, so a refusal that is
+  not declared there fails the moment it fires. A joint saving of zero is a supported,
   honest answer, not a failure. **No report renders a joint block today**: the
   engine stamps none of the required inputs, and the specific gaps are recorded
   in the module and in the wall-clock methodology so a later producer has a

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -98,9 +98,13 @@ unversioned and updates by reinstall from `main`.
   one at 300s caps it at zero), the gate maximum taken per observation before
   any median is formed, and before/after/delta reported as three separate
   summaries that are not implied to subtract into one another. Only disjoint
-  affected work composes; two findings touching the same step, a `needs:` chain,
-  a required aggregator, a shared serial upstream, an unresolved competitor, an
-  ambiguous matrix identity, an unvalidated concurrent timing span, or
+  affected work composes, and it must fit inside the check that was observed —
+  two findings each claiming 250s of a 300s check are double-counting whatever
+  they call the work, not composing. Two findings touching the same step, a
+  `needs:` chain, a required aggregator, a shared serial upstream, an
+  unresolved competitor, an ambiguous matrix identity, an unvalidated
+  concurrent timing span, a missing or repeated finding, workflow, work or
+  evidence identity, one check name claimed by two different workflows, or
   insufficient per-observation evidence all yield an explicit *unsupported*
   verdict rather than a number — and a joint saving of zero is a supported,
   honest answer, not a failure. **No report renders a joint block today**: the

--- a/skills/ci-speedup/CHANGELOG.md
+++ b/skills/ci-speedup/CHANGELOG.md
@@ -82,6 +82,33 @@ unversioned and updates by reinstall from `main`.
     backtick or a leading underscore in a workflow file name can no longer
     break the formatting of the paragraph it is printed in.
 
+- **2026-09-08** — **A contract for sizing two concurrent fixes together — and
+  an honest statement that nothing feeds it yet.** Two findings on two different
+  concurrent checks can each be worth almost nothing alone and a great deal
+  together: with one check at 300s and another at 299s, cutting 100s off either
+  one moves the merge gate by a second or not at all, while doing both moves it
+  by 100s. The obvious way to compute that — subtracting each finding's stamped
+  saving from its check's observed duration — is wrong, because that stamp is
+  already an effective merge-wait saving that has been through the floor-capping
+  and population-weighting cascade, not a post-fix duration; for the shape above
+  it would report a joint saving of one second instead of a hundred. This adds
+  the data contract and the calculator that would do it correctly: explicit
+  per-observation local reductions, every unaffected gating check retained as a
+  competitor (an untouched third check at 295s caps the joint saving at 5s, and
+  one at 300s caps it at zero), the gate maximum taken per observation before
+  any median is formed, and before/after/delta reported as three separate
+  summaries that are not implied to subtract into one another. Only disjoint
+  affected work composes; two findings touching the same step, a `needs:` chain,
+  a required aggregator, a shared serial upstream, an unresolved competitor, an
+  ambiguous matrix identity, an unvalidated concurrent timing span, or
+  insufficient per-observation evidence all yield an explicit *unsupported*
+  verdict rather than a number — and a joint saving of zero is a supported,
+  honest answer, not a failure. **No report renders a joint block today**: the
+  engine stamps none of the required inputs, and the specific gaps are recorded
+  in the module and in the wall-clock methodology so a later producer has a
+  target rather than a guess. Building an adapter before that evidence exists
+  would produce confident numbers with nothing behind them.
+
 - **2026-09-02** — **A long pole whose job is declared advisory now says so.**
   Nothing in the engine read a job's `continue-on-error` setting, so a job could
   be reported as the slowest check on the pull-request path, and as the dominant

--- a/skills/ci-speedup/references/wall-clock-methodology.md
+++ b/skills/ci-speedup/references/wall-clock-methodology.md
@@ -545,11 +545,23 @@ different workflows — the gating set holds a single duration under that name, 
 the two cannot be modelled as one check. An observation that timed a check the
 gating set does not declare is refused for the mirror-image reason: the gate
 maximum is taken over the declared names, so an undeclared competitor would be
-dropped out of the competition instead of capping the saving. And a reduction
-basis that merely *names* one of the capped savings stamps — "derived from the
-capped merge-wait saving", in any spelling or case — is refused exactly as the
-bare field name is, because a paraphrase around that stamp is the same
-already-capped number under another sentence. This is
+dropped out of the competition instead of capping the saving. Affected work is
+also budgeted **across the selected effects**, not only per effect: two effects
+that each claim 250s of affected work in one 300s check cannot both be telling
+the truth whatever their work IDs say, so a per-check affected-work sum that
+exceeds the observed duration is refused rather than composed. And a reduction
+basis that *names* one of the capped savings stamps — in any case, punctuation
+or camelCase spelling of the field name, including inside a longer sentence
+such as "derived from `wall_clock_p50_s`" — is refused exactly as the bare
+field name is, because a sentence wrapped around that stamp is the same
+already-capped number under another name. That last check matches the **field
+name**, not the meaning: an English description that never names the field
+("derived from the capped merge-wait saving") is not caught, so it is defence
+in depth behind the producer's own declarations, not a substitute for them.
+Note that most of the refusals above fire on what the producer **declares** —
+the calculator does not detect a `needs:` chain or verify concurrency itself;
+it refuses when the contract says the topology is not independent-concurrent,
+or leaves the concurrency validation unstamped. This is
 deliberately not a general DAG scheduler; the existing single-finding
 chain-aware behaviour is unchanged.
 
@@ -559,8 +571,9 @@ chain-aware behaviour is unchanged.
 admission rules, unit-tested against every counterexample above. **Nothing in
 the engine stamps its inputs**, so no report renders a joint block. The gaps are
 listed in that module as `MISSING_PRODUCER_EVIDENCE`; in summary, the engine has
-no per-observation durations for the *whole* gating set — `pr_critical_path.
-chain_facts` carries per-sha, era-scoped `member_spans_s`, but only for the
+no per-observation durations for the *whole* gating set —
+`pr_critical_path.chain_facts` carries per-sha, era-scoped `member_spans_s`,
+but only for the
 members of that PR's winning chain and with no attempt or runner identity,
 while `populations` is bimodal-gated and identity-free — no stamped
 concurrency validation (overlap is inferred from the `needs:` closure and

--- a/skills/ci-speedup/references/wall-clock-methodology.md
+++ b/skills/ci-speedup/references/wall-clock-methodology.md
@@ -542,7 +542,14 @@ the identity failures, because each of them silently changes which comparison
 gets made rather than erroring: a missing or repeated finding ID, a missing
 workflow, affected-work or evidence identity, and one check name claimed by two
 different workflows — the gating set holds a single duration under that name, so
-the two cannot be modelled as one check. This is
+the two cannot be modelled as one check. An observation that timed a check the
+gating set does not declare is refused for the mirror-image reason: the gate
+maximum is taken over the declared names, so an undeclared competitor would be
+dropped out of the competition instead of capping the saving. And a reduction
+basis that merely *names* one of the capped savings stamps — "derived from the
+capped merge-wait saving", in any spelling or case — is refused exactly as the
+bare field name is, because a paraphrase around that stamp is the same
+already-capped number under another sentence. This is
 deliberately not a general DAG scheduler; the existing single-finding
 chain-aware behaviour is unchanged.
 

--- a/skills/ci-speedup/references/wall-clock-methodology.md
+++ b/skills/ci-speedup/references/wall-clock-methodology.md
@@ -448,9 +448,11 @@ live data.
 ### The per-finding savings stamps CANNOT drive this
 
 `wall_clock_p50_s` is **not a post-fix duration**. It is an *effective merge-wait
-saving* that has already been through the cross-cutting bound cascade in §2 —
-developer-facing gate, measured population-weighted critical-path floor,
-cross-workflow floor. For the shape above it stamps A=1s and B=0s. Subtracting
+saving* that has already been through the cross-cutting bound cascade in
+`scripts/wall_clock.py` — developer-facing gate, measured population-weighted
+critical-path floor, cross-workflow floor (ARCHITECTURE.md documents the
+cascade and its `bound_*` derivation labels). For the shape above it stamps
+A=1s and B=0s. Subtracting
 those from the observed durations gives post-fix durations of 299s/299s and a
 joint saving of **1s**: wrong by two orders of magnitude.
 
@@ -470,6 +472,23 @@ T_after(r,S)   = max_j d_after(r,j,S)
 delta(r,S)     = T_before(r) − T_after(r,S)
 scenario_delta_p50(S) = median_r delta(r,S)
 ```
+
+**How this sits with §7's stacked-model projection.** The two are not
+alternatives and neither supersedes the other. §7 projects a *modeled* future
+shape of the whole cluster from measured step durations, for the Projected
+Impact narrative; §8 measures *observed* joint behaviour of a fixed gating set,
+run by run, and is admissible only when every observation is matched. Where §8
+is available it is the stronger claim about the gate, because it never forms a
+per-check median. Nothing here licenses computing §7's REQUIRED monthly
+headline by any new route: that headline still comes from the stacked model as
+§7 specifies, and no joint block replaces or is added into it.
+
+**v1 is P50-only, and that is a scope limit rather than an exemption from §3,
+§5 and §7's tail requirement.** A joint tail figure needs a per-observation
+tail decomposition the contract does not define and no producer stamps, and a
+P95 of a max is not derivable from the P50 quantities above. Until that is
+specified, a joint block states its median and says nothing about the tail — it
+must never be read as a P95 line.
 
 `max` is taken **per observation, before any aggregation**. `median(max(checks))`
 is not `max(median(checks))`: with A and B alternating between 300s and 100s,
@@ -518,7 +537,12 @@ staggered start or queue effect, an unresolved competitor, a conditional or
 missing check population, an ambiguous matrix identity, or insufficient per-job
 effect evidence all yield **unsupported**, with a concise limitation instead of
 a number. Non-finite or negative inputs, a reduction exceeding its affected
-work, and a negative modeled post-fix duration are refused the same way. This is
+work, and a negative modeled post-fix duration are refused the same way. So are
+the identity failures, because each of them silently changes which comparison
+gets made rather than erroring: a missing or repeated finding ID, a missing
+workflow, affected-work or evidence identity, and one check name claimed by two
+different workflows — the gating set holds a single duration under that name, so
+the two cannot be modelled as one check. This is
 deliberately not a general DAG scheduler; the existing single-finding
 chain-aware behaviour is unchanged.
 
@@ -528,13 +552,18 @@ chain-aware behaviour is unchanged.
 admission rules, unit-tested against every counterexample above. **Nothing in
 the engine stamps its inputs**, so no report renders a joint block. The gaps are
 listed in that module as `MISSING_PRODUCER_EVIDENCE`; in summary, the engine has
-no per-observation gating durations with run/attempt/era/runner identity (the
-nearest artifact is bimodal-gated, pole-capped and identity-free), no stamped
+no per-observation durations for the *whole* gating set — `pr_critical_path.
+chain_facts` carries per-sha, era-scoped `member_spans_s`, but only for the
+members of that PR's winning chain and with no attempt or runner identity,
+while `populations` is bimodal-gated and identity-free — no stamped
 concurrency validation (overlap is inferred from the `needs:` closure and
 *defaults to concurrent* when no job graph is available), no per-observation
 local reductions (raw pre-cascade estimates are one scalar per finding, and one
 scalar across all legs for a cluster finding), no affected-step identity beyond
-a single `decomposition.dominant_step`, no stable matrix-leg identity, and no
+a cluster finding's `measured_evidence.waterfall.shared_step` and a single
+`decomposition.dominant_step`, no stable matrix-leg identity (`affected_jobs`
+holds YAML job keys on the scan path and display names on the measured path,
+and a job key names all of a job's legs at once), and no
 certificate that a fix leaves scheduling, coverage and the job set unchanged.
 Adding an adapter before that evidence exists would produce confident numbers
 with nothing behind them.

--- a/skills/ci-speedup/references/wall-clock-methodology.md
+++ b/skills/ci-speedup/references/wall-clock-methodology.md
@@ -27,6 +27,7 @@ illustrative figures from real audits, kept to anchor the model.
 - [5a. Observed timing spread is descriptive, never an inference](#5a-observed-timing-spread-is-descriptive-never-an-inference)
 - [6. Reliability is a wall-clock multiplier](#6-reliability-is-a-wall-clock-multiplier)
 - [7. Report structure](#7-report-structure)
+- [8. Joint scenarios for two concurrent checks (contract only — not yet produced)](#8-joint-scenarios-for-two-concurrent-checks-contract-only--not-yet-produced)
 
 ---
 
@@ -432,3 +433,108 @@ same-pattern residual findings that are not promoted into Runner-minute
 reductions. State the budget inversion plainly for wall-clock-negative rows:
 e.g. build-dedup spends developer-minutes of *wait* to save runner-minutes of
 *bill* — the two budgets move in opposite directions.
+
+---
+
+## 8. Joint scenarios for two concurrent checks (contract only — not yet produced)
+
+Two findings on two *different* concurrent checks can each be worth almost
+nothing alone and a great deal together. With A at 300s and B at 299s, cutting
+100s off A moves the gate by 1s and cutting 100s off B moves it by 0s — but
+doing both moves it by 100s. The report cannot say that today, and this section
+records the model that would let it, plus the reason it is not yet wired to
+live data.
+
+### The per-finding savings stamps CANNOT drive this
+
+`wall_clock_p50_s` is **not a post-fix duration**. It is an *effective merge-wait
+saving* that has already been through the cross-cutting bound cascade in §2 —
+developer-facing gate, measured population-weighted critical-path floor,
+cross-workflow floor. For the shape above it stamps A=1s and B=0s. Subtracting
+those from the observed durations gives post-fix durations of 299s/299s and a
+joint saving of **1s**: wrong by two orders of magnitude.
+
+`wall_clock_uncapped_p50_s` is not a substitute. It is a single workflow-level
+scalar. It does not describe each affected job, it does not decompose across
+matrix legs (a cluster finding stamps one number for *all* its legs), and it is
+absent entirely when no bound fired.
+
+### The model
+
+For observation `r`, check `j`, and a selected set of effects `S`:
+
+```text
+d_after(r,j,S) = d_before(r,j) − sum(eligible local reductions for j in S)
+T_before(r)    = max_j d_before(r,j)
+T_after(r,S)   = max_j d_after(r,j,S)
+delta(r,S)     = T_before(r) − T_after(r,S)
+scenario_delta_p50(S) = median_r delta(r,S)
+```
+
+`max` is taken **per observation, before any aggregation**. `median(max(checks))`
+is not `max(median(checks))`: with A and B alternating between 300s and 100s,
+both per-check medians are 200s while every observed gate is 300s. Per-check
+medians throw away exactly the co-occurrence information the gate is made of.
+
+`median(T_before)`, `median(T_after)` and `median(delta)` are **three separate
+summaries**. They are not required to subtract into one another, and a report
+must not present them as if they do.
+
+Every unaffected gating check stays in the `max` as a competitor, including
+unaffected matrix legs. Adding an untouched C=295s to the example caps the joint
+saving at 5s; C=300s caps it at 0s. **Zero is an honest supported answer** — it
+means C is the blocker — and it is a different answer from *unsupported*.
+
+The result is explicitly a **modeled concurrent-runtime change with unchanged
+scheduling**. It is not an observed before/after measurement and it does not
+replace or subtract from the report's merge-wait headline.
+
+### What a producer must stamp
+
+An effect is not derivable from what the engine stamps today. Each eligible
+effect has to record, explicitly:
+
+- the finding ID, the exact workflow / job / matrix-leg identity, the affected
+  step or work identity, and its source evidence references;
+- a modeled local duration reduction **per matched observation**, the assumption
+  that generated it, and a bound by that observation's affected work duration;
+- that it is a local runtime change with unchanged scheduling, coverage and job
+  set — relocation, new sharding, cancellation and trigger changes are
+  ineligible;
+- compatibility evidence. Only **disjoint affected work** is accepted; two
+  findings touching the same step are overlapping alternatives and are rejected,
+  never summed and never heuristically de-overlapped.
+
+Matched observations of the **whole** gating set are required on one
+configuration / runner / population basis, each validating concurrent execution
+against its timing span within a tested tolerance, with any tolerated residual
+disclosed and excluded from the runtime-only model. If timeline evidence is
+missing, concurrency is **not** assumed from similar durations.
+
+### When a numeric scenario is refused
+
+A `needs:` chain, a required aggregator, a shared serial upstream, an unmodelled
+staggered start or queue effect, an unresolved competitor, a conditional or
+missing check population, an ambiguous matrix identity, or insufficient per-job
+effect evidence all yield **unsupported**, with a concise limitation instead of
+a number. Non-finite or negative inputs, a reduction exceeding its affected
+work, and a negative modeled post-fix duration are refused the same way. This is
+deliberately not a general DAG scheduler; the existing single-finding
+chain-aware behaviour is unchanged.
+
+### Status: the contract exists, no producer feeds it
+
+`scripts/joint_scenario.py` holds the data contract, the calculator and the
+admission rules, unit-tested against every counterexample above. **Nothing in
+the engine stamps its inputs**, so no report renders a joint block. The gaps are
+listed in that module as `MISSING_PRODUCER_EVIDENCE`; in summary, the engine has
+no per-observation gating durations with run/attempt/era/runner identity (the
+nearest artifact is bimodal-gated, pole-capped and identity-free), no stamped
+concurrency validation (overlap is inferred from the `needs:` closure and
+*defaults to concurrent* when no job graph is available), no per-observation
+local reductions (raw pre-cascade estimates are one scalar per finding, and one
+scalar across all legs for a cluster finding), no affected-step identity beyond
+a single `decomposition.dominant_step`, no stable matrix-leg identity, and no
+certificate that a fix leaves scheduling, coverage and the job set unchanged.
+Adding an adapter before that evidence exists would produce confident numbers
+with nothing behind them.

--- a/skills/ci-speedup/scripts/joint_scenario.py
+++ b/skills/ci-speedup/scripts/joint_scenario.py
@@ -280,16 +280,28 @@ def _finite(value: Any) -> bool:
 
 
 def _normalise_basis(value: Any) -> str:
-    """Lowercase a declared basis and reduce every run of non-alphanumerics to
-    one underscore, so `Derived from wall_clock_p50_s.` and `wall clock p50 s`
-    reach the same token stream as the field they are naming."""
-    return re.sub(r"[^a-z0-9]+", "_", str(value).lower()).strip("_")
+    """Reduce a declared basis to a token stream, so the spellings a producer
+    might reasonably use for one field name all land on the same tokens:
+    `Derived from wall_clock_p50_s.`, `wall clock p50 s` and the camelCased
+    `wallClockP50s` a JSON producer would stamp all normalise to
+    `wall_clock_p50_s`. Case and punctuation are folded, camelCase humps and
+    digit/letter joins become token boundaries."""
+    spaced = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", str(value))
+    spaced = re.sub(r"(?<=[0-9])(?=[A-Za-z])", "_", spaced)
+    return re.sub(r"[^a-z0-9]+", "_", spaced.lower()).strip("_")
 
 
 def _names_a_capped_stamp(basis: str) -> str | None:
-    """The capped field a basis names, or None. Matching is on whole tokens of
-    the normalised form, so a paraphrase around a capped field is caught while
-    a different field that merely shares a word with one is not."""
+    """The capped field a basis names, or None.
+
+    Matching is on the field's whole token sequence within the normalised
+    basis, so the field name spelled in any case, punctuation or camelCase
+    convention is caught — including inside a longer sentence — while a
+    different field that merely shares a word with one is not. It is a
+    field-name match, NOT a semantic one: an English description of a capped
+    stamp that never names the field ("the capped merge-wait saving") is not
+    caught, and this guard is defence in depth rather than the contract.
+    """
     padded = f"_{_normalise_basis(basis)}_"
     for field_name in sorted(CAPPED_STAMP_FIELDS):
         if f"_{_normalise_basis(field_name)}_" in padded:
@@ -665,8 +677,13 @@ def _evaluate(gating: GatingSet, effects: tuple[ScenarioEffect, ...],
 def eligible_pairs(gating: GatingSet,
                    effects: Sequence[ScenarioEffect]) -> list[ScenarioResult]:
     """Every supported pair with a positive modeled joint reduction, ranked by
-    that reduction and then by stable finding IDs. Unsupported pairs are
-    dropped silently here — the caller renders the limitation, not a number."""
+    that reduction and then by stable finding IDs.
+
+    Unsupported pairs are dropped here and their rejections are NOT returned:
+    this layer answers "which pair is worth rendering", not "why was this pair
+    refused". A caller that needs the named limitation for a specific pair
+    calls `evaluate_scenario` on it directly.
+    """
     ordered = sorted(effects, key=lambda e: e.finding_id)
     out: list[ScenarioResult] = []
     for i in range(len(ordered)):
@@ -760,7 +777,7 @@ def load_inputs(doc: Mapping[str, Any]
                     for eo in (e.get("observations") or ())),
             )
             for e in (raw.get("effects") or ()))
-    except (AttributeError, TypeError, ValueError) as exc:
+    except (AttributeError, TypeError, ValueError, OverflowError) as exc:
         return None, (), ScenarioRejection(
             "malformed_contract_inputs", f"could not read the contract: {exc}")
 

--- a/skills/ci-speedup/scripts/joint_scenario.py
+++ b/skills/ci-speedup/scripts/joint_scenario.py
@@ -1,5 +1,8 @@
 """Joint scenarios for supported parallel checks — the data contract and the
-pure calculator (SPEC-2026-09-08 §6).
+pure calculator.
+
+The methodology this implements is
+`references/wall-clock-methodology.md` §8.
 
 WHY THIS MODULE EXISTS
 ----------------------
@@ -81,11 +84,13 @@ CAPPED_STAMP_FIELDS = frozenset({
 #: What no current producer stamps. This is the stop condition for the
 #: workstream, kept in code so a later adapter has a target rather than a guess.
 MISSING_PRODUCER_EVIDENCE = (
-    "per-observation gating durations: the engine keeps raw per-run job "
-    "durations only as a local in the collector and returns aggregated "
-    "job_p50/job_p95; `pr_critical_path.populations` is the closest artifact "
-    "and it is bimodal-gated, pole-capped, and carries no run, attempt, sha, "
-    "era or runner identity",
+    "per-observation gating durations for the WHOLE gating set: "
+    "`pr_critical_path.chain_facts` is the closest artifact and it does carry "
+    "per-sha, era-scoped `member_spans_s`, but only for the members of that "
+    "PR's winning chain, span-capped per check — never every competitor, and "
+    "with no attempt or runner identity. `populations` is bimodal-gated and "
+    "identity-free, and raw per-run job durations survive only as a local in "
+    "the collector, which returns aggregated job_p50/job_p95",
     "stamped concurrency validation: overlap is inferred structurally from the "
     "`needs:` closure and DEFAULTS TO CONCURRENT when no job graph is "
     "available; per-check start/finish intervals exist in memory but are "
@@ -94,12 +99,15 @@ MISSING_PRODUCER_EVIDENCE = (
     "one scalar per finding (and one scalar across ALL legs for a cluster "
     "finding), never a value per matched observation bounded by that "
     "observation's affected work",
-    "affected step/work identity: findings carry no `affected_steps` key; step "
-    "identity reaches a finding only as `decomposition.dominant_step`, which "
-    "cannot decide whether two findings touch disjoint work",
-    "stable matrix-leg identity: legs are display-name strings inside "
-    "`affected_jobs`, with no mapping from a finding to the exact legs it "
-    "changes",
+    "affected step/work identity: findings carry no `affected_steps` key. A "
+    "cluster finding does stamp `measured_evidence.waterfall.shared_step` (the "
+    "one step its fix changes) and every other finding reaches step identity "
+    "only as `decomposition.dominant_step` — one dominant step, which cannot "
+    "decide whether two findings touch disjoint work",
+    "stable matrix-leg identity: `affected_jobs` holds YAML job keys on the "
+    "scan path and GitHub display names on the measured path (`wall_clock.py` "
+    "bridges the two), and a job key names ALL of that job's legs at once, so "
+    "nothing maps a finding to the exact legs it changes",
     "a local-runtime-only certificate: nothing on a finding asserts that its "
     "fix leaves scheduling, coverage and the job set unchanged, which is the "
     "precondition for composing two effects at all",
@@ -137,10 +145,15 @@ class EffectObservation:
 class ScenarioEffect:
     """One finding's complete, explicit scenario effect."""
 
+    #: Unique within a scenario: solo reductions are keyed by it, so a blank or
+    #: repeated id would change which comparison the admission rule makes.
     finding_id: str
+    #: Required. Gating durations are keyed by bare check name, so two
+    #: workflows claiming one name are refused rather than conflated.
     workflow: str
-    #: Affected step/work identity. Two effects sharing a (check, work_id) pair
-    #: are overlapping alternatives and are rejected, never summed.
+    #: Affected step/work identity, required. Two effects sharing a
+    #: (check, work_id) pair are overlapping alternatives and are rejected,
+    #: never summed; blank work is not disjoint work and is refused too.
     work_id: str
     basis: str
     #: The assumption that generated the reductions, carried into the report.
@@ -293,6 +306,58 @@ def _validate_effects(g: GatingSet,
     obs_by_id = {o.observation_id: o for o in g.observations}
     all_ids = set(obs_by_id)
 
+    # Attribution identity comes first: a numeric result may not rest on an
+    # effect that cannot be told apart from another one. Solo results are keyed
+    # by finding ID and overlap is keyed by (check, work_id), so a blank or
+    # repeated identity silently changes which comparison the admission rule
+    # makes rather than producing an error.
+    seen_finding_ids: set[str] = set()
+    for e in effects:
+        if not (e.finding_id or "").strip():
+            return ScenarioRejection(
+                "missing_finding_id",
+                "an effect declares no finding id; solo reductions are keyed "
+                "by it and an unnamed effect cannot be compared against the "
+                "joint result")
+        if e.finding_id in seen_finding_ids:
+            return ScenarioRejection(
+                "duplicate_finding_id",
+                f"{e.finding_id!r} is declared by more than one effect; the "
+                "later solo reduction would overwrite the earlier one and the "
+                "joint result would be admitted against one half, not both")
+        seen_finding_ids.add(e.finding_id)
+        if not (e.workflow or "").strip():
+            return ScenarioRejection(
+                "missing_workflow_identity",
+                f"{e.finding_id} names no workflow; gating durations are keyed "
+                "by check name, so an unattributed check cannot be told apart "
+                "from a same-named check in another workflow")
+        if not (e.work_id or "").strip():
+            return ScenarioRejection(
+                "missing_work_identity",
+                f"{e.finding_id} names no affected work; unknown work is not "
+                "disjoint work, and it would key the overlap check differently "
+                "from the named step it may actually be")
+        if not [r for r in e.evidence_refs if (r or "").strip()]:
+            return ScenarioRejection(
+                "missing_evidence_refs",
+                f"{e.finding_id} carries no source evidence references; a "
+                "supported scenario states where its reductions came from")
+
+    # Gating durations are keyed by bare check name, so one name means one
+    # check. Two workflows claiming it are two different checks sharing one
+    # duration entry, and summing both reductions onto it invents a saving.
+    check_workflow: dict[str, str] = {}
+    for e in effects:
+        for check in sorted(e.check_names):
+            prior = check_workflow.setdefault(check, e.workflow)
+            if prior != e.workflow:
+                return ScenarioRejection(
+                    "ambiguous_check_identity",
+                    f"{check!r} is claimed by both {prior!r} and "
+                    f"{e.workflow!r}; the gating set carries one duration for "
+                    "that name, so the two cannot be modelled as one check")
+
     for e in effects:
         if not e.local_runtime_only:
             return ScenarioRejection(
@@ -394,6 +459,25 @@ def _validate_effects(g: GatingSet,
                     f"{check!r}; overlapping alternatives are rejected, never "
                     "summed or heuristically de-overlapped")
             owner[key] = e.finding_id
+
+    # Disjointness is a producer-declared label, so it is also budgeted against
+    # the observation. Two effects that each claim 250s of affected work in one
+    # 300s check cannot both be telling the truth, whatever their work ids say,
+    # and summing their reductions would take the same seconds off twice.
+    work_budget: dict[tuple[str, str], float] = {}
+    for e in effects:
+        for eo in e.observations:
+            key = (eo.observation_id, eo.check_name)
+            work_budget[key] = work_budget.get(key, 0.0) + float(eo.affected_work_s)
+    for (oid, check), claimed in sorted(work_budget.items()):
+        observed = float(obs_by_id[oid].check_durations[check])
+        if claimed > observed:
+            return ScenarioRejection(
+                "affected_work_sum_exceeds_duration",
+                f"the selected effects claim {claimed}s of affected work in "
+                f"{check!r} in {oid!r}, which observed only {observed}s; work "
+                "declared disjoint that does not fit inside the check is "
+                "double-counted, not composed")
     return None
 
 

--- a/skills/ci-speedup/scripts/joint_scenario.py
+++ b/skills/ci-speedup/scripts/joint_scenario.py
@@ -1,0 +1,598 @@
+"""Joint scenarios for supported parallel checks — the data contract and the
+pure calculator (SPEC-2026-09-08 §6).
+
+WHY THIS MODULE EXISTS
+----------------------
+Two findings on two *different* concurrent checks can each be worth ~nothing on
+their own and a great deal together: if A takes 300s and B takes 299s, cutting
+100s off A moves the merge gate by 1s and cutting 100s off B moves it by 0s, but
+doing both moves it by 100s. The report has no way to say that today.
+
+WHY IT DOES NOT READ THE EXISTING SAVINGS STAMPS
+------------------------------------------------
+`wall_clock_p50_s` is NOT a post-fix duration. It is an *effective merge-wait
+saving* that has already been through the cross-cutting bound cascade in
+`wall_clock.py` — developer-facing gate, measured population-weighted
+critical-path floor, cross-workflow floor — so for the shape above it stamps
+A=1s and B=0s. Subtracting those from the observed durations yields post-fix
+durations of 299s/299s and a joint saving of 1s: the wrong answer by two orders
+of magnitude. `wall_clock_uncapped_p50_s` is not a substitute either — it is a
+single workflow-level scalar that does not describe each affected job, does not
+decompose across matrix legs, and is absent entirely when no bound fired.
+
+So this module refuses to guess. It consumes an explicit, producer-stamped
+contract of matched observations and per-observation local effects, validates
+every admission condition, and either returns exact numbers or a named
+rejection. `MISSING_PRODUCER_EVIDENCE` records what a producer would have to
+stamp for that contract to be satisfiable; nothing in the engine stamps it yet.
+
+SCOPE
+-----
+V1 supports independent, concurrent checks with a fixed measured gating set. It
+is NOT a general DAG scheduler: a `needs:` chain, a required aggregator, a
+shared serial upstream, an unresolved competitor, a conditional check
+population, an ambiguous matrix identity, or insufficient per-job effect
+evidence all yield an *unsupported* verdict. Unsupported is not zero, and a
+zero saving is not unsupported — the two are different answers and this module
+keeps them apart.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Sequence
+
+# --------------------------------------------------------------------------
+# contract constants
+# --------------------------------------------------------------------------
+
+SCENARIO_CONTRACT_VERSION = 1
+
+#: Top-level findings-artifact key a producer would stamp to feed this module.
+JOINT_SCENARIO_INPUTS_KEY = "joint_scenario_inputs"
+
+#: The only gating topology v1 can model.
+SUPPORTED_TOPOLOGY = "independent_concurrent"
+
+#: Seconds of start/finish skew tolerated when an observation claims its checks
+#: ran concurrently. A residual inside this bound is kept and DISCLOSED; the
+#: runtime-only model does not attempt to credit or debit it. Beyond it the
+#: observation is rejected rather than modelled with an unmodelled queue effect.
+CONCURRENCY_TOLERANCE_S = 5.0
+
+#: The report renders whole seconds; scenario selection compares at that
+#: precision so a block is never crowned on a difference the reader cannot see.
+DISPLAY_DECIMALS = 0
+
+#: Fields that are already-capped or already-aggregated savings stamps. None of
+#: them is a per-observation local duration reduction, so none may be declared
+#: as an effect's `reduction_basis`.
+CAPPED_STAMP_FIELDS = frozenset({
+    "wall_clock_p50_s",
+    "wall_clock_uncapped_p50_s",
+    "wall_clock_derivation",
+    "cluster_floor_lever",
+    "runner_min_saving",
+    "chain_win_s",
+})
+
+#: What no current producer stamps. This is the stop condition for the
+#: workstream, kept in code so a later adapter has a target rather than a guess.
+MISSING_PRODUCER_EVIDENCE = (
+    "per-observation gating durations: the engine keeps raw per-run job "
+    "durations only as a local in the collector and returns aggregated "
+    "job_p50/job_p95; `pr_critical_path.populations` is the closest artifact "
+    "and it is bimodal-gated, pole-capped, and carries no run, attempt, sha, "
+    "era or runner identity",
+    "stamped concurrency validation: overlap is inferred structurally from the "
+    "`needs:` closure and DEFAULTS TO CONCURRENT when no job graph is "
+    "available; per-check start/finish intervals exist in memory but are "
+    "reduced to a single makespan scalar and never persisted",
+    "per-observation local duration reductions: raw pre-cascade estimates are "
+    "one scalar per finding (and one scalar across ALL legs for a cluster "
+    "finding), never a value per matched observation bounded by that "
+    "observation's affected work",
+    "affected step/work identity: findings carry no `affected_steps` key; step "
+    "identity reaches a finding only as `decomposition.dominant_step`, which "
+    "cannot decide whether two findings touch disjoint work",
+    "stable matrix-leg identity: legs are display-name strings inside "
+    "`affected_jobs`, with no mapping from a finding to the exact legs it "
+    "changes",
+    "a local-runtime-only certificate: nothing on a finding asserts that its "
+    "fix leaves scheduling, coverage and the job set unchanged, which is the "
+    "precondition for composing two effects at all",
+)
+
+
+# --------------------------------------------------------------------------
+# data contract
+# --------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class GatingObservation:
+    """One matched observation (run/attempt) of the WHOLE gating set."""
+
+    observation_id: str
+    basis: str
+    check_durations: Mapping[str, float]
+    concurrency_validated: bool = False
+    scheduling_residual_s: float = 0.0
+
+
+@dataclass(frozen=True)
+class EffectObservation:
+    """One finding's modeled local reduction on one check in one observation."""
+
+    observation_id: str
+    check_name: str
+    reduction_s: float
+    #: The duration of the work this finding actually changes in this
+    #: observation. The reduction may not exceed it.
+    affected_work_s: float
+
+
+@dataclass(frozen=True)
+class ScenarioEffect:
+    """One finding's complete, explicit scenario effect."""
+
+    finding_id: str
+    workflow: str
+    #: Affected step/work identity. Two effects sharing a (check, work_id) pair
+    #: are overlapping alternatives and are rejected, never summed.
+    work_id: str
+    basis: str
+    #: The assumption that generated the reductions, carried into the report.
+    assumption: str
+    evidence_refs: tuple[str, ...]
+    #: True only for a local runtime change with unchanged scheduling, coverage
+    #: and job set. Relocation, new sharding, cancellation and trigger changes
+    #: are ineligible in v1.
+    local_runtime_only: bool
+    matrix_identity_resolved: bool
+    #: Where the reductions came from. May not name a capped savings stamp.
+    reduction_basis: str
+    observations: tuple[EffectObservation, ...]
+
+    @property
+    def check_names(self) -> frozenset[str]:
+        return frozenset(o.check_name for o in self.observations)
+
+
+@dataclass(frozen=True)
+class GatingSet:
+    """The fixed measured gating set and its matched observations."""
+
+    topology: str
+    check_names: frozenset[str]
+    basis: str
+    observations: tuple[GatingObservation, ...]
+
+
+@dataclass(frozen=True)
+class ScenarioRejection:
+    code: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class ScenarioResult:
+    supported: bool
+    rejection: ScenarioRejection | None = None
+    finding_ids: tuple[str, ...] = ()
+    n_observations: int = 0
+    basis: str = ""
+    median_t_before_s: float | None = None
+    median_t_after_s: float | None = None
+    median_delta_s: float | None = None
+    individual_delta_s: Mapping[str, float] = field(default_factory=dict)
+    modeled_check_after_s: Mapping[str, float] = field(default_factory=dict)
+    tolerated_residual_s: float = 0.0
+    assumptions: tuple[str, ...] = ()
+    evidence_refs: tuple[str, ...] = ()
+    contract_version: int = SCENARIO_CONTRACT_VERSION
+
+
+# --------------------------------------------------------------------------
+# small helpers
+# --------------------------------------------------------------------------
+
+def median(values: Iterable[float]) -> float:
+    """Plain median. Exported so callers and tests share one definition and
+    nobody re-derives a 'median' that is really a mean or a p50 of a p50."""
+    return float(statistics.median(list(values)))
+
+
+def _display(value: float) -> float:
+    return round(float(value), DISPLAY_DECIMALS)
+
+
+def _finite(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) \
+        and math.isfinite(float(value))
+
+
+def _reject(code: str, detail: str) -> ScenarioResult:
+    return ScenarioResult(supported=False,
+                          rejection=ScenarioRejection(code, detail))
+
+
+# --------------------------------------------------------------------------
+# validation
+# --------------------------------------------------------------------------
+
+def _validate_gating(g: GatingSet) -> ScenarioRejection | None:
+    if g.topology != SUPPORTED_TOPOLOGY:
+        return ScenarioRejection(
+            "unsupported_topology",
+            f"gating topology {g.topology!r} is not {SUPPORTED_TOPOLOGY!r}; "
+            "a needs: chain, required aggregator or shared serial upstream "
+            "needs a DAG counterfactual v1 does not implement")
+    if not g.observations:
+        return ScenarioRejection("no_matched_observations",
+                                 "no matched observations of the gating set")
+    if not g.check_names:
+        return ScenarioRejection("no_matched_observations",
+                                 "the gating set names no checks")
+
+    seen: set[str] = set()
+    for o in g.observations:
+        if o.observation_id in seen:
+            return ScenarioRejection(
+                "duplicate_observation",
+                f"observation {o.observation_id!r} appears twice")
+        seen.add(o.observation_id)
+        if o.basis != g.basis:
+            return ScenarioRejection(
+                "basis_mismatch",
+                f"observation {o.observation_id!r} is on basis {o.basis!r}, "
+                f"not the scenario basis {g.basis!r}")
+        for name, dur in o.check_durations.items():
+            if not _finite(dur):
+                return ScenarioRejection(
+                    "non_finite_input",
+                    f"{name!r} in {o.observation_id!r} has a non-finite "
+                    f"duration {dur!r}")
+            if float(dur) < 0:
+                return ScenarioRejection(
+                    "negative_input",
+                    f"{name!r} in {o.observation_id!r} has a negative "
+                    f"duration {dur!r}")
+        missing = sorted(set(g.check_names) - set(o.check_durations))
+        if missing:
+            return ScenarioRejection(
+                "missing_competitor",
+                f"observation {o.observation_id!r} has no duration for "
+                f"{', '.join(missing)}; an unresolved competitor cannot be "
+                "treated as absent from the gate")
+        if not o.concurrency_validated:
+            return ScenarioRejection(
+                "concurrency_unvalidated",
+                f"observation {o.observation_id!r} does not carry a validated "
+                "concurrent timing span; similar durations are not evidence "
+                "of concurrency")
+        res = o.scheduling_residual_s
+        if not _finite(res) or float(res) < 0:
+            return ScenarioRejection(
+                "non_finite_input" if not _finite(res) else "negative_input",
+                f"observation {o.observation_id!r} has scheduling residual "
+                f"{res!r}")
+        if float(res) > CONCURRENCY_TOLERANCE_S:
+            return ScenarioRejection(
+                "scheduling_residual_exceeds_tolerance",
+                f"observation {o.observation_id!r} has a {res}s scheduling "
+                f"residual, beyond the {CONCURRENCY_TOLERANCE_S}s tolerance; "
+                "a staggered start is not modelled by a runtime-only scenario")
+    return None
+
+
+def _validate_effects(g: GatingSet,
+                      effects: Sequence[ScenarioEffect]
+                      ) -> ScenarioRejection | None:
+    obs_by_id = {o.observation_id: o for o in g.observations}
+    all_ids = set(obs_by_id)
+
+    for e in effects:
+        if not e.local_runtime_only:
+            return ScenarioRejection(
+                "not_local_runtime_only",
+                f"{e.finding_id} is not a local runtime change with unchanged "
+                "scheduling, coverage and job set; relocation, new sharding, "
+                "cancellation and trigger changes are ineligible in v1")
+        if not e.matrix_identity_resolved:
+            return ScenarioRejection(
+                "ambiguous_matrix_identity",
+                f"{e.finding_id} does not resolve which matrix legs it changes")
+        if not (e.reduction_basis or "").strip():
+            return ScenarioRejection(
+                "missing_reduction_basis",
+                f"{e.finding_id} declares no reduction basis")
+        if e.reduction_basis in CAPPED_STAMP_FIELDS:
+            return ScenarioRejection(
+                "capped_stamp_not_a_local_reduction",
+                f"{e.finding_id} declares {e.reduction_basis!r} as its "
+                "reduction basis; that field is an already-capped or "
+                "workflow-level savings stamp, not a per-observation local "
+                "duration reduction")
+        if not (e.assumption or "").strip():
+            return ScenarioRejection(
+                "missing_assumption",
+                f"{e.finding_id} states no modelling assumption")
+        if e.basis != g.basis:
+            return ScenarioRejection(
+                "basis_mismatch",
+                f"{e.finding_id} is on basis {e.basis!r}, not the scenario "
+                f"basis {g.basis!r}")
+
+        off = sorted(e.check_names - set(g.check_names))
+        if off:
+            return ScenarioRejection(
+                "off_gating_set_check",
+                f"{e.finding_id} names {', '.join(off)}, which is not in the "
+                "measured gating set; an off-spine check has no competitor "
+                "semantics and cannot enter a joint scenario")
+
+        seen: set[tuple[str, str]] = set()
+        for eo in e.observations:
+            key = (eo.observation_id, eo.check_name)
+            if key in seen:
+                return ScenarioRejection(
+                    "duplicate_effect_row",
+                    f"{e.finding_id} states {eo.check_name!r} twice for "
+                    f"{eo.observation_id!r}")
+            seen.add(key)
+            if eo.observation_id not in obs_by_id:
+                return ScenarioRejection(
+                    "insufficient_effect_evidence",
+                    f"{e.finding_id} refers to unmatched observation "
+                    f"{eo.observation_id!r}")
+            if not _finite(eo.reduction_s) or not _finite(eo.affected_work_s):
+                return ScenarioRejection(
+                    "non_finite_input",
+                    f"{e.finding_id} has a non-finite reduction or affected "
+                    f"work in {eo.observation_id!r}")
+            if float(eo.reduction_s) < 0 or float(eo.affected_work_s) < 0:
+                return ScenarioRejection(
+                    "negative_input",
+                    f"{e.finding_id} has a negative reduction or affected "
+                    f"work in {eo.observation_id!r}")
+            if float(eo.reduction_s) > float(eo.affected_work_s):
+                return ScenarioRejection(
+                    "reduction_exceeds_affected_work",
+                    f"{e.finding_id} models {eo.reduction_s}s off "
+                    f"{eo.check_name!r} in {eo.observation_id!r} but only "
+                    f"{eo.affected_work_s}s of affected work is present")
+            d_before = float(
+                obs_by_id[eo.observation_id].check_durations[eo.check_name])
+            if float(eo.affected_work_s) > d_before:
+                return ScenarioRejection(
+                    "affected_work_exceeds_duration",
+                    f"{e.finding_id} claims {eo.affected_work_s}s of affected "
+                    f"work in {eo.check_name!r} but {eo.observation_id!r} "
+                    f"observed only {d_before}s")
+
+        covered = {eo.observation_id for eo in e.observations}
+        if covered != all_ids:
+            gap = sorted(all_ids - covered)
+            return ScenarioRejection(
+                "insufficient_effect_evidence",
+                f"{e.finding_id} has no modeled effect for "
+                f"{', '.join(gap) or 'some observations'}; a per-job effect "
+                "must be stated for every matched observation")
+
+    # compatibility: v1 accepts only disjoint affected work
+    owner: dict[tuple[str, str], str] = {}
+    for e in effects:
+        for check in sorted(e.check_names):
+            key = (check, e.work_id)
+            prior = owner.get(key)
+            if prior is not None:
+                return ScenarioRejection(
+                    "overlapping_affected_work",
+                    f"{prior} and {e.finding_id} both change {e.work_id!r} in "
+                    f"{check!r}; overlapping alternatives are rejected, never "
+                    "summed or heuristically de-overlapped")
+            owner[key] = e.finding_id
+    return None
+
+
+# --------------------------------------------------------------------------
+# calculation
+# --------------------------------------------------------------------------
+
+def _after_durations(o: GatingObservation,
+                     effects: Sequence[ScenarioEffect]
+                     ) -> dict[str, float] | ScenarioRejection:
+    after = {k: float(v) for k, v in o.check_durations.items()}
+    for e in effects:
+        for eo in e.observations:
+            if eo.observation_id != o.observation_id:
+                continue
+            after[eo.check_name] = after[eo.check_name] - float(eo.reduction_s)
+    for name, value in after.items():
+        if value < 0:
+            return ScenarioRejection(
+                "negative_post_fix_duration",
+                f"{name!r} in {o.observation_id!r} models to {value}s; the "
+                "selected reductions exceed the observed duration")
+    return after
+
+
+def evaluate_scenario(gating: GatingSet,
+                      effects: Sequence[ScenarioEffect]) -> ScenarioResult:
+    """Model the merge gate under the selected effects, or say why it cannot.
+
+    Every finding's solo effect is evaluated with the same machinery, so the
+    individual and joint numbers below can never drift apart.
+
+        d_after(r,j,S) = d_before(r,j) - sum(eligible local reductions for j)
+        T_before(r)    = max_j d_before(r,j)
+        T_after(r,S)   = max_j d_after(r,j,S)
+        delta(r,S)     = T_before(r) - T_after(r,S)
+        scenario_delta_p50(S) = median_r delta(r,S)
+
+    `max` is taken PER OBSERVATION, before any aggregation: median(max(checks))
+    is not max(median(checks)), and per-check medians throw away exactly the
+    co-occurrence information the gate is made of. The three medians are
+    reported separately and are NOT required to subtract into one another.
+    """
+    return _evaluate(gating, tuple(effects), with_individuals=True)
+
+
+def _evaluate(gating: GatingSet, effects: tuple[ScenarioEffect, ...],
+              *, with_individuals: bool) -> ScenarioResult:
+    rej = _validate_gating(gating)
+    if rej is None:
+        rej = _validate_effects(gating, effects)
+    if rej is not None:
+        return _reject(rej.code, rej.detail)
+
+    t_before: list[float] = []
+    t_after: list[float] = []
+    deltas: list[float] = []
+    after_by_check: dict[str, list[float]] = {n: [] for n in gating.check_names}
+
+    for o in gating.observations:
+        after = _after_durations(o, effects)
+        if isinstance(after, ScenarioRejection):
+            return _reject(after.code, after.detail)
+        before_max = max(float(o.check_durations[n]) for n in gating.check_names)
+        after_max = max(after[n] for n in gating.check_names)
+        t_before.append(before_max)
+        t_after.append(after_max)
+        deltas.append(before_max - after_max)
+        for n in gating.check_names:
+            after_by_check[n].append(after[n])
+
+    individual: dict[str, float] = {}
+    if with_individuals:
+        for e in effects:
+            solo = _evaluate(gating, (e,), with_individuals=False)
+            if not solo.supported:
+                return _reject(
+                    solo.rejection.code,
+                    f"{e.finding_id} alone: {solo.rejection.detail}")
+            individual[e.finding_id] = solo.median_delta_s
+
+    return ScenarioResult(
+        supported=True,
+        finding_ids=tuple(sorted(e.finding_id for e in effects)),
+        n_observations=len(gating.observations),
+        basis=gating.basis,
+        median_t_before_s=median(t_before),
+        median_t_after_s=median(t_after),
+        median_delta_s=median(deltas),
+        individual_delta_s=individual,
+        modeled_check_after_s={n: median(v) for n, v in after_by_check.items()},
+        tolerated_residual_s=max(
+            (float(o.scheduling_residual_s) for o in gating.observations),
+            default=0.0),
+        assumptions=tuple(e.assumption for e in effects),
+        evidence_refs=tuple(r for e in effects for r in e.evidence_refs),
+    )
+
+
+def eligible_pairs(gating: GatingSet,
+                   effects: Sequence[ScenarioEffect]) -> list[ScenarioResult]:
+    """Every supported pair with a positive modeled joint reduction, ranked by
+    that reduction and then by stable finding IDs. Unsupported pairs are
+    dropped silently here — the caller renders the limitation, not a number."""
+    ordered = sorted(effects, key=lambda e: e.finding_id)
+    out: list[ScenarioResult] = []
+    for i in range(len(ordered)):
+        for j in range(i + 1, len(ordered)):
+            res = evaluate_scenario(gating, [ordered[i], ordered[j]])
+            if res.supported and _display(res.median_delta_s) > 0:
+                out.append(res)
+    out.sort(key=lambda r: (-_display(r.median_delta_s), r.finding_ids))
+    return out
+
+
+def select_joint_block(gating: GatingSet,
+                       effects: Sequence[ScenarioEffect]
+                       ) -> ScenarioResult | None:
+    """The at-most-one pair worth rendering: the highest-ranked eligible pair
+    whose joint reduction exceeds BOTH individual reductions at the report's
+    displayed precision. This is a scenario-selection rule, not a significance
+    or noise threshold — a pair that merely ties its best half tells the reader
+    nothing the single finding did not already say."""
+    for res in eligible_pairs(gating, effects):
+        joint = _display(res.median_delta_s)
+        if all(joint > _display(v) for v in res.individual_delta_s.values()):
+            return res
+    return None
+
+
+# --------------------------------------------------------------------------
+# artifact loading
+# --------------------------------------------------------------------------
+
+def load_inputs(doc: Mapping[str, Any]
+                ) -> tuple[GatingSet | None, tuple[ScenarioEffect, ...],
+                           ScenarioRejection | None]:
+    """Read a producer-stamped contract out of a findings artifact.
+
+    No producer stamps it today, so on a current artifact this returns
+    `contract_inputs_absent` — deliberately, rather than reconstructing a
+    scenario out of the aggregate stamps that happen to be present.
+    See `MISSING_PRODUCER_EVIDENCE`.
+    """
+    raw = doc.get(JOINT_SCENARIO_INPUTS_KEY) if isinstance(doc, Mapping) else None
+    if not isinstance(raw, Mapping) or not raw:
+        return None, (), ScenarioRejection(
+            "contract_inputs_absent",
+            f"no {JOINT_SCENARIO_INPUTS_KEY!r} in the findings artifact; "
+            "joint sizing needs stamped per-observation effects, not the "
+            "capped per-finding savings stamps")
+
+    version = raw.get("contract_version")
+    if version != SCENARIO_CONTRACT_VERSION:
+        return None, (), ScenarioRejection(
+            "unsupported_contract_version",
+            f"contract version {version!r} is not "
+            f"{SCENARIO_CONTRACT_VERSION}; refusing to interpret it")
+
+    try:
+        gating = GatingSet(
+            topology=str(raw.get("topology") or ""),
+            check_names=frozenset(str(n) for n in (raw.get("check_names") or ())),
+            basis=str(raw.get("basis") or ""),
+            observations=tuple(
+                GatingObservation(
+                    observation_id=str(o.get("observation_id") or ""),
+                    basis=str(o.get("basis") or ""),
+                    check_durations={str(k): float(v) for k, v
+                                     in (o.get("check_durations") or {}).items()},
+                    concurrency_validated=bool(o.get("concurrency_validated")),
+                    scheduling_residual_s=float(
+                        o.get("scheduling_residual_s") or 0.0),
+                )
+                for o in (raw.get("observations") or ())),
+        )
+        effects = tuple(
+            ScenarioEffect(
+                finding_id=str(e.get("finding_id") or ""),
+                workflow=str(e.get("workflow") or ""),
+                work_id=str(e.get("work_id") or ""),
+                basis=str(e.get("basis") or ""),
+                assumption=str(e.get("assumption") or ""),
+                evidence_refs=tuple(str(r) for r in (e.get("evidence_refs") or ())),
+                local_runtime_only=bool(e.get("local_runtime_only")),
+                matrix_identity_resolved=bool(e.get("matrix_identity_resolved")),
+                reduction_basis=str(e.get("reduction_basis") or ""),
+                observations=tuple(
+                    EffectObservation(
+                        observation_id=str(eo.get("observation_id") or ""),
+                        check_name=str(eo.get("check_name") or ""),
+                        reduction_s=float(eo.get("reduction_s")),
+                        affected_work_s=float(eo.get("affected_work_s")),
+                    )
+                    for eo in (e.get("observations") or ())),
+            )
+            for e in (raw.get("effects") or ()))
+    except (AttributeError, TypeError, ValueError) as exc:
+        return None, (), ScenarioRejection(
+            "malformed_contract_inputs", f"could not read the contract: {exc}")
+
+    return gating, effects, None

--- a/skills/ci-speedup/scripts/joint_scenario.py
+++ b/skills/ci-speedup/scripts/joint_scenario.py
@@ -43,6 +43,7 @@ keeps them apart.
 from __future__ import annotations
 
 import math
+import re
 import statistics
 from dataclasses import dataclass, field
 from typing import Any, Iterable, Mapping, Sequence
@@ -183,10 +184,62 @@ class GatingSet:
     observations: tuple[GatingObservation, ...]
 
 
+#: Every refusal this module can produce. A rejection code is the only part of
+#: an unsupported verdict a caller can branch on and a test can pin, so the
+#: vocabulary is closed: a new refusal is declared here in the same edit that
+#: raises it, or it fails the moment it fires.
+REJECTION_CODES: frozenset[str] = frozenset({
+    # the gating set and its observations
+    "unsupported_topology",
+    "no_matched_observations",
+    "duplicate_observation",
+    "basis_mismatch",
+    "non_finite_input",
+    "negative_input",
+    "missing_competitor",
+    "undeclared_competitor",
+    "concurrency_unvalidated",
+    "scheduling_residual_exceeds_tolerance",
+    # who and what an effect claims to be
+    "missing_finding_id",
+    "duplicate_finding_id",
+    "missing_workflow_identity",
+    "missing_work_identity",
+    "missing_evidence_refs",
+    "ambiguous_check_identity",
+    # whether an effect is eligible at all
+    "not_local_runtime_only",
+    "ambiguous_matrix_identity",
+    "missing_reduction_basis",
+    "capped_stamp_not_a_local_reduction",
+    "missing_assumption",
+    "off_gating_set_check",
+    # the numbers an effect states
+    "duplicate_effect_row",
+    "insufficient_effect_evidence",
+    "reduction_exceeds_affected_work",
+    "affected_work_exceeds_duration",
+    "overlapping_affected_work",
+    "affected_work_sum_exceeds_duration",
+    "negative_post_fix_duration",
+    # reading a producer-stamped artifact
+    "contract_inputs_absent",
+    "unsupported_contract_version",
+    "malformed_contract_inputs",
+})
+
+
 @dataclass(frozen=True)
 class ScenarioRejection:
     code: str
     detail: str
+
+    def __post_init__(self) -> None:
+        if self.code not in REJECTION_CODES:
+            raise ValueError(
+                f"{self.code!r} is not a declared rejection code; add it to "
+                "REJECTION_CODES so callers and tests can see the whole "
+                "refusal vocabulary")
 
 
 @dataclass(frozen=True)
@@ -224,6 +277,24 @@ def _display(value: float) -> float:
 def _finite(value: Any) -> bool:
     return isinstance(value, (int, float)) and not isinstance(value, bool) \
         and math.isfinite(float(value))
+
+
+def _normalise_basis(value: Any) -> str:
+    """Lowercase a declared basis and reduce every run of non-alphanumerics to
+    one underscore, so `Derived from wall_clock_p50_s.` and `wall clock p50 s`
+    reach the same token stream as the field they are naming."""
+    return re.sub(r"[^a-z0-9]+", "_", str(value).lower()).strip("_")
+
+
+def _names_a_capped_stamp(basis: str) -> str | None:
+    """The capped field a basis names, or None. Matching is on whole tokens of
+    the normalised form, so a paraphrase around a capped field is caught while
+    a different field that merely shares a word with one is not."""
+    padded = f"_{_normalise_basis(basis)}_"
+    for field_name in sorted(CAPPED_STAMP_FIELDS):
+        if f"_{_normalise_basis(field_name)}_" in padded:
+            return field_name
+    return None
 
 
 def _reject(code: str, detail: str) -> ScenarioResult:
@@ -279,6 +350,18 @@ def _validate_gating(g: GatingSet) -> ScenarioRejection | None:
                 f"observation {o.observation_id!r} has no duration for "
                 f"{', '.join(missing)}; an unresolved competitor cannot be "
                 "treated as absent from the gate")
+        # The reverse direction matters just as much: the gate maximum is taken
+        # over the DECLARED names, so a check this observation timed but the
+        # gating set never declared would be silently excluded from the
+        # competition and the scenario credited with a saving it cannot have.
+        undeclared = sorted(set(o.check_durations) - set(g.check_names))
+        if undeclared:
+            return ScenarioRejection(
+                "undeclared_competitor",
+                f"observation {o.observation_id!r} timed "
+                f"{', '.join(undeclared)}, which the gating set does not "
+                "declare; an undeclared check would be dropped from the gate "
+                "maximum rather than competing in it")
         if not o.concurrency_validated:
             return ScenarioRejection(
                 "concurrency_unvalidated",
@@ -373,13 +456,15 @@ def _validate_effects(g: GatingSet,
             return ScenarioRejection(
                 "missing_reduction_basis",
                 f"{e.finding_id} declares no reduction basis")
-        if e.reduction_basis in CAPPED_STAMP_FIELDS:
+        capped = _names_a_capped_stamp(e.reduction_basis)
+        if capped is not None:
             return ScenarioRejection(
                 "capped_stamp_not_a_local_reduction",
                 f"{e.finding_id} declares {e.reduction_basis!r} as its "
-                "reduction basis; that field is an already-capped or "
-                "workflow-level savings stamp, not a per-observation local "
-                "duration reduction")
+                f"reduction basis, which names {capped!r}; that field is an "
+                "already-capped or workflow-level savings stamp, not a "
+                "per-observation local duration reduction. A basis derived "
+                "from it is the same stamp under another sentence")
         if not (e.assumption or "").strip():
             return ScenarioRejection(
                 "missing_assumption",

--- a/skills/ci-speedup/tests/test_joint_sizing.py
+++ b/skills/ci-speedup/tests/test_joint_sizing.py
@@ -1122,3 +1122,73 @@ def test_an_unenumerated_rejection_code_cannot_be_constructed():
         js.ScenarioRejection("a_code_nobody_declared", "detail")
     for code in sorted(js.REJECTION_CODES):
         assert js.ScenarioRejection(code, "detail").code == code
+
+
+# --------------------------------------------------------------------------
+# the capped-stamp refusal reads a camelCased field name too
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("basis", [
+    "wallClockP50S",
+    "wallClockP50s",
+    "derived from the finding's wallClockUncappedP50s",
+    "runnerMinSaving / n_runs",
+    "chainWinS, apportioned",
+    "clusterFloorLever (per leg)",
+])
+def test_a_camel_cased_capped_stamp_is_still_refused(basis):
+    """A producer stamping JSON writes `wallClockP50s`, not `wall_clock_p50_s`.
+    That is the same already-capped merge-wait saving under a different casing
+    convention, and letting it through produces the two-orders-of-magnitude
+    wrong joint number the whole refusal exists to prevent."""
+    g = _ab_gating()
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, oids,
+                        reduction_basis=basis),
+        constant_effect("F-B", "B::npm", "B", 100.0, 250.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == "capped_stamp_not_a_local_reduction"
+
+
+@pytest.mark.parametrize("basis", [
+    "affected_step_p50_s",
+    "stepP50Measured",
+    "chain_facts.member_spans_s",
+    "modeled local saving per observation, measured from the job log",
+    "per-observation wall clock of the affected step, uncapped by any stamp",
+])
+def test_camel_case_splitting_does_not_sweep_up_a_legitimate_basis(basis):
+    """Widening the match must not cost the module its usability: a basis that
+    merely shares a word — or a camelCased legitimate field — still admits."""
+    g = _ab_gating()
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, oids,
+                        reduction_basis=basis),
+        constant_effect("F-B", "B::npm", "B", 100.0, 250.0, oids)])
+    assert res.supported is True, res.rejection
+    assert res.median_delta_s == 100.0
+
+
+# --------------------------------------------------------------------------
+# a malformed artifact is refused by code, never by traceback
+# --------------------------------------------------------------------------
+
+def test_an_out_of_range_json_integer_is_a_named_refusal_not_a_traceback():
+    """JSON carries arbitrary-precision integers, so a findings artifact can
+    hold a duration `float()` cannot represent. `load_inputs` promises a named
+    rejection a caller can branch on; an escaping OverflowError is a traceback
+    instead of a refusal."""
+    doc = {js.JOINT_SCENARIO_INPUTS_KEY: {
+        "contract_version": js.SCENARIO_CONTRACT_VERSION,
+        "topology": js.SUPPORTED_TOPOLOGY, "basis": BASIS,
+        "check_names": ["A"],
+        "observations": [{"observation_id": "r0", "basis": BASIS,
+                          "check_durations": {"A": 10 ** 400},
+                          "concurrency_validated": True}],
+        "effects": []}}
+    gating_set, effects, rejection = js.load_inputs(doc)
+    assert gating_set is None
+    assert effects == ()
+    assert rejection.code == "malformed_contract_inputs"

--- a/skills/ci-speedup/tests/test_joint_sizing.py
+++ b/skills/ci-speedup/tests/test_joint_sizing.py
@@ -1,4 +1,5 @@
-"""Joint scenarios for supported parallel checks (SPEC-2026-09-08 §6).
+"""Joint scenarios for supported parallel checks
+(`references/wall-clock-methodology.md` §8).
 
 These tests pin the *numbers*, not the vocabulary. Every supported case asserts
 the exact seconds the calculator must produce; every unsupported case asserts
@@ -53,7 +54,9 @@ def gating(observations, *, topology="independent_concurrent", basis=BASIS,
 
 def effect(finding_id, work_id, per_obs, *, basis=BASIS, local=True,
            matrix_resolved=True, reduction_basis="step_p50_measured",
-           assumption="modeled: the named step is removed from the job"):
+           assumption="modeled: the named step is removed from the job",
+           workflow=".github/workflows/ci.yml",
+           evidence_refs=("run/1#step/3",)):
     """per_obs: {observation_id: {check_name: (reduction_s, affected_work_s)}}"""
     rows = []
     for oid, checks in per_obs.items():
@@ -63,11 +66,11 @@ def effect(finding_id, work_id, per_obs, *, basis=BASIS, local=True,
                 reduction_s=red, affected_work_s=work))
     return js.ScenarioEffect(
         finding_id=finding_id,
-        workflow=".github/workflows/ci.yml",
+        workflow=workflow,
         work_id=work_id,
         basis=basis,
         assumption=assumption,
-        evidence_refs=("run/1#step/3",),
+        evidence_refs=tuple(evidence_refs),
         local_runtime_only=local,
         matrix_identity_resolved=matrix_resolved,
         reduction_basis=reduction_basis,
@@ -82,7 +85,7 @@ def constant_effect(finding_id, work_id, check, reduction, work, oids,
 
 
 # --------------------------------------------------------------------------
-# §6 headline counterexample: A=300 / B=299, local reductions 100 each
+# §8 headline counterexample: A=300 / B=299, local reductions 100 each
 # --------------------------------------------------------------------------
 
 def _ab_gating(extra=None, n=3):
@@ -506,15 +509,29 @@ def test_affected_work_exceeding_the_observed_duration_is_rejected():
     assert res.rejection.code == "affected_work_exceeds_duration"
 
 
-def test_negative_post_fix_duration_is_rejected():
+def test_combined_reduction_beyond_the_job_duration_is_rejected():
+    """Two disjoint steps whose combined reduction exceeds the job duration are
+    caught by the affected-work budget, which fires before the arithmetic can
+    reach a negative post-fix duration: 200s + 150s of work did not happen in a
+    300s check, so the reductions were never both admissible."""
     g = _ab_gating()
     oids = [o.observation_id for o in g.observations]
-    # two disjoint steps whose combined reduction exceeds the job duration
     res = js.evaluate_scenario(g, [
         constant_effect("F-1", "A::install", "A", 200.0, 200.0, oids),
         constant_effect("F-2", "A::pytest", "A", 150.0, 150.0, oids)])
     assert res.supported is False
-    assert res.rejection.code == "negative_post_fix_duration"
+    assert res.rejection.code == "affected_work_sum_exceeds_duration"
+
+
+def test_the_negative_post_fix_floor_still_holds_under_the_budget():
+    """The budget guard makes a negative post-fix duration unreachable through
+    the public entry point, so the floor is pinned where it lives: reductions
+    that outrun the observed duration are refused, never clamped to zero."""
+    o = obs("r0", {"A": 300.0})
+    over = constant_effect("F-1", "A::install", "A", 400.0, 400.0, ["r0"])
+    rejection = js._after_durations(o, [over])
+    assert isinstance(rejection, js.ScenarioRejection)
+    assert rejection.code == "negative_post_fix_duration"
 
 
 # --------------------------------------------------------------------------
@@ -675,3 +692,199 @@ def test_the_missing_producer_evidence_is_named_in_the_module():
     missing = js.MISSING_PRODUCER_EVIDENCE
     assert isinstance(missing, tuple) and len(missing) >= 5
     assert all(isinstance(m, str) and m.strip() for m in missing)
+
+
+# --------------------------------------------------------------------------
+# attribution identity: a numeric result may not rest on unnamed or
+# indistinguishable findings, work, evidence or workflows
+# --------------------------------------------------------------------------
+
+def test_duplicate_finding_ids_are_rejected():
+    """Two effects sharing one id collapse into a single solo entry, so the
+    admission rule compares the joint saving against one half and not both."""
+    g = _ab_gating()
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-DUP", "A::pytest", "A", 100.0, 250.0, oids),
+        constant_effect("F-DUP", "B::npm-test", "B", 100.0, 250.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == "duplicate_finding_id"
+
+
+def test_duplicate_finding_ids_do_not_reach_block_selection():
+    g = _ab_gating()
+    oids = ["r0", "r1", "r2"]
+    assert js.select_joint_block(g, [
+        constant_effect("F-DUP", "A::pytest", "A", 100.0, 250.0, oids),
+        constant_effect("F-DUP", "B::npm-test", "B", 100.0, 250.0, oids)]) is None
+
+
+def test_every_supported_pair_carries_one_individual_per_finding():
+    g = _ab_gating()
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, oids),
+        constant_effect("F-B", "B::npm-test", "B", 100.0, 250.0, oids)])
+    assert res.supported is True
+    assert len(res.individual_delta_s) == len(res.finding_ids) == 2
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_a_blank_finding_id_is_rejected(blank):
+    g = _ab_gating()
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect(blank, "A::pytest", "A", 100.0, 250.0, oids),
+        constant_effect("F-B", "B::npm-test", "B", 100.0, 250.0, oids)])
+    assert res.rejection.code == "missing_finding_id"
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_a_blank_work_identity_is_rejected(blank):
+    """Unknown work is not disjoint work: an effect with no work id would key
+    the overlap check differently from a named step on the same check and be
+    summed with the alternative it may actually be."""
+    g = _ab_gating()
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", blank, "A", 60.0, 250.0, oids),
+        constant_effect("F-B", "A::pytest", "A", 80.0, 250.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == "missing_work_identity"
+
+
+def test_missing_evidence_refs_are_rejected():
+    g = _ab_gating()
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, oids,
+                        evidence_refs=()),
+        constant_effect("F-B", "B::npm-test", "B", 100.0, 250.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == "missing_evidence_refs"
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_a_blank_workflow_identity_is_rejected(blank):
+    g = _ab_gating()
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, oids,
+                        workflow=blank),
+        constant_effect("F-B", "B::npm-test", "B", 100.0, 250.0, oids)])
+    assert res.rejection.code == "missing_workflow_identity"
+
+
+def test_one_check_name_claimed_by_two_workflows_is_rejected():
+    """Gating durations are keyed by check name. Two workflows with a check of
+    the same name are two different checks sharing one duration entry, so
+    summing both reductions onto it invents a saving that does not exist."""
+    g = gating([obs(f"r{i}", {"test": 300.0, "B": 299.0}) for i in range(3)])
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "test::pytest", "test", 100.0, 250.0, oids,
+                        workflow=".github/workflows/ci.yml"),
+        constant_effect("F-B", "test::npm", "test", 100.0, 250.0, oids,
+                        workflow=".github/workflows/release.yml")])
+    assert res.supported is False
+    assert res.rejection.code == "ambiguous_check_identity"
+
+
+def test_two_workflows_keep_composing_on_checks_of_different_names():
+    """The identity guard refuses conflation, not cross-workflow scenarios."""
+    g = _ab_gating()
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, oids,
+                        workflow=".github/workflows/ci.yml"),
+        constant_effect("F-B", "B::npm", "B", 100.0, 250.0, oids,
+                        workflow=".github/workflows/release.yml")])
+    assert res.supported is True
+    assert res.median_delta_s == 100.0
+
+
+# --------------------------------------------------------------------------
+# the displayed-precision admission rule, the disclosed residual, and the
+# affected-work budget of a single check
+# --------------------------------------------------------------------------
+
+def test_a_pair_that_only_beats_its_half_below_display_precision_is_refused():
+    """Joint 1.4s against a best half of 1.2s is a 0.2s improvement the report
+    cannot print. Both round to 1s, so the pair says nothing the single finding
+    did not already say and earns no block."""
+    g = gating([obs(f"r{i}", {"A": 300.0, "B": 298.8}) for i in range(3)])
+    oids = ["r0", "r1", "r2"]
+    ea = constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, oids)
+    eb = constant_effect("F-B", "B::npm", "B", 0.2, 250.0, oids)
+
+    res = js.evaluate_scenario(g, [ea, eb])
+    assert res.supported is True
+    assert res.median_delta_s == pytest.approx(1.4)
+    assert res.individual_delta_s["F-A"] == pytest.approx(1.2)
+    assert res.individual_delta_s["F-B"] == pytest.approx(0.0)
+
+    # 1.4 > 1.2 arithmetically, 1s vs 1s at the precision the reader sees
+    assert js.select_joint_block(g, [ea, eb]) is None
+
+
+def test_the_disclosed_residual_is_the_largest_one_tolerated():
+    """The reader is told the worst skew the scenario absorbed, not the best."""
+    g = gating([
+        obs("r0", {"A": 300.0, "B": 299.0}, residual=0.0),
+        obs("r1", {"A": 300.0, "B": 299.0}, residual=2.0),
+        obs("r2", {"A": 300.0, "B": 299.0}, residual=5.0),
+    ])
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, oids),
+        constant_effect("F-B", "B::npm", "B", 100.0, 250.0, oids)])
+    assert res.supported is True
+    assert res.tolerated_residual_s == 5.0
+
+
+def test_affected_work_summed_over_one_check_may_not_exceed_its_duration():
+    """Two effects with different work ids that each claim 250s of a 300s check
+    cannot both be telling the truth: 500s of disjoint work did not happen in
+    300s. Summing their reductions would double-count one region of the job."""
+    g = _ab_gating()
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, oids),
+        constant_effect("F-B", "A::npm", "A", 100.0, 250.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == "affected_work_sum_exceeds_duration"
+
+
+def test_disjoint_work_that_fits_inside_the_check_still_composes():
+    """The budget guard refuses double-counting, not composition."""
+    g = _ab_gating()
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-1", "A::install", "A", 60.0, 70.0, oids),
+        constant_effect("F-2", "A::pytest", "A", 41.0, 180.0, oids)])
+    assert res.supported is True
+    assert res.modeled_check_after_s["A"] == 199.0
+
+
+# --------------------------------------------------------------------------
+# degenerate populations
+# --------------------------------------------------------------------------
+
+def test_a_single_matched_observation_is_supported():
+    g = gating([obs("r0", {"A": 300.0, "B": 299.0})])
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, ["r0"]),
+        constant_effect("F-B", "B::npm", "B", 100.0, 250.0, ["r0"])])
+    assert res.supported is True
+    assert res.n_observations == 1
+    assert res.median_delta_s == 100.0
+
+
+def test_a_scenario_with_no_effects_saves_nothing():
+    g = _ab_gating()
+    res = js.evaluate_scenario(g, [])
+    assert res.supported is True
+    assert res.finding_ids == ()
+    assert res.median_t_before_s == 300.0
+    assert res.median_t_after_s == 300.0
+    assert res.median_delta_s == 0.0

--- a/skills/ci-speedup/tests/test_joint_sizing.py
+++ b/skills/ci-speedup/tests/test_joint_sizing.py
@@ -1,0 +1,677 @@
+"""Joint scenarios for supported parallel checks (SPEC-2026-09-08 §6).
+
+These tests pin the *numbers*, not the vocabulary. Every supported case asserts
+the exact seconds the calculator must produce; every unsupported case asserts
+the exact rejection code. A test that only matched prose would pass with the
+numbers swapped, which is precisely the failure this suite exists to prevent.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import joint_scenario as js  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# builders
+# --------------------------------------------------------------------------
+
+BASIS = "era=e1;runner=ubuntu-latest;population=pr"
+
+
+def obs(observation_id, durations, *, basis=BASIS, validated=True, residual=0.0):
+    return js.GatingObservation(
+        observation_id=observation_id,
+        basis=basis,
+        check_durations=dict(durations),
+        concurrency_validated=validated,
+        scheduling_residual_s=residual,
+    )
+
+
+def gating(observations, *, topology="independent_concurrent", basis=BASIS,
+           check_names=None):
+    if check_names is None:
+        check_names = set()
+        for o in observations:
+            check_names |= set(o.check_durations)
+    return js.GatingSet(
+        topology=topology,
+        check_names=frozenset(check_names),
+        basis=basis,
+        observations=tuple(observations),
+    )
+
+
+def effect(finding_id, work_id, per_obs, *, basis=BASIS, local=True,
+           matrix_resolved=True, reduction_basis="step_p50_measured",
+           assumption="modeled: the named step is removed from the job"):
+    """per_obs: {observation_id: {check_name: (reduction_s, affected_work_s)}}"""
+    rows = []
+    for oid, checks in per_obs.items():
+        for check, (red, work) in checks.items():
+            rows.append(js.EffectObservation(
+                observation_id=oid, check_name=check,
+                reduction_s=red, affected_work_s=work))
+    return js.ScenarioEffect(
+        finding_id=finding_id,
+        workflow=".github/workflows/ci.yml",
+        work_id=work_id,
+        basis=basis,
+        assumption=assumption,
+        evidence_refs=("run/1#step/3",),
+        local_runtime_only=local,
+        matrix_identity_resolved=matrix_resolved,
+        reduction_basis=reduction_basis,
+        observations=tuple(rows),
+    )
+
+
+def constant_effect(finding_id, work_id, check, reduction, work, oids,
+                    **kw):
+    return effect(finding_id, work_id,
+                  {oid: {check: (reduction, work)} for oid in oids}, **kw)
+
+
+# --------------------------------------------------------------------------
+# §6 headline counterexample: A=300 / B=299, local reductions 100 each
+# --------------------------------------------------------------------------
+
+def _ab_gating(extra=None, n=3):
+    rows = []
+    for i in range(n):
+        d = {"A": 300.0, "B": 299.0}
+        if extra:
+            d.update(extra)
+        rows.append(obs(f"r{i}", d))
+    return gating(rows)
+
+
+def test_ab_pair_individual_1_and_0_joint_100():
+    g = _ab_gating()
+    oids = [o.observation_id for o in g.observations]
+    ea = constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, oids)
+    eb = constant_effect("F-B", "B::npm-test", "B", 100.0, 250.0, oids)
+
+    res = js.evaluate_scenario(g, [ea, eb])
+    assert res.supported is True, res.rejection
+    assert res.median_t_before_s == 300.0
+    assert res.median_t_after_s == 200.0
+    assert res.median_delta_s == 100.0
+    assert res.individual_delta_s == {"F-A": 1.0, "F-B": 0.0}
+    assert res.modeled_check_after_s == {"A": 200.0, "B": 199.0}
+
+
+def test_capped_stamps_cannot_drive_the_joint_result():
+    """The existing capped stamps for this shape are A=1s and B=0s. Feeding
+    those as local reductions yields joint 1s, not 100s — so the contract must
+    refuse a capped stamp as a reduction basis rather than silently model it."""
+    g = _ab_gating()
+    oids = [o.observation_id for o in g.observations]
+    capped_a = constant_effect("F-A", "A::pytest", "A", 1.0, 250.0, oids)
+    capped_b = constant_effect("F-B", "B::npm-test", "B", 0.0, 250.0, oids)
+
+    numeric = js.evaluate_scenario(g, [capped_a, capped_b])
+    assert numeric.supported is True
+    assert numeric.median_delta_s == 1.0  # the wrong answer, arithmetically
+
+    declared = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::pytest", "A", 1.0, 250.0, oids,
+                        reduction_basis="wall_clock_p50_s"),
+        capped_b,
+    ])
+    assert declared.supported is False
+    assert declared.rejection.code == "capped_stamp_not_a_local_reduction"
+
+    uncapped = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, oids,
+                        reduction_basis="wall_clock_uncapped_p50_s"),
+        capped_b,
+    ])
+    assert uncapped.supported is False
+    assert uncapped.rejection.code == "capped_stamp_not_a_local_reduction"
+
+
+def test_unaffected_competitor_at_295_caps_the_joint_saving_at_5():
+    g = _ab_gating(extra={"C": 295.0})
+    oids = [o.observation_id for o in g.observations]
+    ea = constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, oids)
+    eb = constant_effect("F-B", "B::npm-test", "B", 100.0, 250.0, oids)
+
+    res = js.evaluate_scenario(g, [ea, eb])
+    assert res.supported is True
+    assert res.median_t_before_s == 300.0
+    assert res.median_t_after_s == 295.0
+    assert res.median_delta_s == 5.0
+    assert res.individual_delta_s == {"F-A": 1.0, "F-B": 0.0}
+
+
+def test_unaffected_competitor_at_300_makes_the_joint_saving_zero():
+    g = _ab_gating(extra={"C": 300.0})
+    oids = [o.observation_id for o in g.observations]
+    ea = constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, oids)
+    eb = constant_effect("F-B", "B::npm-test", "B", 100.0, 250.0, oids)
+
+    res = js.evaluate_scenario(g, [ea, eb])
+    assert res.supported is True
+    assert res.median_t_before_s == 300.0
+    assert res.median_t_after_s == 300.0
+    assert res.median_delta_s == 0.0
+    # zero savings is an honest, supported answer — it just earns no block
+    assert js.select_joint_block(g, [ea, eb]) is None
+
+
+def test_zero_joint_saving_is_not_a_rejection():
+    g = _ab_gating(extra={"C": 300.0})
+    oids = [o.observation_id for o in g.observations]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, oids),
+        constant_effect("F-B", "B::npm-test", "B", 100.0, 250.0, oids)])
+    assert res.rejection is None
+
+
+# --------------------------------------------------------------------------
+# median(max) is not max(median)
+# --------------------------------------------------------------------------
+
+def test_median_of_max_differs_from_max_of_median():
+    g = gating([
+        obs("r0", {"A": 300.0, "B": 100.0}),
+        obs("r1", {"A": 100.0, "B": 300.0}),
+        obs("r2", {"A": 300.0, "B": 100.0}),
+        obs("r3", {"A": 100.0, "B": 300.0}),
+    ])
+    # per-check medians are both 200s, so max(median) would say 200s
+    assert js.median([300.0, 100.0, 300.0, 100.0]) == 200.0
+    ea = constant_effect("F-A", "A::s", "A", 50.0, 90.0, ["r0", "r1", "r2", "r3"])
+    eb = constant_effect("F-B", "B::s", "B", 50.0, 90.0, ["r0", "r1", "r2", "r3"])
+    res = js.evaluate_scenario(g, [ea, eb])
+    assert res.supported is True
+    # median(max_j d_before) == 300, not 200
+    assert res.median_t_before_s == 300.0
+    assert res.median_t_after_s == 250.0
+    assert res.median_delta_s == 50.0
+
+
+def test_medians_are_reported_separately_and_need_not_subtract():
+    """T_before/T_after/delta are three independent medians. This fixture makes
+    median(T_before) - median(T_after) != median(delta) so a renderer that
+    subtracts the first two cannot fake the third."""
+    g = gating([
+        obs("r0", {"A": 100.0, "B": 10.0}),
+        obs("r1", {"A": 200.0, "B": 10.0}),
+        obs("r2", {"A": 300.0, "B": 10.0}),
+    ])
+    ea = js.ScenarioEffect(
+        finding_id="F-A", workflow=".github/workflows/ci.yml", work_id="A::s",
+        basis=BASIS, assumption="modeled", evidence_refs=("e",),
+        local_runtime_only=True, matrix_identity_resolved=True,
+        reduction_basis="step_p50_measured",
+        observations=(
+            js.EffectObservation("r0", "A", 90.0, 90.0),
+            js.EffectObservation("r1", "A", 10.0, 90.0),
+            js.EffectObservation("r2", "A", 20.0, 90.0),
+        ))
+    eb = constant_effect("F-B", "B::s", "B", 0.0, 5.0, ["r0", "r1", "r2"])
+    res = js.evaluate_scenario(g, [ea, eb])
+    assert res.supported is True
+    assert res.median_t_before_s == 200.0
+    assert res.median_t_after_s == 190.0   # after = 10, 190, 280
+    assert res.median_delta_s == 20.0      # deltas = 90, 10, 20
+    assert res.median_t_before_s - res.median_t_after_s != res.median_delta_s
+
+
+# --------------------------------------------------------------------------
+# matrix legs
+# --------------------------------------------------------------------------
+
+def test_matrix_effect_covering_all_legs_versus_one_leg():
+    rows = [obs(f"r{i}", {"T (a)": 300.0, "T (b)": 300.0, "T (c)": 300.0,
+                          "Lint": 50.0}) for i in range(3)]
+    g = gating(rows)
+    oids = [o.observation_id for o in g.observations]
+    one_leg = effect("F-1", "T::pytest",
+                     {oid: {"T (a)": (100.0, 250.0)} for oid in oids})
+    lint = constant_effect("F-L", "Lint::eslint", "Lint", 10.0, 40.0, oids)
+
+    res_one = js.evaluate_scenario(g, [one_leg, lint])
+    assert res_one.supported is True
+    # unaffected sibling legs remain floors at 300s
+    assert res_one.median_t_after_s == 300.0
+    assert res_one.median_delta_s == 0.0
+
+    all_legs = effect("F-1", "T::pytest",
+                      {oid: {"T (a)": (100.0, 250.0),
+                             "T (b)": (100.0, 250.0),
+                             "T (c)": (100.0, 250.0)} for oid in oids})
+    res_all = js.evaluate_scenario(g, [all_legs, lint])
+    assert res_all.supported is True
+    assert res_all.median_t_after_s == 200.0
+    assert res_all.median_delta_s == 100.0
+
+
+def test_unknown_matrix_mapping_is_rejected():
+    g = _ab_gating()
+    oids = [o.observation_id for o in g.observations]
+    ea = constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, oids,
+                         matrix_resolved=False)
+    eb = constant_effect("F-B", "B::npm", "B", 100.0, 250.0, oids)
+    res = js.evaluate_scenario(g, [ea, eb])
+    assert res.supported is False
+    assert res.rejection.code == "ambiguous_matrix_identity"
+
+
+def test_effect_naming_a_check_outside_the_gating_set_is_rejected():
+    g = _ab_gating()
+    oids = [o.observation_id for o in g.observations]
+    off = constant_effect("F-X", "X::s", "X", 100.0, 250.0, oids)
+    eb = constant_effect("F-B", "B::npm", "B", 100.0, 250.0, oids)
+    res = js.evaluate_scenario(g, [off, eb])
+    assert res.supported is False
+    assert res.rejection.code == "off_gating_set_check"
+
+
+# --------------------------------------------------------------------------
+# overlap / compatibility
+# --------------------------------------------------------------------------
+
+def test_two_findings_touching_the_same_step_are_unsupported():
+    g = _ab_gating()
+    oids = [o.observation_id for o in g.observations]
+    e1 = constant_effect("F-1", "A::pytest", "A", 60.0, 250.0, oids)
+    e2 = constant_effect("F-2", "A::pytest", "A", 80.0, 250.0, oids)
+    res = js.evaluate_scenario(g, [e1, e2])
+    assert res.supported is False
+    assert res.rejection.code == "overlapping_affected_work"
+    assert res.median_delta_s is None
+
+
+def test_two_findings_on_different_steps_of_the_same_job_compose():
+    g = _ab_gating()
+    oids = [o.observation_id for o in g.observations]
+    e1 = constant_effect("F-1", "A::install", "A", 60.0, 70.0, oids)
+    e2 = constant_effect("F-2", "A::pytest", "A", 41.0, 180.0, oids)
+    res = js.evaluate_scenario(g, [e1, e2])
+    assert res.supported is True
+    assert res.median_t_after_s == 299.0   # A -> 199, B stays 299
+    assert res.median_delta_s == 1.0
+
+
+# --------------------------------------------------------------------------
+# topology rejections
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("topology,code", [
+    ("needs_chain", "unsupported_topology"),
+    ("required_aggregator", "unsupported_topology"),
+    ("shared_serial_upstream", "unsupported_topology"),
+    ("unknown", "unsupported_topology"),
+])
+def test_non_independent_topologies_are_unsupported(topology, code):
+    rows = [obs(f"r{i}", {"A": 300.0, "B": 299.0}) for i in range(3)]
+    g = gating(rows, topology=topology)
+    oids = [o.observation_id for o in g.observations]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::s", "A", 100.0, 250.0, oids),
+        constant_effect("F-B", "B::s", "B", 100.0, 250.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == code
+    assert res.median_delta_s is None
+
+
+def test_relocation_and_other_non_runtime_effects_are_ineligible():
+    g = _ab_gating()
+    oids = [o.observation_id for o in g.observations]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::s", "A", 100.0, 250.0, oids, local=False),
+        constant_effect("F-B", "B::s", "B", 100.0, 250.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == "not_local_runtime_only"
+
+
+# --------------------------------------------------------------------------
+# observation-level rejections
+# --------------------------------------------------------------------------
+
+def test_missing_competitor_in_one_observation_is_rejected():
+    g = gating([
+        obs("r0", {"A": 300.0, "B": 299.0}),
+        obs("r1", {"A": 300.0}),          # B did not run / was not sampled
+        obs("r2", {"A": 300.0, "B": 299.0}),
+    ], check_names={"A", "B"})
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::s", "A", 100.0, 250.0, oids),
+        constant_effect("F-B", "B::s", "B", 100.0, 250.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == "missing_competitor"
+
+
+def test_unvalidated_concurrency_is_rejected():
+    rows = [obs("r0", {"A": 300.0, "B": 299.0}, validated=False),
+            obs("r1", {"A": 300.0, "B": 299.0}),
+            obs("r2", {"A": 300.0, "B": 299.0})]
+    g = gating(rows)
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::s", "A", 100.0, 250.0, oids),
+        constant_effect("F-B", "B::s", "B", 100.0, 250.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == "concurrency_unvalidated"
+
+
+def test_scheduling_residual_within_tolerance_is_kept_and_disclosed():
+    rows = [obs(f"r{i}", {"A": 300.0, "B": 299.0},
+                residual=js.CONCURRENCY_TOLERANCE_S) for i in range(3)]
+    g = gating(rows)
+    oids = [o.observation_id for o in g.observations]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::s", "A", 100.0, 250.0, oids),
+        constant_effect("F-B", "B::s", "B", 100.0, 250.0, oids)])
+    assert res.supported is True
+    assert res.median_delta_s == 100.0
+    assert res.tolerated_residual_s == js.CONCURRENCY_TOLERANCE_S
+
+
+def test_scheduling_residual_beyond_tolerance_is_rejected():
+    rows = [obs(f"r{i}", {"A": 300.0, "B": 299.0},
+                residual=js.CONCURRENCY_TOLERANCE_S + 0.5) for i in range(3)]
+    g = gating(rows)
+    oids = [o.observation_id for o in g.observations]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::s", "A", 100.0, 250.0, oids),
+        constant_effect("F-B", "B::s", "B", 100.0, 250.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == "scheduling_residual_exceeds_tolerance"
+
+
+def test_stale_era_observation_is_rejected():
+    rows = [obs("r0", {"A": 300.0, "B": 299.0}),
+            obs("r1", {"A": 300.0, "B": 299.0}, basis="era=e0;runner=x;population=pr"),
+            obs("r2", {"A": 300.0, "B": 299.0})]
+    g = gating(rows)
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::s", "A", 100.0, 250.0, oids),
+        constant_effect("F-B", "B::s", "B", 100.0, 250.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == "basis_mismatch"
+
+
+def test_effect_on_a_different_basis_is_rejected():
+    g = _ab_gating()
+    oids = [o.observation_id for o in g.observations]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::s", "A", 100.0, 250.0, oids,
+                        basis="era=e0;runner=x;population=pr"),
+        constant_effect("F-B", "B::s", "B", 100.0, 250.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == "basis_mismatch"
+
+
+def test_effect_missing_an_observation_is_insufficient_evidence():
+    g = _ab_gating()
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::s", "A", 100.0, 250.0, ["r0", "r1"]),
+        constant_effect("F-B", "B::s", "B", 100.0, 250.0, ["r0", "r1", "r2"])])
+    assert res.supported is False
+    assert res.rejection.code == "insufficient_effect_evidence"
+
+
+def test_no_observations_at_all_is_rejected():
+    g = gating([], check_names={"A", "B"})
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::s", "A", 100.0, 250.0, []),
+        constant_effect("F-B", "B::s", "B", 100.0, 250.0, [])])
+    assert res.supported is False
+    assert res.rejection.code == "no_matched_observations"
+
+
+# --------------------------------------------------------------------------
+# numeric rejections
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_duration_is_rejected(bad):
+    rows = [obs("r0", {"A": bad, "B": 299.0}),
+            obs("r1", {"A": 300.0, "B": 299.0}),
+            obs("r2", {"A": 300.0, "B": 299.0})]
+    g = gating(rows)
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::s", "A", 100.0, 250.0, oids),
+        constant_effect("F-B", "B::s", "B", 100.0, 250.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == "non_finite_input"
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+def test_non_finite_reduction_is_rejected(bad):
+    g = _ab_gating()
+    oids = [o.observation_id for o in g.observations]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::s", "A", bad, 250.0, oids),
+        constant_effect("F-B", "B::s", "B", 100.0, 250.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == "non_finite_input"
+
+
+def test_negative_duration_is_rejected():
+    rows = [obs("r0", {"A": -1.0, "B": 299.0})] + \
+           [obs(f"r{i}", {"A": 300.0, "B": 299.0}) for i in (1, 2)]
+    g = gating(rows)
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::s", "A", 100.0, 250.0, oids),
+        constant_effect("F-B", "B::s", "B", 100.0, 250.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == "negative_input"
+
+
+def test_negative_reduction_is_rejected():
+    g = _ab_gating()
+    oids = [o.observation_id for o in g.observations]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::s", "A", -5.0, 250.0, oids),
+        constant_effect("F-B", "B::s", "B", 100.0, 250.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == "negative_input"
+
+
+def test_reduction_exceeding_affected_work_is_rejected():
+    g = _ab_gating()
+    oids = [o.observation_id for o in g.observations]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::s", "A", 100.0, 90.0, oids),
+        constant_effect("F-B", "B::s", "B", 100.0, 250.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == "reduction_exceeds_affected_work"
+
+
+def test_affected_work_exceeding_the_observed_duration_is_rejected():
+    g = _ab_gating()
+    oids = [o.observation_id for o in g.observations]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::s", "A", 100.0, 400.0, oids),
+        constant_effect("F-B", "B::s", "B", 100.0, 250.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == "affected_work_exceeds_duration"
+
+
+def test_negative_post_fix_duration_is_rejected():
+    g = _ab_gating()
+    oids = [o.observation_id for o in g.observations]
+    # two disjoint steps whose combined reduction exceeds the job duration
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-1", "A::install", "A", 200.0, 200.0, oids),
+        constant_effect("F-2", "A::pytest", "A", 150.0, 150.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == "negative_post_fix_duration"
+
+
+# --------------------------------------------------------------------------
+# admission: off-spine vs below-floor
+# --------------------------------------------------------------------------
+
+def test_below_floor_required_check_may_enter_a_pair():
+    """B never gates on its own (0s individual) but is a gating competitor, so
+    it is a legitimate half of a joint scenario."""
+    g = _ab_gating()
+    oids = [o.observation_id for o in g.observations]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::s", "A", 100.0, 250.0, oids),
+        constant_effect("F-B", "B::s", "B", 100.0, 250.0, oids)])
+    assert res.individual_delta_s["F-B"] == 0.0
+    assert res.supported is True
+    assert res.median_delta_s == 100.0
+
+
+def test_off_spine_finding_cannot_enter_a_pair():
+    """A check that is not part of the measured gating set is off the spine;
+    it has no competitor semantics and must not join a numeric scenario."""
+    g = _ab_gating()
+    oids = [o.observation_id for o in g.observations]
+    pairs = js.eligible_pairs(g, [
+        constant_effect("F-A", "A::s", "A", 100.0, 250.0, oids),
+        constant_effect("F-OFF", "Nightly::s", "Nightly", 100.0, 250.0, oids)])
+    assert pairs == []
+
+
+# --------------------------------------------------------------------------
+# selection rule
+# --------------------------------------------------------------------------
+
+def test_block_renders_only_when_joint_beats_both_individuals():
+    g = _ab_gating()
+    oids = [o.observation_id for o in g.observations]
+    ea = constant_effect("F-A", "A::s", "A", 100.0, 250.0, oids)
+    eb = constant_effect("F-B", "B::s", "B", 100.0, 250.0, oids)
+    chosen = js.select_joint_block(g, [ea, eb])
+    assert chosen is not None
+    assert chosen.finding_ids == ("F-A", "F-B")
+    assert chosen.median_delta_s == 100.0
+
+    # a pair whose joint equals the better individual earns no block
+    g2 = gating([obs(f"r{i}", {"A": 300.0, "B": 100.0}) for i in range(3)])
+    only_a = constant_effect("F-A", "A::s", "A", 50.0, 250.0, ["r0", "r1", "r2"])
+    tiny_b = constant_effect("F-B", "B::s", "B", 10.0, 90.0, ["r0", "r1", "r2"])
+    assert js.evaluate_scenario(g2, [only_a, tiny_b]).median_delta_s == 50.0
+    assert js.evaluate_scenario(g2, [only_a]).median_delta_s == 50.0
+    assert js.select_joint_block(g2, [only_a, tiny_b]) is None
+
+
+def test_pairs_rank_by_joint_reduction_then_by_stable_finding_ids():
+    g = gating([obs(f"r{i}", {"A": 300.0, "B": 299.0, "C": 298.0})
+                for i in range(3)])
+    oids = [o.observation_id for o in g.observations]
+    ea = constant_effect("F-A", "A::s", "A", 100.0, 250.0, oids)
+    eb = constant_effect("F-B", "B::s", "B", 100.0, 250.0, oids)
+    ec = constant_effect("F-C", "C::s", "C", 100.0, 250.0, oids)
+    ranked = js.eligible_pairs(g, [ec, eb, ea])
+    # every pair leaves the third check as a floor, so all three tie at 2s/1s;
+    # A+B leaves C=298 (2s), A+C leaves B=299 (1s), B+C leaves A=300 (0s)
+    assert [r.finding_ids for r in ranked] == [("F-A", "F-B"), ("F-A", "F-C")]
+    assert ranked[0].median_delta_s == 2.0
+    assert ranked[1].median_delta_s == 1.0
+
+
+def test_selection_uses_displayed_precision():
+    """Joint 100.4 vs individual 100.0 does not clear the bar at whole seconds."""
+    g = gating([obs(f"r{i}", {"A": 300.0, "B": 200.0}) for i in range(3)])
+    oids = [o.observation_id for o in g.observations]
+    ea = constant_effect("F-A", "A::s", "A", 100.0, 250.0, oids)
+    eb = constant_effect("F-B", "B::s", "B", 0.4, 90.0, oids)
+    joint = js.evaluate_scenario(g, [ea, eb])
+    assert joint.median_delta_s == pytest.approx(100.0)
+    assert js.select_joint_block(g, [ea, eb]) is None
+
+
+# --------------------------------------------------------------------------
+# artifact contract: what a producer would have to stamp
+# --------------------------------------------------------------------------
+
+def test_todays_artifact_shape_reports_the_inputs_as_absent():
+    """No producer stamps the contract today. Reading a current findings doc
+    must say so explicitly rather than fabricating a scenario from the
+    aggregate stamps that happen to be present."""
+    doc = {
+        "findings": [{"pattern": "OPT73", "affected_jobs": ["A", "B"],
+                      "wall_clock_p50_s": 1.0,
+                      "wall_clock_uncapped_p50_s": 100.0,
+                      "cluster_floor_lever": True}],
+        "pr_critical_path": {"populations": [[0.5, [["A", 300.0], ["B", 299.0]]]]},
+        "per_workflow_timing": {".github/workflows/ci.yml":
+                                {"job_p50": {"A": 300.0, "B": 299.0}}},
+    }
+    g, effects, rejection = js.load_inputs(doc)
+    assert g is None
+    assert effects == ()
+    assert rejection.code == "contract_inputs_absent"
+
+
+def test_a_stamped_contract_round_trips_to_the_same_numbers():
+    doc = {
+        js.JOINT_SCENARIO_INPUTS_KEY: {
+            "contract_version": js.SCENARIO_CONTRACT_VERSION,
+            "topology": "independent_concurrent",
+            "basis": BASIS,
+            "check_names": ["A", "B"],
+            "observations": [
+                {"observation_id": f"r{i}", "basis": BASIS,
+                 "check_durations": {"A": 300.0, "B": 299.0},
+                 "concurrency_validated": True,
+                 "scheduling_residual_s": 0.0} for i in range(3)],
+            "effects": [
+                {"finding_id": "F-A", "workflow": ".github/workflows/ci.yml",
+                 "work_id": "A::pytest", "basis": BASIS,
+                 "assumption": "modeled", "evidence_refs": ["e1"],
+                 "local_runtime_only": True, "matrix_identity_resolved": True,
+                 "reduction_basis": "step_p50_measured",
+                 "observations": [
+                     {"observation_id": f"r{i}", "check_name": "A",
+                      "reduction_s": 100.0, "affected_work_s": 250.0}
+                     for i in range(3)]},
+                {"finding_id": "F-B", "workflow": ".github/workflows/ci.yml",
+                 "work_id": "B::npm", "basis": BASIS,
+                 "assumption": "modeled", "evidence_refs": ["e2"],
+                 "local_runtime_only": True, "matrix_identity_resolved": True,
+                 "reduction_basis": "step_p50_measured",
+                 "observations": [
+                     {"observation_id": f"r{i}", "check_name": "B",
+                      "reduction_s": 100.0, "affected_work_s": 250.0}
+                     for i in range(3)]},
+            ],
+        }
+    }
+    g, effects, rejection = js.load_inputs(doc)
+    assert rejection is None
+    res = js.evaluate_scenario(g, effects)
+    assert res.median_delta_s == 100.0
+    assert res.median_t_before_s == 300.0
+    assert res.median_t_after_s == 200.0
+
+
+def test_a_future_contract_version_is_not_interpreted():
+    doc = {js.JOINT_SCENARIO_INPUTS_KEY: {
+        "contract_version": js.SCENARIO_CONTRACT_VERSION + 1,
+        "topology": "independent_concurrent", "basis": BASIS,
+        "check_names": ["A"], "observations": [], "effects": []}}
+    g, effects, rejection = js.load_inputs(doc)
+    assert g is None
+    assert rejection.code == "unsupported_contract_version"
+
+
+def test_the_missing_producer_evidence_is_named_in_the_module():
+    """The stop condition is part of the contract: name the fields a producer
+    would have to add, so a later adapter has a target instead of a guess."""
+    missing = js.MISSING_PRODUCER_EVIDENCE
+    assert isinstance(missing, tuple) and len(missing) >= 5
+    assert all(isinstance(m, str) and m.strip() for m in missing)

--- a/skills/ci-speedup/tests/test_joint_sizing.py
+++ b/skills/ci-speedup/tests/test_joint_sizing.py
@@ -601,7 +601,9 @@ def test_pairs_rank_by_joint_reduction_then_by_stable_finding_ids():
 
 
 def test_selection_uses_displayed_precision():
-    """Joint 100.4 vs individual 100.0 does not clear the bar at whole seconds."""
+    """The 0.4s cut on B never reaches the gate — A still finishes last — so
+    the joint saving is 100.0s, exactly what F-A is worth alone. A pair that
+    only ties its better half says nothing new and earns no block."""
     g = gating([obs(f"r{i}", {"A": 300.0, "B": 200.0}) for i in range(3)])
     oids = [o.observation_id for o in g.observations]
     ea = constant_effect("F-A", "A::s", "A", 100.0, 250.0, oids)
@@ -888,3 +890,235 @@ def test_a_scenario_with_no_effects_saves_nothing():
     assert res.median_t_before_s == 300.0
     assert res.median_t_after_s == 300.0
     assert res.median_delta_s == 0.0
+
+
+# --------------------------------------------------------------------------
+# an undeclared competitor may not be dropped out of the gate maximum
+# --------------------------------------------------------------------------
+
+def test_a_competitor_absent_from_the_declared_gating_set_is_rejected():
+    """The gating set is the fixed list of competitors. An observation that
+    timed a check the set never declared is evidence of a check that competes
+    for the gate, and taking `max` over the declared names alone would silently
+    drop it: C at 290s never competes, and the pair is credited with 100s it
+    would not get. §8 keeps every gating competitor."""
+    rows = [obs(f"r{i}", {"A": 300.0, "B": 299.0, "C": 290.0}) for i in range(3)]
+    g = gating(rows, check_names={"A", "B"})
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, oids),
+        constant_effect("F-B", "B::npm", "B", 100.0, 250.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == "undeclared_competitor"
+    assert res.median_delta_s is None
+
+
+def test_a_declared_competitor_still_caps_the_joint_saving():
+    """The guard refuses undeclared checks, not extra competitors: declare C
+    and the same observations produce the honest 10s, not 100s."""
+    rows = [obs(f"r{i}", {"A": 300.0, "B": 299.0, "C": 290.0}) for i in range(3)]
+    g = gating(rows, check_names={"A", "B", "C"})
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, oids),
+        constant_effect("F-B", "B::npm", "B", 100.0, 250.0, oids)])
+    assert res.supported is True
+    assert res.median_delta_s == 10.0
+
+
+# --------------------------------------------------------------------------
+# the capped-stamp refusal reads the basis, not an exact string match
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("basis", [
+    "derived from wall_clock_p50_s",
+    "Derived From Wall_Clock_P50_S.",
+    "wall-clock-p50-s",
+    "computed from the finding's wall_clock_uncapped_p50_s",
+    "cluster_floor_lever (per leg)",
+    "runner_min_saving / n_runs",
+    "chain_win_s, apportioned",
+])
+def test_a_paraphrased_capped_stamp_is_still_refused(basis):
+    """The single most important refusal in the module cannot be exact-match:
+    a producer that writes `derived from wall_clock_p50_s` is declaring the
+    same already-capped merge-wait saving, and letting it through produces a
+    joint number two orders of magnitude wrong."""
+    g = _ab_gating()
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, oids,
+                        reduction_basis=basis),
+        constant_effect("F-B", "B::npm", "B", 100.0, 250.0, oids)])
+    assert res.supported is False
+    assert res.rejection.code == "capped_stamp_not_a_local_reduction"
+
+
+@pytest.mark.parametrize("basis", [
+    "step_p50_measured",
+    "pr_critical_path.chain_facts.member_spans_s",
+    "measured step span, wall clock, p50 across the matched attempts",
+])
+def test_a_legitimate_reduction_basis_is_not_swept_up(basis):
+    """The refusal is scoped to the capped stamps themselves. A per-observation
+    measured step basis — including one that merely shares a word with a capped
+    field — is exactly what the contract asks a producer for."""
+    g = _ab_gating()
+    oids = ["r0", "r1", "r2"]
+    res = js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, oids,
+                        reduction_basis=basis),
+        constant_effect("F-B", "B::npm", "B", 100.0, 250.0, oids)])
+    assert res.supported is True, res.rejection
+    assert res.median_delta_s == 100.0
+
+
+# --------------------------------------------------------------------------
+# the rejection vocabulary is a closed, pinned set
+# --------------------------------------------------------------------------
+
+def _raw_effect(finding_id, work_id, rows, **kw):
+    """A ScenarioEffect built from explicit EffectObservation rows, so a test
+    can state a shape the keyed builder cannot express."""
+    fields = dict(
+        workflow=".github/workflows/ci.yml", basis=BASIS,
+        assumption="modeled", evidence_refs=("e",),
+        local_runtime_only=True, matrix_identity_resolved=True,
+        reduction_basis="step_p50_measured")
+    fields.update(kw)
+    return js.ScenarioEffect(finding_id=finding_id, work_id=work_id,
+                             observations=tuple(rows), **fields)
+
+
+def _observed_rejection_codes():
+    """Drive every rejection path in the module and collect the codes it
+    produced. Kept next to the exported set so a renamed code shows up as a
+    mismatch rather than as a literal nobody reads."""
+    codes = set()
+
+    def note(res):
+        assert res.supported is False, res
+        codes.add(res.rejection.code)
+
+    good = [obs(f"r{i}", {"A": 300.0, "B": 299.0}) for i in range(3)]
+    oids = ["r0", "r1", "r2"]
+
+    def pair(**kw):
+        return [constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, oids, **kw),
+                constant_effect("F-B", "B::npm", "B", 100.0, 250.0, oids)]
+
+    # gating-set rejections
+    note(js.evaluate_scenario(gating(good, topology="needs_chain"), pair()))
+    note(js.evaluate_scenario(gating([], check_names={"A"}), []))
+    note(js.evaluate_scenario(
+        gating([obs("r0", {"A": 300.0}), obs("r0", {"A": 300.0})]),
+        [constant_effect("F-A", "A::s", "A", 1.0, 2.0, ["r0"])]))
+    note(js.evaluate_scenario(gating(
+        [obs("r0", {"A": 300.0, "B": 299.0}, basis="era=e0")] + good[1:]),
+        pair()))
+    note(js.evaluate_scenario(gating(
+        [obs("r0", {"A": float("nan"), "B": 299.0})] + good[1:]), pair()))
+    note(js.evaluate_scenario(gating(
+        [obs("r0", {"A": -1.0, "B": 299.0})] + good[1:]), pair()))
+    note(js.evaluate_scenario(gating(
+        [obs("r0", {"A": 300.0})] + good[1:], check_names={"A", "B"}), pair()))
+    note(js.evaluate_scenario(gating(
+        [obs("r0", {"A": 300.0, "B": 299.0}, validated=False)] + good[1:]),
+        pair()))
+    note(js.evaluate_scenario(gating(
+        [obs("r0", {"A": 300.0, "B": 299.0}, residual=99.0)] + good[1:]),
+        pair()))
+    note(js.evaluate_scenario(gating(
+        [obs(f"r{i}", {"A": 300.0, "B": 299.0, "C": 290.0}) for i in range(3)],
+        check_names={"A", "B"}), pair()))
+
+    # effect-identity rejections
+    g = gating(good)
+    note(js.evaluate_scenario(g, [
+        constant_effect("", "A::pytest", "A", 100.0, 250.0, oids),
+        constant_effect("F-B", "B::npm", "B", 100.0, 250.0, oids)]))
+    note(js.evaluate_scenario(g, [
+        constant_effect("F-D", "A::pytest", "A", 100.0, 250.0, oids),
+        constant_effect("F-D", "B::npm", "B", 100.0, 250.0, oids)]))
+    note(js.evaluate_scenario(g, pair(workflow="")))
+    note(js.evaluate_scenario(g, [
+        constant_effect("F-A", "", "A", 100.0, 250.0, oids),
+        constant_effect("F-B", "B::npm", "B", 100.0, 250.0, oids)]))
+    note(js.evaluate_scenario(g, pair(evidence_refs=())))
+    note(js.evaluate_scenario(
+        gating([obs(f"r{i}", {"test": 300.0, "B": 299.0}) for i in range(3)]), [
+            constant_effect("F-A", "test::a", "test", 100.0, 250.0, oids,
+                            workflow=".github/workflows/ci.yml"),
+            constant_effect("F-B", "test::b", "test", 100.0, 250.0, oids,
+                            workflow=".github/workflows/release.yml")]))
+
+    # effect-eligibility rejections
+    note(js.evaluate_scenario(g, pair(local=False)))
+    note(js.evaluate_scenario(g, pair(matrix_resolved=False)))
+    note(js.evaluate_scenario(g, pair(reduction_basis="   ")))
+    note(js.evaluate_scenario(g, pair(reduction_basis="wall_clock_p50_s")))
+    note(js.evaluate_scenario(g, pair(assumption="  ")))
+    note(js.evaluate_scenario(g, [
+        constant_effect("F-X", "X::s", "X", 100.0, 250.0, oids),
+        constant_effect("F-B", "B::npm", "B", 100.0, 250.0, oids)]))
+    note(js.evaluate_scenario(g, [_raw_effect("F-A", "A::pytest", [
+        js.EffectObservation(o, "A", 1.0, 2.0) for o in oids] + [
+        js.EffectObservation("r0", "A", 1.0, 2.0)])]))
+    note(js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::pytest", "A", 100.0, 250.0, ["r0", "r1"]),
+        constant_effect("F-B", "B::npm", "B", 100.0, 250.0, oids)]))
+    note(js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::pytest", "A", 100.0, 90.0, oids),
+        constant_effect("F-B", "B::npm", "B", 100.0, 250.0, oids)]))
+    note(js.evaluate_scenario(g, [
+        constant_effect("F-A", "A::pytest", "A", 100.0, 400.0, oids),
+        constant_effect("F-B", "B::npm", "B", 100.0, 250.0, oids)]))
+    note(js.evaluate_scenario(g, [
+        constant_effect("F-1", "A::pytest", "A", 60.0, 100.0, oids),
+        constant_effect("F-2", "A::pytest", "A", 80.0, 100.0, oids)]))
+    note(js.evaluate_scenario(g, [
+        constant_effect("F-1", "A::install", "A", 100.0, 250.0, oids),
+        constant_effect("F-2", "A::pytest", "A", 100.0, 250.0, oids)]))
+
+    # arithmetic floor, reachable only through the private helper
+    floor = js._after_durations(
+        obs("r0", {"A": 300.0}),
+        [constant_effect("F-1", "A::s", "A", 400.0, 400.0, ["r0"])])
+    codes.add(floor.code)
+
+    # artifact-loading rejections
+    for doc in ({},
+                {js.JOINT_SCENARIO_INPUTS_KEY: {
+                    "contract_version": js.SCENARIO_CONTRACT_VERSION + 1}},
+                {js.JOINT_SCENARIO_INPUTS_KEY: {
+                    "contract_version": js.SCENARIO_CONTRACT_VERSION,
+                    "topology": "independent_concurrent", "basis": BASIS,
+                    "check_names": ["A"], "observations": [],
+                    "effects": [{"finding_id": "F-A", "observations": [
+                        {"observation_id": "r0", "check_name": "A"}]}]}}):
+        _, _, rejection = js.load_inputs(doc)
+        codes.add(rejection.code)
+
+    return codes
+
+
+def test_the_exported_rejection_codes_are_exactly_the_ones_the_module_emits():
+    """`code` is a bare string, so a typo or a silent rename would produce a
+    rejection nothing tests and no caller can branch on. The exported set is
+    the vocabulary; this pins that it is neither larger nor smaller than what
+    the module actually produces."""
+    assert _observed_rejection_codes() == set(js.REJECTION_CODES)
+
+
+def test_the_rejection_vocabulary_size_is_pinned():
+    assert len(js.REJECTION_CODES) == 32
+    assert all(isinstance(c, str) and c.strip() for c in js.REJECTION_CODES)
+
+
+def test_an_unenumerated_rejection_code_cannot_be_constructed():
+    """A new refusal has to be added to the exported vocabulary in the same
+    edit, or it fails the moment it fires."""
+    with pytest.raises(ValueError):
+        js.ScenarioRejection("a_code_nobody_declared", "detail")
+    for code in sorted(js.REJECTION_CODES):
+        assert js.ScenarioRejection(code, "detail").code == code


### PR DESCRIPTION
## TL;DR

Two slow CI checks that run at the same time have a trap in them: fixing either one alone can save almost no waiting time, while fixing both saves a lot — and the audit currently has no way to tell anyone that, so a genuinely valuable pair of fixes reads as two worthless ones. **This is a plan, not a shipped behaviour.** It lands the measurement rules and the arithmetic for saying it correctly, and then stops, because the audit does not currently record the evidence those rules need. No report changes; the pull request states exactly what the engine would have to start recording before any such number could honestly be printed.

## Why the obvious approach is wrong

Each finding already carries a saving in seconds, so it is tempting to subtract it from the check's measured time and call the remainder the "after" time. That number is not an after time. It is a saving that has already been reduced to what the merge gate would actually feel, after flooring it against every check running beside it.

```
Two concurrent checks, each with a real local reduction of 100s:

  check A  300s ──┐                    stamped saving: 1s
  check B  299s ──┴─ gate = 300s       stamped saving: 0s

  subtract the stamps  ->  A 299s, B 299s  ->  "joint saving 1s"   WRONG
  apply the reductions ->  A 200s, B 199s  ->  joint saving 100s    right
```

The first answer is wrong by two orders of magnitude. The uncapped variant of the same field does not help either: it is a single workflow-wide number that says nothing about which job, or which matrix leg, actually gets faster.

## What is in this pull request

A new scripts module holding the data contract and a pure calculator, plus its test suite and a new methodology section.

The rules it enforces:

- Reductions are stated per observed run and bounded by the work that run actually spent on the thing being changed.
- Every untouched check stays in the comparison as a competitor. An unrelated third check at 295s caps the joint saving at 5s; one at 300s caps it at zero.
- The gate is the slowest check **in each individual run**, taken before any averaging. Averaging each check first and then taking the slowest is a different, wrong number.
- Before, after, and saved are three separate summaries. They are not presented as if the first two subtract into the third.
- Only genuinely separate work composes, and it has to fit inside the check that was observed. Two findings touching the same step are competing alternatives and are refused, never added together; two findings that each claim 250 seconds of a 300-second check are double-counting whatever they call the work, and are refused as well.
- Every effect names the finding, the workflow, the work it changes and its evidence, and no two of them may be indistinguishable. An unnamed or repeated identity does not fail loudly on its own — it quietly changes which comparison the rule makes — so each one is refused before any arithmetic runs. One check name claimed by two different workflows is two checks sharing one measurement, and is refused rather than modelled as one.
- The refusal that the whole design rests on — a saving that has already been capped cannot be used as a starting point — reads what the producer says its figure came from, rather than matching one exact spelling. A sentence built around that capped field name is refused exactly as the bare name is, in any casing, punctuation or camelCase spelling of it; a genuine per-run measured basis that merely shares a word with one is not. It matches the field name rather than the meaning, so it backs up the producer's own declarations rather than replacing them.
- Every reason for refusing is drawn from one exported, closed list. A refusal that is not on that list fails the moment it fires, so a renamed or mistyped reason cannot become a verdict nobody can act on.

Refused, with a stated reason rather than a number: dependency chains, required aggregator jobs, a shared job that runs first, an unresolved competitor, a check timed in a run but missing from the declared set of gating checks (it would drop out of the comparison altogether instead of capping the saving), an unclear matrix-leg mapping, an unproven claim that checks overlapped in time, start-time skew beyond tolerance, missing per-run evidence, and the identity failures above. A saving of **zero** is a supported, honest answer — the third check is simply still the blocker — and is kept distinct from "cannot be modelled".

The result is reported as a median only. A tail figure would need a per-run tail decomposition that neither the contract nor any producer defines, so the methodology says so explicitly rather than leaving a later reader to assume the number covers the slow end.

## Why it stops here

No part of the audit records what these rules require. It has no per-run durations for the **whole** set of gating checks: the closest thing it keeps does carry per-commit, configuration-era-scoped timings, but only for the members of each pull request's own longest chain, and with no attempt or runner identity. There is no recorded proof that the checks overlapped in time (overlap is inferred from declared dependencies and assumes overlap when the job graph is unavailable); no per-run reduction figures (the estimates are one number per finding, and one number across all matrix legs at once); no record of which step a finding changes beyond a single dominant step, or a single named shared step for one class of finding; no stable matrix-leg identity, since one name covers every leg of a job at once; and nothing asserting that a fix leaves scheduling, coverage and the set of jobs unchanged.

Those gaps are written into the module and the methodology so the work has a target instead of a guess. Building an adapter over the evidence that exists would have produced confident numbers with nothing behind them.

## Verification

Red first, three times. The suite was written and run before the module existed and failed at collection, then failed 15 of its first 44 cases against the first implementation. The identity and double-counting rules were added the same way afterwards: ten cases written against the unfixed module, all ten failing, then passing. A pre-merge conformance review then found three more gaps — a check present in the timings but missing from the declared set, a capped saving that got through under a paraphrase, and an unpinned list of refusal reasons — and those were closed the same way: eleven cases written first, all eleven failing against the unfixed module, then passing.

The tests assert printed values rather than wording. Deliberate mutations confirm they bite: averaging before taking the slowest check fails the case built to catch exactly that, dropping untouched competitors from the comparison fails eight cases, and removing the guard that refuses an already-capped saving as a starting point fails another. Three mutations that survived the first round — reporting the smallest tolerated timing skew instead of the largest, and two changes to the precision at which the selection rule compares — now have cases of their own.

The rendering, collection, sizing and report-verification code is untouched. The existing headline, savings, off-spine, cluster-ceiling and chain guards are green and unweakened.

Three claims about what the engine records were checked against the engine itself and corrected here, because they are the justification for shipping no behaviour: the nearest existing artifact is named correctly, one class of finding does record the exact step it changes, and the matrix-leg names come from two different sources depending on how the finding was produced. Two of the shipped files also cited a planning document that does not exist in the repository and would never reach anyone who installs the skill; they now cite the methodology that ships beside them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


